### PR TITLE
Add support for record metadata

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -106,7 +106,9 @@ lazy val mimaSettings = Seq(
       ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.internal.Synchronized#ApplyBuilders.F"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.internal.syntax#FiniteDurationSyntax.duration"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.internal.syntax#JavaUtilCollectionSyntax.collection"),
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.CommittableOffsetBatch.updated")
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.CommittableOffsetBatch.updated"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.ConsumerSettings.recordMetadata"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.ConsumerSettings.withRecordMetadata")
     )
     // format: on
   }

--- a/src/main/scala/fs2/kafka/KafkaConsumerActor.scala
+++ b/src/main/scala/fs2/kafka/KafkaConsumerActor.scala
@@ -234,7 +234,10 @@ private[kafka] final class KafkaConsumerActor[F[_], K, V](
       record = record,
       committableOffset = CommittableOffset(
         topicPartition = partition,
-        offsetAndMetadata = new OffsetAndMetadata(record.offset + 1L),
+        offsetAndMetadata = new OffsetAndMetadata(
+          record.offset + 1L,
+          settings.recordMetadata(record)
+        ),
         commit = messageCommit
       )
     )

--- a/src/test/scala/fs2/kafka/BaseKafkaSpec.scala
+++ b/src/test/scala/fs2/kafka/BaseKafkaSpec.scala
@@ -27,6 +27,7 @@ abstract class BaseKafkaSpec extends BaseAsyncSpec with EmbeddedKafka {
         valueDeserializer = new StringDeserializer,
         executionContext = executionContext
       ).withProperties(consumerProperties(config))
+        .withRecordMetadata(_.timestamp.toString)
     }
 
   final def producerSettings(


### PR DESCRIPTION
Add `ConsumerSettings#withRecordMetadata`, which allows to specify a function for creating metadata for consumed records. Metadata will be included in `OffsetAndMetadata` for `CommittableOffset` (and in turn, `CommittableMessage`), and can then be committed together with the offsets. Just like before this change, there will be no metadata by default.