### PR TITLE
Add support for offset commit recovery

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -63,7 +63,18 @@ lazy val mimaSettings = Seq(
   mimaBinaryIssueFilters ++= {
     import com.typesafe.tools.mima.core._
     Seq(
-      ProblemFilters.exclude[IncompatibleMethTypeProblem]("fs2.kafka.KafkaConsumerActor.this")
+      ProblemFilters.exclude[IncompatibleMethTypeProblem]("fs2.kafka.KafkaConsumerActor.this"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.KafkaConsumerActor.this"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "fs2.kafka.ConsumerSettings#ConsumerSettingsImpl.apply"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem](
+        "fs2.kafka.ConsumerSettings.commitRecovery"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem](
+        "fs2.kafka.ConsumerSettings.withCommitRecovery"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "fs2.kafka.ConsumerSettings#ConsumerSettingsImpl.copy"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "fs2.kafka.ConsumerSettings#ConsumerSettingsImpl.this")
     )
   }
 )

--- a/src/main/scala/fs2/kafka/CommitRecovery.scala
+++ b/src/main/scala/fs2/kafka/CommitRecovery.scala
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2018 OVO Energy Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fs2.kafka
+
+import cats.effect.Timer
+import cats.syntax.applicativeError._
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+import cats.{Functor, MonadError}
+import org.apache.kafka.clients.consumer.{OffsetAndMetadata, RetriableCommitFailedException}
+import org.apache.kafka.common.TopicPartition
+
+import scala.concurrent.duration._
+
+/**
+  * [[CommitRecovery]] describes how to recover from exceptions raised
+  * while trying to commit offsets. See [[CommitRecovery.Default]] for
+  * the default recovery strategy. If you do not wish to recover from
+  * any exceptions, you can use [[CommitRecovery.None]].<br>
+  * <br>
+  * To create a new [[CommitRecovery]], simply create a new instance
+  * and implement the [[recoverCommitWith]] function with the wanted
+  * recovery strategy.
+  */
+abstract class CommitRecovery {
+
+  /**
+    * Describes recovery from offset commit exceptions. The `commit`
+    * parameter can be used to retry the commit. Note that if more
+    * than one retry is desirable, errors from `commit` will need
+    * to be handled and recovered.<br>
+    * <br>
+    * The offsets we are trying to commit are available via the
+    * `offsets` parameter. Waiting before retrying again can be
+    * done via the provided `Timer` instance, and jitter can be
+    * applied using the `Jitter` instance.
+    */
+  def recoverCommitWith[F[_]](
+    offsets: Map[TopicPartition, OffsetAndMetadata],
+    commit: F[Unit]
+  )(
+    implicit F: MonadError[F, Throwable],
+    jitter: Jitter[F],
+    timer: Timer[F]
+  ): Throwable => F[Unit]
+}
+
+object CommitRecovery {
+
+  /**
+    * The default [[CommitRecovery]] used in [[ConsumerSettings]] unless
+    * a different one has been specified. The default recovery strategy
+    * only retries `RetriableCommitFailedException`s. These exceptions
+    * are retried with a jittered exponential backoff, where the time
+    * in milliseconds before retrying is calculated using:
+    *
+    * {{{
+    * Random.nextDouble() * Math.min(10000, 10 * Math.pow(2, n))
+    * }}}
+    *
+    * where `n` is the retry attempt (first attempt is `n = 1`). This is
+    * done for up to 10 attempts, after which we change to retry using a
+    * fixed time of 10 seconds, for up to another 5 attempts. If at that
+    * point we are still faced with `RetriableCommitFailedException`, we
+    * give up and raise a [[CommitRecoveryException]] with the last such
+    * error experienced.<br>
+    * <br>
+    * The sum of time spent waiting between retries will always be less
+    * than 70 220 milliseconds, or ~70 seconds. Note that this does not
+    * include the time for attempting to commit offsets. Offset commit
+    * times are limited with [[ConsumerSettings.commitTimeout]].
+    */
+  val Default: CommitRecovery =
+    new CommitRecovery {
+      private def backoff[F[_]](attempt: Int)(
+        implicit F: Functor[F],
+        jitter: Jitter[F]
+      ): F[FiniteDuration] = {
+        val millis = Math.min(10000, 10 * Math.pow(2, attempt.toDouble))
+        jitter.withJitter(millis).map(_.millis)
+      }
+
+      override def recoverCommitWith[F[_]](
+        offsets: Map[TopicPartition, OffsetAndMetadata],
+        commit: F[Unit]
+      )(
+        implicit F: MonadError[F, Throwable],
+        jitter: Jitter[F],
+        timer: Timer[F]
+      ): Throwable => F[Unit] = {
+        def retry(attempt: Int): Throwable => F[Unit] = {
+          case retriable: RetriableCommitFailedException =>
+            val commitWithRecovery = commit.handleErrorWith(retry(attempt + 1))
+            if (attempt <= 10) backoff(attempt).flatMap(timer.sleep) >> commitWithRecovery
+            else if (attempt <= 15) timer.sleep(10.seconds) >> commitWithRecovery
+            else F.raiseError(CommitRecoveryException(attempt - 1, retriable, offsets))
+
+          case nonRetriable: Throwable =>
+            F.raiseError(nonRetriable)
+        }
+
+        retry(attempt = 1)
+      }
+
+      override def toString: String =
+        "Default"
+    }
+
+  /**
+    * A [[CommitRecovery]] that does not retry any exceptions.
+    */
+  val None: CommitRecovery =
+    new CommitRecovery {
+      override def recoverCommitWith[F[_]](
+        offsets: Map[TopicPartition, OffsetAndMetadata],
+        commit: F[Unit]
+      )(
+        implicit F: MonadError[F, Throwable],
+        jitter: Jitter[F],
+        timer: Timer[F]
+      ): Throwable => F[Unit] = F.raiseError
+
+      override def toString: String =
+        "None"
+    }
+}

