### PR TITLE
Fix StackOverflowError in KafkaConsumer

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -90,7 +90,9 @@ lazy val mimaSettings = Seq(
       ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.KafkaConsumerActor#Request#Assignment.this"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.KafkaConsumerActor#State.withFetch"),
       ProblemFilters.exclude[IncompatibleResultTypeProblem]("fs2.kafka.KafkaConsumerActor#State.copy$default$3"),
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.KafkaConsumer.parallelPartitionedStream")
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.KafkaConsumer.parallelPartitionedStream"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.internal.syntax#MapSyntax.toKeySet"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.internal.syntax#MapSyntax.toKeySet$extension")
     )
     // format: on
   }

--- a/src/main/scala/fs2/kafka/internal/syntax.scala
+++ b/src/main/scala/fs2/kafka/internal/syntax.scala
@@ -49,19 +49,19 @@ private[kafka] object syntax {
 
     def filterKeysStrict(p: K => Boolean): Map[K, V] = {
       val builder = Map.newBuilder[K, V]
-      map.foreach(e => if(p(e._1)) builder += e)
+      map.foreach(e => if (p(e._1)) builder += e)
       builder.result()
     }
 
     def filterKeysStrictList(p: K => Boolean): List[(K, V)] = {
       val builder = List.newBuilder[(K, V)]
-      map.foreach(e => if(p(e._1)) builder += e)
+      map.foreach(e => if (p(e._1)) builder += e)
       builder.result()
     }
 
     def filterKeysStrictValuesList(p: K => Boolean): List[V] = {
       val builder = List.newBuilder[V]
-      map.foreach(e => if(p(e._1)) builder += e._2)
+      map.foreach(e => if (p(e._1)) builder += e._2)
       builder.result()
     }
   }

--- a/src/main/scala/fs2/kafka/internal/syntax.scala
+++ b/src/main/scala/fs2/kafka/internal/syntax.scala
@@ -41,7 +41,7 @@ private[kafka] object syntax {
   }
 
   implicit final class MapSyntax[K, V](val map: Map[K, V]) extends AnyVal {
-    def toKeySet: Set[K] = {
+    def keySetStrict: Set[K] = {
       val builder = Set.newBuilder[K]
       map.foreach(builder += _._1)
       builder.result()

--- a/src/main/scala/fs2/kafka/internal/syntax.scala
+++ b/src/main/scala/fs2/kafka/internal/syntax.scala
@@ -46,6 +46,24 @@ private[kafka] object syntax {
       map.foreach(builder += _._1)
       builder.result()
     }
+
+    def filterKeysStrict(p: K => Boolean): Map[K, V] = {
+      val builder = Map.newBuilder[K, V]
+      map.foreach(e => if(p(e._1)) builder += e)
+      builder.result()
+    }
+
+    def filterKeysStrictList(p: K => Boolean): List[(K, V)] = {
+      val builder = List.newBuilder[(K, V)]
+      map.foreach(e => if(p(e._1)) builder += e)
+      builder.result()
+    }
+
+    def filterKeysStrictValuesList(p: K => Boolean): List[V] = {
+      val builder = List.newBuilder[V]
+      map.foreach(e => if(p(e._1)) builder += e._2)
+      builder.result()
+    }
   }
 
   implicit final class JavaUtilCollectionSyntax[A](val collection: util.Collection[A])

--- a/src/test/scala/fs2/kafka/KafkaConsumerSpec.scala
+++ b/src/test/scala/fs2/kafka/KafkaConsumerSpec.scala
@@ -10,10 +10,6 @@ final class KafkaConsumerSpec extends BaseKafkaSpec {
     tests(_.stream)
   }
 
-  describe("KafkaConsumer#partitionedStream") {
-    tests(_.partitionedStream.parJoin(partitions))
-  }
-
   describe("KafkaConsumer#parallelPartitionedStream") {
     tests(_.parallelPartitionedStream.parJoin(partitions))
   }


### PR DESCRIPTION
This fixes the following `StackOverflowError` which occurs because we use `Map#filterKeys` which provides a lazy view, and over time we accumulate more and more of these views on the same `Map`, eventually resulting in a stack overflow. This pull request fixes the issue by using a strict version of `filterKeys` (and specialized `filterKeysStrictList` and `filterKeysStrictValuesList`).

Thanks to @sebastianvoss (https://github.com/ovotech/fs2-kafka/issues/14#issuecomment-438617692) for discovering and reporting this issue.

```
Exception in thread "fs2-kafka-consumer-20" java.lang.StackOverflowError
  at scala.collection.MapLike$FilteredKeys.foreach(MapLike.scala:234)
  at scala.collection.MapLike$FilteredKeys.foreach(MapLike.scala:234)
  [...]
  at scala.collection.MapLike$FilteredKeys.foreach(MapLike.scala:234)
  at scala.collection.TraversableOnce.size(TraversableOnce.scala:106)
  at scala.collection.TraversableOnce.size$(TraversableOnce.scala:104)
  at scala.collection.AbstractTraversable.size(Traversable.scala:104)
  at cats.kernel.instances.MapMonoid.combine(map.scala:62)
  at cats.kernel.instances.MapMonoid.combine(map.scala:57)
  at fs2.kafka.KafkaConsumerActor.handleBatch$1(KafkaConsumerActor.scala:294)
  at fs2.kafka.KafkaConsumerActor.$anonfun$poll$24(KafkaConsumerActor.scala:359)
  at cats.effect.internals.IORunLoop$.cats$effect$internals$IORunLoop$$loop(IORunLoop.scala:139)
  at cats.effect.internals.IORunLoop$RestartCallback.signal(IORunLoop.scala:345)
  at cats.effect.internals.IORunLoop$RestartCallback.apply(IORunLoop.scala:366)
  at cats.effect.internals.IORunLoop$RestartCallback.apply(IORunLoop.scala:312)
  at cats.effect.internals.IORunLoop$.cats$effect$internals$IORunLoop$$loop(IORunLoop.scala:136)
  at cats.effect.internals.IORunLoop$RestartCallback.signal(IORunLoop.scala:345)
  at cats.effect.internals.IORunLoop$RestartCallback.apply(IORunLoop.scala:366)
  at cats.effect.internals.IORunLoop$RestartCallback.apply(IORunLoop.scala:312)
  at cats.effect.internals.IORunLoop$.cats$effect$internals$IORunLoop$$loop(IORunLoop.scala:136)
  at cats.effect.internals.IORunLoop$RestartCallback.signal(IORunLoop.scala:345)
  at cats.effect.internals.IORunLoop$RestartCallback.apply(IORunLoop.scala:366)
  at cats.effect.internals.IORunLoop$RestartCallback.apply(IORunLoop.scala:312)
  at cats.effect.internals.IOShift$Tick.run(IOShift.scala:36)
  at java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1402)
  at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
  at java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056)
  at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692)
  at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:157)
```