### PR TITLE
Add KafkaConsumer#parallelPartitionedStream

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -62,31 +62,37 @@ lazy val mimaSettings = Seq(
   },
   mimaBinaryIssueFilters ++= {
     import com.typesafe.tools.mima.core._
+    // format: off
     Seq(
       ProblemFilters.exclude[IncompatibleMethTypeProblem]("fs2.kafka.KafkaConsumerActor.this"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.KafkaConsumerActor.this"),
-      ProblemFilters.exclude[DirectMissingMethodProblem](
-        "fs2.kafka.ConsumerSettings#ConsumerSettingsImpl.apply"),
-      ProblemFilters.exclude[ReversedMissingMethodProblem](
-        "fs2.kafka.ConsumerSettings.commitRecovery"),
-      ProblemFilters.exclude[ReversedMissingMethodProblem](
-        "fs2.kafka.ConsumerSettings.withCommitRecovery"),
-      ProblemFilters.exclude[DirectMissingMethodProblem](
-        "fs2.kafka.ConsumerSettings#ConsumerSettingsImpl.copy"),
-      ProblemFilters.exclude[DirectMissingMethodProblem](
-        "fs2.kafka.ConsumerSettings#ConsumerSettingsImpl.this"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.ConsumerSettings#ConsumerSettingsImpl.apply"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.ConsumerSettings.commitRecovery"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.ConsumerSettings.withCommitRecovery"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.ConsumerSettings#ConsumerSettingsImpl.copy"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.ConsumerSettings#ConsumerSettingsImpl.this"),
       ProblemFilters.exclude[MissingClassProblem]("fs2.kafka.KafkaConsumerActor$Request$Shutdown"),
       ProblemFilters.exclude[MissingClassProblem]("fs2.kafka.KafkaConsumerActor$Request$Shutdown$"),
-      ProblemFilters.exclude[DirectMissingMethodProblem](
-        "fs2.kafka.KafkaConsumerActor#State.asShutdown"),
-      ProblemFilters.exclude[DirectMissingMethodProblem](
-        "fs2.kafka.KafkaConsumerActor#State.running"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.KafkaConsumerActor#State.asShutdown"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.KafkaConsumerActor#State.running"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.KafkaConsumerActor#State.copy"),
-      ProblemFilters.exclude[DirectMissingMethodProblem](
-        "fs2.kafka.KafkaConsumerActor#State.copy$default$4"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.KafkaConsumerActor#State.copy$default$4"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.KafkaConsumerActor#State.this"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.KafkaConsumerActor#State.apply")
+      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.KafkaConsumerActor#State.apply"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.KafkaConsumerActor#Request#Assignment.apply"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("fs2.kafka.KafkaConsumerActor#Request#Revoked.partitions"),
+      ProblemFilters.exclude[IncompatibleMethTypeProblem]("fs2.kafka.KafkaConsumerActor#Request#Revoked.copy"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("fs2.kafka.KafkaConsumerActor#Request#Revoked.copy$default$1"),
+      ProblemFilters.exclude[IncompatibleMethTypeProblem]("fs2.kafka.KafkaConsumerActor#Request#Revoked.this"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.KafkaConsumerActor#ExpiringFetch.complete"),
+      ProblemFilters.exclude[IncompatibleMethTypeProblem]("fs2.kafka.KafkaConsumerActor#Request#Revoked.apply"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.KafkaConsumerActor#Request#Assignment.copy"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.KafkaConsumerActor#Request#Assignment.this"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.KafkaConsumerActor#State.withFetch"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem]("fs2.kafka.KafkaConsumerActor#State.copy$default$3"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.KafkaConsumer.parallelPartitionedStream")
     )
+    // format: on
   }
 )
 

--- a/src/main/scala/fs2/kafka/KafkaConsumer.scala
+++ b/src/main/scala/fs2/kafka/KafkaConsumer.scala
@@ -17,9 +17,9 @@
 package fs2.kafka
 
 import cats.data.{NonEmptyList, NonEmptySet}
+import cats.effect._
 import cats.effect.concurrent.{Deferred, Ref}
 import cats.effect.syntax.concurrent._
-import cats.effect.{ConcurrentEffect, Fiber, Timer, _}
 import cats.instances.list._
 import cats.instances.unit._
 import cats.syntax.applicativeError._
@@ -30,7 +30,6 @@ import cats.syntax.monadError._
 import cats.syntax.semigroup._
 import cats.syntax.traverse._
 import fs2.concurrent.Queue
-import fs2.kafka.KafkaConsumerActor.Request._
 import fs2.kafka.KafkaConsumerActor._
 import fs2.kafka.internal.Synchronized
 import fs2.kafka.internal.instances._
@@ -123,7 +122,7 @@ private[kafka] object KafkaConsumer {
       Deferred[F, Unit].flatMap { deferred =>
         F.guarantee {
             {
-              polls.enqueue1(Poll()) >>
+              polls.enqueue1(Request.Poll()) >>
                 timer.sleep(pollInterval)
             }.foreverM[Unit]
           }(deferred.complete(()))
@@ -311,7 +310,7 @@ private[kafka] object KafkaConsumer {
         partitionedStream.flatten
 
       override def subscribe(topics: NonEmptyList[String]): Stream[F, Unit] =
-        Stream.eval(requests.enqueue1(Subscribe(topics)))
+        Stream.eval(requests.enqueue1(Request.Subscribe(topics)))
 
       override def toString: String =
         "KafkaConsumer$" + System.identityHashCode(this)

--- a/src/main/scala/fs2/kafka/KafkaConsumer.scala
+++ b/src/main/scala/fs2/kafka/KafkaConsumer.scala
@@ -152,7 +152,8 @@ private[kafka] object KafkaConsumer {
 
       private val assignment: F[Set[TopicPartition]] =
         Deferred[F, Either[Throwable, Set[TopicPartition]]].flatMap { deferred =>
-          val assignment = requests.enqueue1(Assignment(deferred)) >> deferred.get.rethrow
+          val request = Request.Assignment[F, K, V](deferred, onRebalance = None)
+          val assignment = requests.enqueue1(request) >> deferred.get.rethrow
           F.race(fiber.join, assignment).map {
             case Left(())        => Set.empty
             case Right(assigned) => assigned

--- a/src/test/scala/fs2/kafka/KafkaConsumerSpec.scala
+++ b/src/test/scala/fs2/kafka/KafkaConsumerSpec.scala
@@ -6,83 +6,101 @@ import cats.implicits._
 import fs2.Stream
 
 final class KafkaConsumerSpec extends BaseKafkaSpec {
-  it("should consume all messages") {
-    withKafka { (config, topic) =>
-      createCustomTopic(topic, partitions = 3)
-      val produced = (0 until 1000).map(n => s"key-$n" -> s"value->$n")
-      publishToKafka(topic, produced)
-
-      val consumed =
-        (for {
-          consumerSettings <- consumerSettings(config)
-          consumer <- consumerStream[IO].using(consumerSettings)
-          _ <- consumer.subscribe(NonEmptyList.of(topic))
-          consumed <- consumer.stream.take(produced.size.toLong)
-          record = consumed.record
-        } yield record.key -> record.value).compile.toVector.unsafeRunSync
-
-      consumed should contain theSameElementsAs produced
-    }
+  describe("KafkaConsumer#stream") {
+    tests(_.stream)
   }
 
-  it("should commit the last processed offsets") {
-    withKafka { (config, topic) =>
-      createCustomTopic(topic, partitions = 3)
-      val produced = (0 until 100).map(n => s"key-$n" -> s"value->$n")
-      publishToKafka(topic, produced)
+  describe("KafkaConsumer#partitionedStream") {
+    tests(_.partitionedStream.parJoin(partitions))
+  }
 
-      val committed =
-        (for {
-          consumerSettings <- consumerSettings(config)
-          consumer <- consumerStream[IO].using(consumerSettings)
-          _ <- consumer.subscribe(NonEmptyList.of(topic))
-          offsets <- consumer.stream
-            .take(produced.size.toLong)
-            .map(_.committableOffset)
-            .fold(CommittableOffsetBatch.empty[IO])(_ updated _)
-            .evalMap(batch => batch.commit.as(batch.offsets))
-        } yield offsets).compile.lastOrError.unsafeRunSync
+  describe("KafkaConsumer#parallelPartitionedStream") {
+    tests(_.parallelPartitionedStream.parJoin(partitions))
+  }
 
-      assert {
-        committed.values.toList.foldMap(_.offset) == produced.size.toLong &&
-        withKafkaConsumer[String, String](consumerProperties(config)) { consumer =>
-          committed.foldLeft(true) {
-            case (result, (topicPartition, offsetAndMetadata)) =>
-              result && offsetAndMetadata == consumer.committed(topicPartition)
+  val partitions = 3
+
+  def tests(
+    f: KafkaConsumer[IO, String, String] => Stream[IO, CommittableMessage[IO, String, String]]
+  ): Unit = {
+    it("should consume all messages") {
+      withKafka { (config, topic) =>
+        createCustomTopic(topic, partitions = partitions)
+        val produced = (0 until 100).map(n => s"key-$n" -> s"value->$n")
+        publishToKafka(topic, produced)
+
+        val consumed =
+          (for {
+            consumerSettings <- consumerSettings(config)
+            consumer <- consumerStream[IO].using(consumerSettings)
+            _ <- consumer.subscribe(NonEmptyList.of(topic))
+            consumed <- f(consumer).take(produced.size.toLong)
+            record = consumed.record
+          } yield record.key -> record.value).compile.toVector.unsafeRunSync
+
+        consumed should contain theSameElementsAs produced
+      }
+    }
+
+    it("should commit the last processed offsets") {
+      withKafka { (config, topic) =>
+        createCustomTopic(topic, partitions = partitions)
+        val produced = (0 until 100).map(n => s"key-$n" -> s"value->$n")
+        publishToKafka(topic, produced)
+
+        val committed =
+          (for {
+            consumerSettings <- consumerSettings(config)
+            consumer <- consumerStream[IO].using(consumerSettings)
+            _ <- consumer.subscribe(NonEmptyList.of(topic))
+            offsets <- f(consumer)
+              .take(produced.size.toLong)
+              .map(_.committableOffset)
+              .fold(CommittableOffsetBatch.empty[IO])(_ updated _)
+              .evalMap(batch => batch.commit.as(batch.offsets))
+          } yield offsets).compile.lastOrError.unsafeRunSync
+
+        assert {
+          committed.values.toList.foldMap(_.offset) == produced.size.toLong &&
+          withKafkaConsumer[String, String](consumerProperties(config)) { consumer =>
+            committed.foldLeft(true) {
+              case (result, (topicPartition, offsetAndMetadata)) =>
+                result && offsetAndMetadata == consumer.committed(topicPartition)
+            }
           }
         }
       }
     }
-  }
 
-  it("should interrupt the stream when cancelled") {
-    withKafka { (config, topic) =>
-      val consumed =
-        (for {
-          consumerSettings <- consumerSettings(config)
-          consumer <- consumerStream[IO].using(consumerSettings)
-          _ <- consumer.subscribe(NonEmptyList.of(topic))
-          _ <- Stream.eval(consumer.fiber.cancel)
-          _ <- consumer.stream
-          _ <- Stream.eval(consumer.fiber.join)
-        } yield ()).compile.toVector.unsafeRunSync
+    it("should interrupt the stream when cancelled") {
+      withKafka { (config, topic) =>
+        val consumed =
+          (for {
+            consumerSettings <- consumerSettings(config)
+            consumer <- consumerStream[IO].using(consumerSettings)
+            _ <- consumer.subscribe(NonEmptyList.of(topic))
+            _ <- Stream.eval(consumer.fiber.cancel)
+            _ <- f(consumer)
+            _ <- Stream.eval(consumer.fiber.join)
+          } yield ()).compile.toVector.unsafeRunSync
 
-      assert(consumed.isEmpty)
+        assert(consumed.isEmpty)
+      }
     }
-  }
 
-  it("should fail with an error if not subscribed") {
-    withKafka { (config, topic) =>
-      createCustomTopic(topic, partitions = 3)
+    it("should fail with an error if not subscribed") {
+      withKafka { (config, topic) =>
+        createCustomTopic(topic, partitions = partitions)
 
-      val consumed =
-        (for {
-          consumerSettings <- consumerSettings(config)
-          consumer <- consumerStream[IO].using(consumerSettings)
-          _ <- consumer.stream
-        } yield ()).compile.lastOrError.attempt.unsafeRunSync
+        val consumed =
+          (for {
+            consumerSettings <- consumerSettings(config)
+            consumer <- consumerStream[IO].using(consumerSettings)
+            _ <- f(consumer)
+          } yield ()).compile.lastOrError.attempt.unsafeRunSync
 
-      assert(consumed.left.toOption.contains(NotSubscribedException))
+        assert(consumed.left.toOption.contains(NotSubscribedException))
+      }
     }
   }
 }


### PR DESCRIPTION
Add `KafkaConsumer#parallelPartitionedStream` for parallel processing per topic-partition. The main difference compared to `partitionedStream` is that we start individual streams per partition, which  get completed once the partition is revoked. When we get assigned a new partition, a new stream is started for that partition. This allows for parallel processing per topic-partition, where `partitionedStream` can only support parallel processing per topic-partition fetches.

---

Detailed changes to support this addition are listed below.

For `KafkaConsumer`:
- Add documentation for `KafkaConsumer` and provided functions.
- Change `partitionedStream` (and `stream`) to support faster interrupts.
- Fix `partitionedStream` (and `stream`) to support main fiber cancellation.

For `KafkaConsumerActor`:
- Add support for non-expiring fetches.
- Add reason for why a fetch was completed:
    - for expiring fetches: `TopicPartitionRevoked`, `FetchedRecords`, `FetchExpired`,
    - for non-expiring fetches: `TopicPartitionRevoked`, `FetchedRecords`.
- Add support for rebalance listeners to `Assignment`.
- Change to use `NonEmptySet` for `Assigned` and `Revoked`.
- Change to use `SortedSet` for the `Deferred` in `Assignment`.
- Fix to complete received fetch if the partition has been revoked.