--- a/src/main/scala/fs2/kafka/CommitRecoveryException.scala
+++ b/src/main/scala/fs2/kafka/CommitRecoveryException.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2018 OVO Energy Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fs2.kafka
+
+import cats.syntax.show._
+import fs2.kafka.internal.instances._
+import org.apache.kafka.clients.consumer.OffsetAndMetadata
+import org.apache.kafka.common.{KafkaException, TopicPartition}
+
+sealed abstract class CommitRecoveryException(
+  attempts: Int,
+  lastException: Throwable,
+  offsets: Map[TopicPartition, OffsetAndMetadata]
+) extends KafkaException({
+      val builder =
+        new StringBuilder(s"offset commit is still failing after $attempts attempts")
+
+      if (offsets.nonEmpty) {
+        builder.append(" for offsets: ")
+        val sorted = offsets.toList.sorted
+        var first = true
+
+        sorted.foreach {
+          case (tp, oam) =>
+            if (first) first = false
+            else builder.append(", ")
+
+            builder.append(tp.show).append(" -> ").append(oam.show)
+        }
+      }
+
+      builder.append(s"; last exception was: $lastException").toString
+    }) {
+
+  override def toString: String =
+    s"fs2.kafka.CommitRecoveryException: $getMessage"
+}
+
+object CommitRecoveryException {
+  def apply(
+    attempts: Int,
+    lastException: Throwable,
+    offsets: Map[TopicPartition, OffsetAndMetadata]
+  ): CommitRecoveryException =
+    new CommitRecoveryException(attempts, lastException, offsets) {}
+}

--- a/src/main/scala/fs2/kafka/ConsumerSettings.scala
+++ b/src/main/scala/fs2/kafka/ConsumerSettings.scala
@@ -77,6 +77,10 @@ sealed abstract class ConsumerSettings[K, V] {
   def pollTimeout: FiniteDuration
 
   def withPollTimeout(pollTimeout: FiniteDuration): ConsumerSettings[K, V]
+
+  def commitRecovery: CommitRecovery
+
+  def withCommitRecovery(commitRecovery: CommitRecovery): ConsumerSettings[K, V]
 }
 
 object ConsumerSettings {
@@ -89,7 +93,8 @@ object ConsumerSettings {
     override val commitTimeout: FiniteDuration,
     override val fetchTimeout: FiniteDuration,
     override val pollInterval: FiniteDuration,
-    override val pollTimeout: FiniteDuration
+    override val pollTimeout: FiniteDuration,
+    override val commitRecovery: CommitRecovery
   ) extends ConsumerSettings[K, V] {
     override def withBootstrapServers(bootstrapServers: String): ConsumerSettings[K, V] =
       withProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers)
@@ -157,6 +162,9 @@ object ConsumerSettings {
     override def withPollTimeout(pollTimeout: FiniteDuration): ConsumerSettings[K, V] =
       copy(pollTimeout = pollTimeout)
 
+    override def withCommitRecovery(commitRecovery: CommitRecovery): ConsumerSettings[K, V] =
+      copy(commitRecovery = commitRecovery)
+
     override def toString: String =
       Show[ConsumerSettings[K, V]].show(this)
   }
@@ -184,11 +192,12 @@ object ConsumerSettings {
     commitTimeout = 15.seconds,
     fetchTimeout = 500.millis,
     pollInterval = 50.millis,
-    pollTimeout = 50.millis
+    pollTimeout = 50.millis,
+    commitRecovery = CommitRecovery.Default
   )
 
   implicit def consumerSettingsShow[K, V]: Show[ConsumerSettings[K, V]] =
     Show.show { s =>
-      s"ConsumerSettings(closeTimeout = ${s.closeTimeout}, commitTimeout = ${s.commitTimeout}, fetchTimeout = ${s.fetchTimeout}, pollInterval = ${s.pollInterval}, pollTimeout = ${s.pollTimeout})"
+      s"ConsumerSettings(closeTimeout = ${s.closeTimeout}, commitTimeout = ${s.commitTimeout}, fetchTimeout = ${s.fetchTimeout}, pollInterval = ${s.pollInterval}, pollTimeout = ${s.pollTimeout}, commitRecovery = ${s.commitRecovery})"
     }
 }

