### PR TITLE
Change to allow overriding consumer and producer

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -92,7 +92,14 @@ lazy val mimaSettings = Seq(
       ProblemFilters.exclude[IncompatibleResultTypeProblem]("fs2.kafka.KafkaConsumerActor#State.copy$default$3"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.KafkaConsumer.parallelPartitionedStream"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.internal.syntax#MapSyntax.toKeySet"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.internal.syntax#MapSyntax.toKeySet$extension")
+      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.internal.syntax#MapSyntax.toKeySet$extension"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.ConsumerSettings.consumerFactory"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.ConsumerSettings.withConsumerFactory"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.ProducerSettings.producerFactory"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.ProducerSettings.withProducerFactory"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.ProducerSettings#ProducerSettingsImpl.apply"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.ProducerSettings#ProducerSettingsImpl.copy"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.ProducerSettings#ProducerSettingsImpl.this")
     )
     // format: on
   }

--- a/src/main/scala/fs2/kafka/ConsumerFactory.scala
+++ b/src/main/scala/fs2/kafka/ConsumerFactory.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 OVO Energy Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fs2.kafka
+
+import cats.effect.Sync
+import org.apache.kafka.clients.consumer.Consumer
+
+import scala.collection.JavaConverters._
+
+abstract class ConsumerFactory {
+  def create[F[_], K, V](
+    settings: ConsumerSettings[K, V]
+  )(implicit F: Sync[F]): F[Consumer[K, V]]
+}
+
+object ConsumerFactory {
+  val Default: ConsumerFactory =
+    new ConsumerFactory {
+      override def create[F[_], K, V](
+        settings: ConsumerSettings[K, V]
+      )(implicit F: Sync[F]): F[Consumer[K, V]] =
+        F.delay {
+          new org.apache.kafka.clients.consumer.KafkaConsumer(
+            (settings.properties: Map[String, AnyRef]).asJava,
+            settings.keyDeserializer,
+            settings.valueDeserializer
+          )
+        }
+
+      override def toString: String =
+        "Default"
+    }
+}

--- a/src/main/scala/fs2/kafka/ConsumerSettings.scala
+++ b/src/main/scala/fs2/kafka/ConsumerSettings.scala
@@ -81,6 +81,10 @@ sealed abstract class ConsumerSettings[K, V] {
   def commitRecovery: CommitRecovery
 
   def withCommitRecovery(commitRecovery: CommitRecovery): ConsumerSettings[K, V]
+
+  def consumerFactory: ConsumerFactory
+
+  def withConsumerFactory(consumerFactory: ConsumerFactory): ConsumerSettings[K, V]
 }
 
 object ConsumerSettings {
@@ -94,7 +98,8 @@ object ConsumerSettings {
     override val fetchTimeout: FiniteDuration,
     override val pollInterval: FiniteDuration,
     override val pollTimeout: FiniteDuration,
-    override val commitRecovery: CommitRecovery
+    override val commitRecovery: CommitRecovery,
+    override val consumerFactory: ConsumerFactory
   ) extends ConsumerSettings[K, V] {
     override def withBootstrapServers(bootstrapServers: String): ConsumerSettings[K, V] =
       withProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers)
@@ -165,6 +170,9 @@ object ConsumerSettings {
     override def withCommitRecovery(commitRecovery: CommitRecovery): ConsumerSettings[K, V] =
       copy(commitRecovery = commitRecovery)
 
+    override def withConsumerFactory(consumerFactory: ConsumerFactory): ConsumerSettings[K, V] =
+      copy(consumerFactory = consumerFactory)
+
     override def toString: String =
       Show[ConsumerSettings[K, V]].show(this)
   }
@@ -193,11 +201,12 @@ object ConsumerSettings {
     fetchTimeout = 500.millis,
     pollInterval = 50.millis,
     pollTimeout = 50.millis,
-    commitRecovery = CommitRecovery.Default
+    commitRecovery = CommitRecovery.Default,
+    consumerFactory = ConsumerFactory.Default
   )
 
   implicit def consumerSettingsShow[K, V]: Show[ConsumerSettings[K, V]] =
     Show.show { s =>
-      s"ConsumerSettings(closeTimeout = ${s.closeTimeout}, commitTimeout = ${s.commitTimeout}, fetchTimeout = ${s.fetchTimeout}, pollInterval = ${s.pollInterval}, pollTimeout = ${s.pollTimeout}, commitRecovery = ${s.commitRecovery})"
+      s"ConsumerSettings(closeTimeout = ${s.closeTimeout}, commitTimeout = ${s.commitTimeout}, fetchTimeout = ${s.fetchTimeout}, pollInterval = ${s.pollInterval}, pollTimeout = ${s.pollTimeout}, commitRecovery = ${s.commitRecovery}, consumerFactory = ${s.consumerFactory})"
     }
 }

