### PR TITLE
Change to improve performance of offset batching

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -100,7 +100,8 @@ lazy val mimaSettings = Seq(
       ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.ProducerSettings#ProducerSettingsImpl.apply"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.ProducerSettings#ProducerSettingsImpl.copy"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.ProducerSettings#ProducerSettingsImpl.this"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.KafkaConsumerActor#State.withoutRecords")
+      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.KafkaConsumerActor#State.withoutRecords"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.CommittableOffset.commitOffsets")
     )
     // format: on
   }

--- a/src/main/scala/fs2/kafka/CommittableOffset.scala
+++ b/src/main/scala/fs2/kafka/CommittableOffset.scala
@@ -22,19 +22,71 @@ import fs2.kafka.internal.instances._
 import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import org.apache.kafka.common.TopicPartition
 
+/**
+  * [[CommittableOffset]] represents an [[offsetAndMetadata]] for a
+  * [[topicPartition]], along with the ability to commit that offset
+  * to Kafka with [[commit]]. Note that offsets are normally committed
+  * in batches for performance reasons. Sinks like [[commitBatch]] and
+  * [[commitBatchWithin]] use [[CommittableOffsetBatch]] to commit the
+  * offsets in batches.<br>
+  * <br>
+  * While normally not necessary, [[CommittableOffset#apply]] can be
+  * used to create a new instance.
+  */
 sealed abstract class CommittableOffset[F[_]] {
+
+  /**
+    * The topic and partition for which [[offsetAndMetadata]]
+    * can be committed using [[commit]].
+    */
   def topicPartition: TopicPartition
 
+  /**
+    * The offset and metadata for the [[topicPartition]], which
+    * can be committed using [[commit]].
+    */
   def offsetAndMetadata: OffsetAndMetadata
 
+  /**
+    * The [[topicPartition]] and [[offsetAndMetadata]] as a `Map`.
+    * This is provided for convenience and is always guaranteed to
+    * be equivalent to the following.
+    *
+    * {{{
+    * Map(topicPartition -> offsetAndMetadata)
+    * }}}
+    */
   def offsets: Map[TopicPartition, OffsetAndMetadata]
 
+  /**
+    * The [[CommittableOffset]] as a [[CommittableOffsetBatch]].
+    */
   def batch: CommittableOffsetBatch[F]
 
+  /**
+    * Commits the [[offsetAndMetadata]] for the [[topicPartition]] to
+    * Kafka. Note that offsets are normally committed in batches for
+    * performance reasons. Prefer to use sinks like [[commitBatch]]
+    * or [[commitBatchWithin]], or [[CommittableOffsetBatch]] for
+    * that reason.
+    */
   def commit: F[Unit]
+
+  /**
+    * The commit function we are using in [[commit]] to commit the
+    * [[offsetAndMetadata]] for the [[topicPartition]]. Is used to
+    * help achieve better performance when batching offsets.
+    */
+  private[kafka] def commitOffsets: Map[TopicPartition, OffsetAndMetadata] => F[Unit]
 }
 
 object CommittableOffset {
+
+  /**
+    * Creates a new [[CommittableOffset]] with the specified `topicPartition`
+    * and `offsetAndMetadata`, along with `commit`, describing how to commit
+    * an arbitrary `Map` of topic-partition offsets.
+    */
   def apply[F[_]](
     topicPartition: TopicPartition,
     offsetAndMetadata: OffsetAndMetadata,
@@ -51,7 +103,7 @@ object CommittableOffset {
       override val offsetAndMetadata: OffsetAndMetadata =
         _offsetAndMetadata
 
-      override val offsets: Map[TopicPartition, OffsetAndMetadata] =
+      override def offsets: Map[TopicPartition, OffsetAndMetadata] =
         Map(_topicPartition -> _offsetAndMetadata)
 
       override def batch: CommittableOffsetBatch[F] =
@@ -59,6 +111,9 @@ object CommittableOffset {
 
       override def commit: F[Unit] =
         _commit(offsets)
+
+      override val commitOffsets: Map[TopicPartition, OffsetAndMetadata] => F[Unit] =
+        _commit
 
       override def toString: String =
         Show[CommittableOffset[F]].show(this)

--- a/src/main/scala/fs2/kafka/package.scala
+++ b/src/main/scala/fs2/kafka/package.scala
@@ -177,12 +177,7 @@ package object kafka {
   def commitBatchChunkOption[F[_]](
     implicit F: Applicative[F]
   ): Sink[F, Chunk[Option[CommittableOffset[F]]]] =
-    _.evalMap {
-      _.foldLeft(CommittableOffsetBatch.empty[F]) {
-        case (batch, Some(offset)) => batch.updated(offset)
-        case (batch, None)         => batch
-      }.commit
-    }
+    _.evalMap(CommittableOffsetBatch.fromFoldableOption(_).commit)
 
   /**
     * Commits offsets in batches determined by `Chunk`s. This allows


### PR DESCRIPTION
- Add  internal `CommittableOffset#commitOffsets` with the offset commit function.
- Change `CommittableOffset#offsets` from `val` to `def`, as it's used less with these changes.
- Change `CommittableOffsetBatch#updated` to use `Map#updated` instead of creating a new `Map` for every offset with `CommittableOffset#offsets`.
- Change `CommittableOffsetBatch#fromFoldable` to avoid creating intermediate `CommittableOffsetBatch` instances.
- Add `CommittableOffsetBatch#fromFoldableOption` and use it in `commitBatchChunkOption`.
- Add documentation for `CommittableOffset` and `CommittableOffsetBatch`.