### PR TITLE
Add Synchronization primitive for synchronized access

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,6 +24,7 @@ lazy val docs = project
 
 lazy val dependencySettings = Seq(
   libraryDependencies ++= Seq(
+    "org.typelevel" %% "cats-effect" % "1.1.0-M1",
     "co.fs2" %% "fs2-core" % "1.0.0",
     "org.apache.kafka" % "kafka-clients" % "2.0.0"
   ),

--- a/src/main/scala/fs2/kafka/internal/Synchronized.scala
+++ b/src/main/scala/fs2/kafka/internal/Synchronized.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2018 OVO Energy Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fs2.kafka.internal
+
+import cats.effect.Concurrent
+import cats.effect.concurrent.{Deferred, Ref}
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+
+/**
+  * Provides synchronized access to a resource `A`, similar to that of
+  * `synchronized(a) { use(a) }`, except the blocking is semantic only,
+  * and no actual threads are blocked by the implementation.
+  */
+private[kafka] abstract class Synchronized[F[_], A] {
+
+  /**
+    * Runs the specified function on the resource `A`, or waits until
+    * given exclusive access to the resource, and then runs the given
+    * function. Can be cancelled while waiting on exclusive access.
+    */
+  def use[B](f: A => F[B]): F[B]
+}
+
+private[kafka] object Synchronized {
+  def apply[F[_]](implicit F: Concurrent[F]): ApplyBuilders[F] =
+    new ApplyBuilders(F)
+
+  def of[F[_], A](a: A)(implicit F: Concurrent[F]): F[Synchronized[F, A]] =
+    Deferred[F, Unit].flatMap { initial =>
+      initial.complete(()).flatMap { _ =>
+        Ref.of[F, Deferred[F, Unit]](initial).map { ref =>
+          new Synchronized[F, A] {
+            override def use[B](f: A => F[B]): F[B] =
+              Deferred[F, Unit].flatMap { next =>
+                F.bracket(ref.getAndSet(next)) { current =>
+                  current.get.flatMap(_ => f(a))
+                }(_ => next.complete(()))
+              }
+          }
+        }
+      }
+    }
+
+  final class ApplyBuilders[F[_]](val F: Concurrent[F]) extends AnyVal {
+    def of[A](a: A): F[Synchronized[F, A]] =
+      Synchronized.of(a)(F)
+  }
+}

--- a/src/main/scala/fs2/kafka/internal/syntax.scala
+++ b/src/main/scala/fs2/kafka/internal/syntax.scala
@@ -20,9 +20,6 @@ import java.time.Duration
 import java.time.temporal.ChronoUnit
 import java.util.concurrent.TimeUnit
 
-import cats.effect.Bracket
-import cats.effect.concurrent.MVar
-
 import scala.concurrent.duration.FiniteDuration
 
 private[kafka] object syntax {
@@ -39,10 +36,5 @@ private[kafka] object syntax {
           case TimeUnit.MICROSECONDS => Duration.of(duration.length, ChronoUnit.MICROS)
           case TimeUnit.NANOSECONDS  => Duration.ofNanos(duration.length)
         }
-  }
-
-  implicit final class MVarSyntax[F[_], A](val mVar: MVar[F, A]) extends AnyVal {
-    def lease[B](f: A => F[B])(implicit F: Bracket[F, Throwable]): F[B] =
-      F.bracket(mVar.take)(f)(mVar.put)
   }
 }

--- a/src/test/scala/fs2/kafka/internal/SynchronizedSpec.scala
+++ b/src/test/scala/fs2/kafka/internal/SynchronizedSpec.scala
@@ -1,0 +1,58 @@
+package fs2.kafka.internal
+
+import cats.effect.concurrent.{MVar, Ref}
+import cats.effect.{Fiber, IO}
+import cats.implicits._
+import fs2.kafka.BaseAsyncSpec
+
+final class SynchronizedSpec extends BaseAsyncSpec {
+  it("should synchronize concurrent access to the resource") {
+    val success =
+      (for {
+        success <- Ref[IO].of(true)
+        resource <- MVar[IO].of("resource")
+        synch <- Synchronized[IO].of(resource)
+        use = (n: Int) =>
+          IO.shift >> synch
+            .use { mVar =>
+              mVar.tryTake.flatMap { takenOption =>
+                takenOption
+                  .map(mVar.put(_) >> {
+                    if (n % 50 == 0)
+                      IO.raiseError(new RuntimeException)
+                    else IO.unit
+                  })
+                  .getOrElse(success.set(false))
+              }
+            }
+            .attempt
+            .start
+        uses <- (1 to 1000).toList.map(use).combineAll
+        _ <- uses.join
+        succeeded <- success.get
+      } yield succeeded).unsafeRunSync
+
+    assert(success)
+  }
+
+  it("should continue to work when use is cancelled") {
+    val success =
+      (for {
+        synch <- Synchronized[IO].of("resource")
+        fiberUnit = Fiber(IO.unit, IO.unit)
+        use = (n: Int) =>
+          IO.shift >> synch
+            .use(_ => IO.unit)
+            .start
+            .flatMap { fiber =>
+              if (n % 50 == 0)
+                fiber.cancel.as(fiberUnit)
+              else IO.pure(fiber)
+          }
+        used <- (1 to 1000).toList.map(use).combineAll
+        _ <- used.join
+      } yield true).unsafeRunSync
+
+    assert(success)
+  }
+}


### PR DESCRIPTION
Pull request #5 introduced an `MVar` for having exclusive access to the `Consumer`, which is necessary for being able to close the `Consumer` safely (avoiding `ConcurrentModificationException`) when using an `ExecutionContext` with more than one thread in `ConsumerSettings`. 

This pull request replaces `MVar` with a `Synchronization` primitive based on `Ref` and `Deferred`.

Massive thanks to @SystemFw for the help leading up to this.