### PR TITLE
Change to use Chunk#buffer in KafkaConsumerActor

### DIFF
--- a/src/main/scala/fs2/kafka/internal/instances.scala
+++ b/src/main/scala/fs2/kafka/internal/instances.scala
@@ -23,12 +23,14 @@ import cats.instances.long._
 import cats.instances.string._
 import cats.instances.tuple._
 import cats.syntax.show._
-import cats.{Order, Show}
+import cats.{Order, Semigroup, Show}
 import org.apache.kafka.clients.consumer.{ConsumerRecord, OffsetAndMetadata}
 import org.apache.kafka.clients.producer.{ProducerRecord, RecordMetadata}
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.header.{Header, Headers}
 import org.apache.kafka.common.record.TimestampType
+
+import scala.collection.mutable.ArrayBuffer
 
 private[kafka] object instances {
   implicit def consumerRecordShow[K, V](
@@ -94,4 +96,7 @@ private[kafka] object instances {
 
   implicit val topicPartitionShow: Show[TopicPartition] =
     Show.show(tp => show"${tp.topic}-${tp.partition}")
+
+  implicit def arrayBufferSemigroup[A]: Semigroup[ArrayBuffer[A]] =
+    Semigroup.instance(_ ++ _)
 }


### PR DESCRIPTION
#21 changed to use `Chunk#vector` in `KafkaConsumerActor`. This pull request instead changes to use `Chunk#buffer`. Since we know the exact number of records we receive per partition, we can allocate an `Array` (via `ArrayBuffer`) to hold the records. We cannot directly use the `java.util.List` (wrapped in `Buffer`), because the `List` is wrapped with `java.util.Collections.unmodifiable`.