--- a/src/main/scala/fs2/kafka/Jitter.scala
+++ b/src/main/scala/fs2/kafka/Jitter.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018 OVO Energy Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fs2.kafka
+
+import cats.Applicative
+import cats.effect.Sync
+import cats.syntax.functor._
+
+/**
+  * [[Jitter]] represents the ability to apply jitter to an existing value
+  * `n`, effectively multiplying `n` with a pseudorandom value between `0`
+  * and `1` (both inclusive, although implementation dependent).<br>
+  * <br>
+  * The default [[Jitter#default]] uses `java.util.Random` for pseudorandom
+  * values and always applies jitter with a value between `0` (inclusive)
+  * and `1` (exclusive). If no jitter is desired, use [[Jitter#none]].
+  */
+sealed abstract class Jitter[F[_]] {
+  def withJitter(n: Double): F[Double]
+}
+
+object Jitter {
+  def apply[F[_]](implicit F: Jitter[F]): Jitter[F] = F
+
+  /**
+    * Creates a default [[Jitter]] instance, which uses `java.util.Random`
+    * for generating pseudorandom values, always applying jitter with a
+    * value between `0` (inclusive) and `1` (exclusive).
+    */
+  def default[F[_]](implicit F: Sync[F]): F[Jitter[F]] =
+    F.delay(new java.util.Random()).map { random =>
+      new Jitter[F] {
+        override def withJitter(n: Double): F[Double] =
+          F.delay(random.nextDouble()).map(_ * n)
+      }
+    }
+
+  /**
+    * Creates a [[Jitter]] instance which does not apply jitter,
+    * meaning all input values will be returned unmodified.
+    */
+  def none[F[_]](implicit F: Applicative[F]): Jitter[F] =
+    new Jitter[F] {
+      override def withJitter(n: Double): F[Double] =
+        F.pure(n)
+    }
+}