--- a/src/main/scala/fs2/kafka/KafkaConsumer.scala
+++ b/src/main/scala/fs2/kafka/KafkaConsumer.scala
@@ -35,10 +35,9 @@ import fs2.kafka.internal.Synchronized
 import fs2.kafka.internal.instances._
 import fs2.kafka.internal.syntax._
 import fs2.{Chunk, Stream}
-import org.apache.kafka.clients.consumer.{KafkaConsumer => KConsumer, _}
+import org.apache.kafka.clients.consumer._
 import org.apache.kafka.common.TopicPartition
 
-import scala.collection.JavaConverters._
 import scala.collection.immutable.SortedSet
 import scala.concurrent.duration.FiniteDuration
 
@@ -166,13 +165,8 @@ private[kafka] object KafkaConsumer {
     context: ContextShift[F]
   ): Resource[F, Synchronized[F, Consumer[K, V]]] =
     Resource.make[F, Synchronized[F, Consumer[K, V]]] {
-      F.delay {
-          new KConsumer(
-            (settings.properties: Map[String, AnyRef]).asJava,
-            settings.keyDeserializer,
-            settings.valueDeserializer
-          )
-        }
+      settings.consumerFactory
+        .create(settings)
         .flatMap(Synchronized[F].of)
     } { synchronized =>
       synchronized.use { consumer =>

--- a/src/main/scala/fs2/kafka/ProducerFactory.scala
+++ b/src/main/scala/fs2/kafka/ProducerFactory.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 OVO Energy Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fs2.kafka
+
+import cats.effect.Sync
+import org.apache.kafka.clients.producer.Producer
+
+import scala.collection.JavaConverters._
+
+abstract class ProducerFactory {
+  def create[F[_], K, V](
+    settings: ProducerSettings[K, V]
+  )(implicit F: Sync[F]): F[Producer[K, V]]
+}
+
+object ProducerFactory {
+  val Default: ProducerFactory =
+    new ProducerFactory {
+      override def create[F[_], K, V](
+        settings: ProducerSettings[K, V]
+      )(implicit F: Sync[F]): F[Producer[K, V]] =
+        F.delay {
+          new org.apache.kafka.clients.producer.KafkaProducer(
+            (settings.properties: Map[String, AnyRef]).asJava,
+            settings.keySerializer,
+            settings.valueSerializer
+          )
+        }
+
+      override def toString: String =
+        "Default"
+    }
+}

--- a/src/main/scala/fs2/kafka/ProducerSettings.scala
+++ b/src/main/scala/fs2/kafka/ProducerSettings.scala
@@ -54,6 +54,10 @@ sealed abstract class ProducerSettings[K, V] {
   def closeTimeout: FiniteDuration
 
   def withCloseTimeout(closeTimeout: FiniteDuration): ProducerSettings[K, V]
+
+  def producerFactory: ProducerFactory
+
+  def withProducerFactory(producerFactory: ProducerFactory): ProducerSettings[K, V]
 }
 
 object ProducerSettings {
@@ -61,7 +65,8 @@ object ProducerSettings {
     override val keySerializer: Serializer[K],
     override val valueSerializer: Serializer[V],
     override val properties: Map[String, String],
-    override val closeTimeout: FiniteDuration
+    override val closeTimeout: FiniteDuration,
+    override val producerFactory: ProducerFactory
   ) extends ProducerSettings[K, V] {
     override def withBootstrapServers(bootstrapServers: String): ProducerSettings[K, V] =
       withProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers)
@@ -105,6 +110,9 @@ object ProducerSettings {
     override def withCloseTimeout(closeTimeout: FiniteDuration): ProducerSettings[K, V] =
       copy(closeTimeout = closeTimeout)
 
+    override def withProducerFactory(producerFactory: ProducerFactory): ProducerSettings[K, V] =
+      copy(producerFactory = producerFactory)
+
     override def toString: String =
       Show[ProducerSettings[K, V]].show(this)
   }
@@ -117,9 +125,12 @@ object ProducerSettings {
       keySerializer = keySerializer,
       valueSerializer = valueSerializer,
       properties = Map.empty,
-      closeTimeout = 60.seconds
+      closeTimeout = 60.seconds,
+      producerFactory = ProducerFactory.Default
     )
 
   implicit def producerSettingsShow[K, V]: Show[ProducerSettings[K, V]] =
-    Show.show(s => s"ProducerSettings(closeTimeout = ${s.closeTimeout})")
+    Show.show { s =>
+      s"ProducerSettings(closeTimeout = ${s.closeTimeout}, producerFactory = ${s.producerFactory})"
+    }
 }


### PR DESCRIPTION
Add `ConsumerFactory` and `ProducerFactory`, along with:

- `ConsumerSettings#withConsumerFactory` and 
- `ProducerSettings#withProducerFactory`

for overriding how the `Consumer` and `Producer` are created, respectively.

This is mainly useful for testing purposes.