### PR TITLE
Make ProducerMessage and ProducerResult covariant

### DIFF
--- a/src/main/scala/fs2/kafka/ProducerMessage.scala
+++ b/src/main/scala/fs2/kafka/ProducerMessage.scala
@@ -27,13 +27,13 @@ import org.apache.kafka.clients.producer.ProducerRecord
   * can be used with [[KafkaProducer]]. A [[ProducerMessage]] can
   * be created using one of the following options.<br>
   * <br>
-  * - [[ProducerMessage#single]] to produce exactly one record and
+  * - `ProducerMessage#single` to produce exactly one record and
   * then emit a [[ProducerResult#Single]] with the result and the
   * passthrough value.<br>
-  * - [[ProducerMessage#multiple]] to produce zero or more records
+  * - `ProducerMessage#multiple` to produce zero or more records
   * and then emit a [[ProducerResult#Multiple]] with the results
   * and the passthrough value.<br>
-  * - [[ProducerMessage#passthrough]] to produce exactly zero records,
+  * - `ProducerMessage#passthrough` to produce exactly zero records,
   * simply emitting a [[ProducerResult#Passthrough]] with the specified
   * passthrough value.<br>
   * <br>
@@ -113,6 +113,19 @@ object ProducerMessage {
     new Single(record, passthrough) {}
 
   /**
+    * Creates a new [[ProducerMessage]] for producing exactly one
+    * `ProducerRecord`, then emitting a [[ProducerResult#Single]]
+    * with the result and `Unit` passthrough value.<br>
+    * <br>
+    * [[ProducerMessage#Single]] can be used to extract instances
+    * created with this function.
+    */
+  def single[K, V](
+    record: ProducerRecord[K, V]
+  ): ProducerMessage[K, V, Unit] =
+    single(record, ())
+
+  /**
     * Creates a new [[ProducerMessage]] for producing zero or more
     * `ProducerRecords`s, then emitting a [[ProducerResult#Multiple]]
     * with the results and specified passthrough value.<br>
@@ -125,6 +138,19 @@ object ProducerMessage {
     passthrough: P
   ): ProducerMessage[K, V, P] =
     new Multiple(records, passthrough) {}
+
+  /**
+    * Creates a new [[ProducerMessage]] for producing zero or more
+    * `ProducerRecords`s, then emitting a [[ProducerResult#Multiple]]
+    * with the results and `Unit` passthrough value.<br>
+    * <br>
+    * [[ProducerMessage#Multiple]] can be used to extract instances
+    * created with this function.
+    */
+  def multiple[K, V, P](
+    records: List[ProducerRecord[K, V]]
+  ): ProducerMessage[K, V, Unit] =
+    multiple(records, ())
 
   /**
     * Creates a new [[ProducerMessage]] for producing exactly zero

--- a/src/main/scala/fs2/kafka/ProducerMessage.scala
+++ b/src/main/scala/fs2/kafka/ProducerMessage.scala
@@ -42,7 +42,7 @@ import org.apache.kafka.clients.producer.ProducerRecord
   * three cases: [[ProducerMessage#Single]], [[ProducerMessage#Multiple]],
   * and [[ProducerMessage#Passthrough]].
   */
-sealed abstract class ProducerMessage[K, V, P] {
+sealed abstract class ProducerMessage[+K, +V, +P] {
   def passthrough: P
 }
 

--- a/src/main/scala/fs2/kafka/ProducerResult.scala
+++ b/src/main/scala/fs2/kafka/ProducerResult.scala
@@ -28,11 +28,11 @@ import org.apache.kafka.clients.producer.{ProducerRecord, RecordMetadata}
   * can be created using one of the following options.<br>
   * <br>
   * - [[ProducerResult#single]] for when exactly one record has been
-  * produced using [[ProducerMessage#single]].<br>
+  * produced using `ProducerMessage#single`.<br>
   * - [[ProducerResult#multiple]] when zero or more records have been
-  * produced with [[ProducerMessage#multiple]].<br>
+  * produced with `ProducerMessage#multiple`.<br>
   * - [[ProducerResult#passthrough]] when exactly zero records have been
-  * produced using [[ProducerMessage#passthrough]].<br>
+  * produced using `ProducerMessage#passthrough`.<br>
   * <br>
   * Most often, only the [[passthrough]] value needs to be accessed.
   * If you need to access the `RecordMetadata` from having produced
@@ -122,7 +122,7 @@ object ProducerResult {
 
   /**
     * Creates a new [[ProducerResult]] for the result of having produced
-    * exactly one `ProducerRecord` using [[ProducerMessage#single]].
+    * exactly one `ProducerRecord` using `ProducerMessage#single`.
     * [[ProducerResult#Single]] can be used to extract instances
     * created with this function.
     */
@@ -135,7 +135,7 @@ object ProducerResult {
 
   /**
     * Creates a new [[ProducerResult]] for the result of having produced
-    * zero or more `ProducerRecord`s using [[ProducerMessage#multiple]].
+    * zero or more `ProducerRecord`s using `ProducerMessage#multiple`.
     * The parts can be created using [[ProducerResult#multiplePart]].
     * [[ProducerResult#Multiple]] can be used to extract instances
     * created with this function.
@@ -159,7 +159,7 @@ object ProducerResult {
 
   /**
     * Creates a new [[ProducerResult]] for the result of having produced
-    * exactly zero `ProducerRecord`s using [[ProducerMessage#passthrough]].
+    * exactly zero `ProducerRecord`s using `ProducerMessage#passthrough`.
     * [[ProducerResult#Passthrough]] can be used to extract instances
     * created with this function.
     */

--- a/src/main/scala/fs2/kafka/ProducerResult.scala
+++ b/src/main/scala/fs2/kafka/ProducerResult.scala
@@ -27,11 +27,11 @@ import org.apache.kafka.clients.producer.{ProducerRecord, RecordMetadata}
   * while keeping an arbitrary passthrough value. [[ProducerResult]]s
   * can be created using one of the following options.<br>
   * <br>
-  * - [[ProducerResult#single]] for when exactly one record has been
+  * - `ProducerResult#single` for when exactly one record has been
   * produced using `ProducerMessage#single`.<br>
-  * - [[ProducerResult#multiple]] when zero or more records have been
+  * - `ProducerResult#multiple` when zero or more records have been
   * produced with `ProducerMessage#multiple`.<br>
-  * - [[ProducerResult#passthrough]] when exactly zero records have been
+  * - `ProducerResult#passthrough` when exactly zero records have been
   * produced using `ProducerMessage#passthrough`.<br>
   * <br>
   * Most often, only the [[passthrough]] value needs to be accessed.
@@ -135,6 +135,18 @@ object ProducerResult {
 
   /**
     * Creates a new [[ProducerResult]] for the result of having produced
+    * exactly one `ProducerRecord` using `ProducerMessage#single`.
+    * [[ProducerResult#Single]] can be used to extract instances
+    * created with this function.
+    */
+  def single[K, V](
+    metadata: RecordMetadata,
+    record: ProducerRecord[K, V]
+  ): ProducerResult[K, V, Unit] =
+    single(metadata, record, ())
+
+  /**
+    * Creates a new [[ProducerResult]] for the result of having produced
     * zero or more `ProducerRecord`s using `ProducerMessage#multiple`.
     * The parts can be created using [[ProducerResult#multiplePart]].
     * [[ProducerResult#Multiple]] can be used to extract instances
@@ -147,7 +159,19 @@ object ProducerResult {
     new Multiple(parts, passthrough) {}
 
   /**
-    * Creates a new [[MultiplePart]] for use with [[ProducerResult#multiple]].
+    * Creates a new [[ProducerResult]] for the result of having produced
+    * zero or more `ProducerRecord`s using `ProducerMessage#multiple`.
+    * The parts can be created using [[ProducerResult#multiplePart]].
+    * [[ProducerResult#Multiple]] can be used to extract instances
+    * created with this function.
+    */
+  def multiple[K, V](
+    parts: List[MultiplePart[K, V]]
+  ): ProducerResult[K, V, Unit] =
+    new Multiple(parts, ()) {}
+
+  /**
+    * Creates a new [[MultiplePart]] for use with `ProducerResult#multiple`.
     * Each part consists of the `ProducerRecord` and `RecordMetadata` metadata
     * from having produced a single record.
     */

--- a/src/main/scala/fs2/kafka/ProducerResult.scala
+++ b/src/main/scala/fs2/kafka/ProducerResult.scala
@@ -40,7 +40,7 @@ import org.apache.kafka.clients.producer.{ProducerRecord, RecordMetadata}
   * also extractors for the three cases: [[ProducerResult#Single]],
   * [[ProducerResult#Multiple]], [[ProducerResult#Passthrough]].
   */
-sealed abstract class ProducerResult[K, V, P] {
+sealed abstract class ProducerResult[+K, +V, +P] {
   def passthrough: P
 }
 


### PR DESCRIPTION
Changes `ProducerMessage` and `ProducerResult` to be covariant in their type parameters. This change is especially helpful for type inference when using `ProducerMessage#passthrough`, where you're often required to currently use explicit type annotations to guide type inference of the key and value.

Additionally:
- add `ProducerMessage#single` and `ProducerMessage#multiple` with `Unit` passthrough,
- add `ProducerResult#single` and `ProducerResult#multiple` with `Unit` passthrough. 