### PR TITLE
Explicitly create new Sets in KafkaConsumerActor

### DIFF
--- a/src/main/scala/fs2/kafka/KafkaConsumerActor.scala
+++ b/src/main/scala/fs2/kafka/KafkaConsumerActor.scala
@@ -162,7 +162,7 @@ private[kafka] final class KafkaConsumerActor[F[_], K, V](
       val records = state.records.toKeySet
 
       val revokedFetches = revoked.partitions.toSortedSet intersect fetches
-      val withRecords = revokedFetches intersect records
+      val withRecords = records intersect revokedFetches
       val withoutRecords = revokedFetches diff records
 
       val completeWithRecords =
@@ -276,7 +276,7 @@ private[kafka] final class KafkaConsumerActor[F[_], K, V](
           val requested = state.fetches.toKeySet
           val available = state.records.toKeySet
 
-          val resume = (assigned intersect requested) diff available
+          val resume = (requested intersect assigned) diff available
           val pause = assigned diff resume
 
           consumer.pause(pause.asJava)

--- a/src/main/scala/fs2/kafka/internal/syntax.scala
+++ b/src/main/scala/fs2/kafka/internal/syntax.scala
@@ -18,8 +18,10 @@ package fs2.kafka.internal
 
 import java.time.Duration
 import java.time.temporal.ChronoUnit
+import java.util
 import java.util.concurrent.TimeUnit
 
+import scala.collection.immutable.SortedSet
 import scala.concurrent.duration.FiniteDuration
 
 private[kafka] object syntax {
@@ -36,5 +38,16 @@ private[kafka] object syntax {
           case TimeUnit.MICROSECONDS => Duration.of(duration.length, ChronoUnit.MICROS)
           case TimeUnit.NANOSECONDS  => Duration.ofNanos(duration.length)
         }
+  }
+
+  implicit final class JavaUtilCollectionSyntax[A](val collection: util.Collection[A])
+      extends AnyVal {
+
+    def toSortedSet(implicit ordering: Ordering[A]): SortedSet[A] = {
+      val builder = SortedSet.newBuilder[A]
+      val it = collection.iterator()
+      while (it.hasNext) builder += it.next()
+      builder.result()
+    }
   }
 }

--- a/src/main/scala/fs2/kafka/internal/syntax.scala
+++ b/src/main/scala/fs2/kafka/internal/syntax.scala
@@ -40,8 +40,23 @@ private[kafka] object syntax {
         }
   }
 
+  implicit final class MapSyntax[K, V](val map: Map[K, V]) extends AnyVal {
+    def toKeySet: Set[K] = {
+      val builder = Set.newBuilder[K]
+      map.foreach(builder += _._1)
+      builder.result()
+    }
+  }
+
   implicit final class JavaUtilCollectionSyntax[A](val collection: util.Collection[A])
       extends AnyVal {
+
+    def toSet: Set[A] = {
+      val builder = Set.newBuilder[A]
+      val it = collection.iterator()
+      while(it.hasNext) builder += it.next()
+      builder.result()
+    }
 
     def toSortedSet(implicit ordering: Ordering[A]): SortedSet[A] = {
       val builder = SortedSet.newBuilder[A]

--- a/src/main/scala/fs2/kafka/internal/syntax.scala
+++ b/src/main/scala/fs2/kafka/internal/syntax.scala
@@ -54,7 +54,7 @@ private[kafka] object syntax {
     def toSet: Set[A] = {
       val builder = Set.newBuilder[A]
       val it = collection.iterator()
-      while(it.hasNext) builder += it.next()
+      while (it.hasNext) builder += it.next()
       builder.result()
     }
 


### PR DESCRIPTION
This pull request attempts to fix #14 by explicitly creating new `Set`s in `KafkaConsumerActor`, instead of relying on `Map#keySet`, which uses a `DefaultKeySet` implementation. More specifically, we should now be avoiding the following code path, as seen at the top of the stack trace in the issue.

```
Exception in thread "fs2-kafka-consumer-20" java.lang.StackOverflowError
  at scala.collection.Iterator$$anon$12.hasNext(Iterator.scala:505)
  [...]
  at scala.collection.Iterator$$anon$12.hasNext(Iterator.scala:507)
  at scala.collection.Iterator$$anon$12.hasNext(Iterator.scala:507)
  at scala.collection.Iterator$$anon$12.hasNext(Iterator.scala:507)
  at scala.collection.MapLike$$anon$1.hasNext(MapLike.scala:186)
  at scala.collection.Iterator.foreach(Iterator.scala:937)
  at scala.collection.Iterator.foreach$(Iterator.scala:937)
  at scala.collection.AbstractIterator.foreach(Iterator.scala:1425)
  at scala.collection.MapLike$DefaultKeySet.foreach(MapLike.scala:177)
```

I've also reordered a couple of intersections for performance, based on of relative `Set` sizes.