--- a/src/test/scala/fs2/kafka/CommitRecoverySpec.scala
+++ b/src/test/scala/fs2/kafka/CommitRecoverySpec.scala
@@ -1,0 +1,90 @@
+package fs2.kafka
+
+import cats.data.Chain
+import cats.effect.concurrent.Ref
+import cats.effect.{Clock, IO, Timer}
+import cats.syntax.functor._
+import org.apache.kafka.clients.consumer.{OffsetAndMetadata, RetriableCommitFailedException}
+import org.apache.kafka.common.TopicPartition
+
+import scala.concurrent.duration.{FiniteDuration, TimeUnit}
+
+final class CommitRecoverySpec extends BaseAsyncSpec {
+  describe("CommitRecovery#Default") {
+    it("should retry with jittered exponential backoff and fixed rate") {
+      val (result, sleeps) =
+        Ref
+          .of[IO, Chain[FiniteDuration]](Chain.empty)
+          .flatMap { ref =>
+            implicit val timer: Timer[IO] = storeSleepsTimer(ref)
+            val commit: IO[Unit] = IO.raiseError(new RetriableCommitFailedException("retriable"))
+            val offsets = Map(new TopicPartition("topic", 0) -> new OffsetAndMetadata(1))
+            val recovery = CommitRecovery.Default.recoverCommitWith(offsets, commit)
+            val attempted = commit.handleErrorWith(recovery).attempt
+            attempted.flatMap(ref.get.tupleLeft)
+          }
+          .unsafeRunSync
+
+      assert {
+        result.left.toOption.map(_.toString).contains {
+          "fs2.kafka.CommitRecoveryException: offset commit is still failing after 15 attempts for offsets: topic-0 -> 1; last exception was: org.apache.kafka.clients.consumer.RetriableCommitFailedException: retriable"
+        }
+      }
+
+      assert { sleeps.size == 15L }
+
+      assert {
+        sleeps.toList.take(10).zipWithIndex.forall {
+          case (sleep, attempt) =>
+            val max = 10 * Math.pow(2, attempt.toDouble + 1)
+            0 <= sleep.toMillis && sleep.toMillis < max
+        }
+      }
+
+      assert { sleeps.toList.drop(10).forall(_.toMillis == 10000L) }
+    }
+
+    it("should not recover non-retriable exceptions") {
+      val commit: IO[Unit] = IO.raiseError(new RuntimeException("commit"))
+      val retry: IO[Unit] = IO.raiseError(new RuntimeException("retry"))
+      val recovery = CommitRecovery.Default.recoverCommitWith(Map(), retry)
+      val result = commit.handleErrorWith(recovery).attempt.unsafeRunSync
+      assert { result.left.toOption.map(_.getMessage).contains("commit") }
+    }
+
+    it("should have Default as String representation") {
+      assert(CommitRecovery.Default.toString == "Default")
+    }
+  }
+
+  describe("CommitRecovery#None") {
+    it("should not recover any exceptions") {
+      val commit: IO[Unit] = IO.raiseError(new RuntimeException("commit"))
+      val retry: IO[Unit] = IO.raiseError(new RuntimeException("retry"))
+      val recovery = CommitRecovery.None.recoverCommitWith(Map(), retry)
+      val result = commit.handleErrorWith(recovery).attempt.unsafeRunSync
+      assert { result.left.toOption.map(_.getMessage).contains("commit") }
+    }
+
+    it("should have None as String representation") {
+      assert(CommitRecovery.None.toString == "None")
+    }
+  }
+
+  implicit val jitter: Jitter[IO] =
+    Jitter.default[IO].unsafeRunSync
+
+  private def storeSleepsTimer(ref: Ref[IO, Chain[FiniteDuration]]): Timer[IO] =
+    new Timer[IO] {
+      override def clock: Clock[IO] = new Clock[IO] {
+        override def realTime(unit: TimeUnit): IO[Long] =
+          IO.raiseError(new RuntimeException("clock#realTime"))
+
+        override def monotonic(unit: TimeUnit): IO[Long] =
+          IO.raiseError(new RuntimeException("clock#monotonic"))
+      }
+
+      override def sleep(duration: FiniteDuration): IO[Unit] =
+        ref.update(_ append duration)
+    }
+}

--- a/src/test/scala/fs2/kafka/JitterSpec.scala
+++ b/src/test/scala/fs2/kafka/JitterSpec.scala
@@ -1,0 +1,34 @@
+package fs2.kafka
+
+import cats.Id
+import cats.effect.IO
+
+final class JitterSpec extends BaseSpec {
+  describe("Jitter#default") {
+    it("should always apply jitter on values") {
+      val jitter: Jitter[IO] = Jitter.default[IO].unsafeRunSync
+
+      forAll { n: Double =>
+        whenever(!n.isNaN) {
+          val jittered = jitter.withJitter(n).unsafeRunSync
+
+          if (n == 0 || n.isInfinite) assert(jittered == n)
+          else if (n > 0) assert(0 <= jittered && jittered < n)
+          else assert(n < jittered && jittered <= 0)
+        }
+      }
+    }
+  }
+
+  describe("Jitter#none") {
+    it("should never apply jitter on values") {
+      val jitter: Jitter[Id] = Jitter.none
+
+      forAll { n: Double =>
+        whenever(!n.isNaN) {
+          assert(jitter.withJitter(n) == n)
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add `CommitRecovery` for defining offset commit recovery strategies. The default strategy only retries `RetriableCommitFailedException` with a jittered exponential backoff for 10 attempts, switching to fixed rate retries for up to another 5 attempts (see `CommitRecovery#Default`).

You can override the `CommitRecovery` using `ConsumerSettings#withCommitRecovery`. If you would like to go back to default behaviour before this change (no retries), simply use `withCommitRecovery` with `CommitRecovery#None`.