### PR TITLE
Change to do less work in KafkaConsumerActor

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -99,7 +99,8 @@ lazy val mimaSettings = Seq(
       ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.ProducerSettings.withProducerFactory"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.ProducerSettings#ProducerSettingsImpl.apply"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.ProducerSettings#ProducerSettingsImpl.copy"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.ProducerSettings#ProducerSettingsImpl.this")
+      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.ProducerSettings#ProducerSettingsImpl.this"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.KafkaConsumerActor#State.withoutRecords")
     )
     // format: on
   }


### PR DESCRIPTION
- Add State#withoutFetchesAndRecords to reduce number of `State#copy`s.
- Change to avoid `copy` in `State#asSubscribed` if already subscribed.
- Change to avoid creating `settings.pollTimeout.asJava` on every poll.
- Change to avoid creating the unused effect when storing new fetches.