### PR TITLE
Use MVar for consumer locking

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -61,7 +61,9 @@ lazy val mimaSettings = Seq(
   },
   mimaBinaryIssueFilters ++= {
     import com.typesafe.tools.mima.core._
-    Seq()
+    Seq(
+      ProblemFilters.exclude[IncompatibleMethTypeProblem]("fs2.kafka.KafkaConsumerActor.this")
+    )
   }
 )
 

--- a/src/main/scala/fs2/kafka/internal/syntax.scala
+++ b/src/main/scala/fs2/kafka/internal/syntax.scala
@@ -20,6 +20,9 @@ import java.time.Duration
 import java.time.temporal.ChronoUnit
 import java.util.concurrent.TimeUnit
 
+import cats.effect.Bracket
+import cats.effect.concurrent.MVar
+
 import scala.concurrent.duration.FiniteDuration
 
 private[kafka] object syntax {
@@ -36,5 +39,10 @@ private[kafka] object syntax {
           case TimeUnit.MICROSECONDS => Duration.of(duration.length, ChronoUnit.MICROS)
           case TimeUnit.NANOSECONDS  => Duration.ofNanos(duration.length)
         }
+  }
+
+  implicit final class MVarSyntax[F[_], A](val mVar: MVar[F, A]) extends AnyVal {
+    def lease[B](f: A => F[B])(implicit F: Bracket[F, Throwable]): F[B] =
+      F.bracket(mVar.take)(f)(mVar.put)
   }
 }


### PR DESCRIPTION
We already require a `ExecutionContext` for shifting (blocking) calls to the underlying Java consumer. However, if that `ExecutionContext` is backed by more than one thread, we still need locking to avoid concurrent modification issues when closing the consumer. This is not an issue if you're already using the default `consumerExecutionContextStream`, as it uses a single thread.