### PR TITLE
Fix KafkaConsumer#fiber instance

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -74,7 +74,18 @@ lazy val mimaSettings = Seq(
       ProblemFilters.exclude[DirectMissingMethodProblem](
         "fs2.kafka.ConsumerSettings#ConsumerSettingsImpl.copy"),
       ProblemFilters.exclude[DirectMissingMethodProblem](
-        "fs2.kafka.ConsumerSettings#ConsumerSettingsImpl.this")
+        "fs2.kafka.ConsumerSettings#ConsumerSettingsImpl.this"),
+      ProblemFilters.exclude[MissingClassProblem]("fs2.kafka.KafkaConsumerActor$Request$Shutdown"),
+      ProblemFilters.exclude[MissingClassProblem]("fs2.kafka.KafkaConsumerActor$Request$Shutdown$"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "fs2.kafka.KafkaConsumerActor#State.asShutdown"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "fs2.kafka.KafkaConsumerActor#State.running"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.KafkaConsumerActor#State.copy"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+        "fs2.kafka.KafkaConsumerActor#State.copy$default$4"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.KafkaConsumerActor#State.this"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.KafkaConsumerActor#State.apply")
     )
   }
 )


### PR DESCRIPTION
- Previously, `KafkaConsumerActor` could be shutdown with a `Shutdown` request. This, and the flag for whether the `KafkaConsumerActor` is `running` has been removed. This means the actor now fully owns and manages its own state.
- Internally, when using `startConsumerActor` and `startPollScheduler`, we now use a `Deferred` together with `guarantee` to signify completion. `Fiber#cancel` semantically blocks until the `guarantee` finishes, so for cancellation we use `cancel.start.void` to avoid blocking. This approach has the benefit that `join` never becomes non-terminating on `cancel`.
- If either the `startConsumerActor`'s or `startPollScehuler`'s `Fiber#join` completes (that is, the `Deferred` is completed), we now cancel the other one in `KafkaConsumer#fiber`, since the other cannot continue to work without the first.
- Add documentation for `KafkaConsumer#fiber` explaining how it can be used.