### PR TITLE
Remove KafkaConsumer#parallelPartitionedStream

### DIFF
--- a/src/main/scala/fs2/kafka/KafkaConsumer.scala
+++ b/src/main/scala/fs2/kafka/KafkaConsumer.scala
@@ -118,11 +118,6 @@ abstract class KafkaConsumer[F[_], K, V] {
   def partitionedStream: Stream[F, Stream[F, CommittableMessage[F, K, V]]]
 
   /**
-    * Alias of [[partitionedStream]].
-    */
-  def parallelPartitionedStream: Stream[F, Stream[F, CommittableMessage[F, K, V]]]
-
-  /**
     * Subscribes the consumer to the specified topics. Note that you have to
     * use this function to subscribe to one or more topics before using any
     * of the provided `Stream`s, or a [[NotSubscribedException]] will be
@@ -345,9 +340,6 @@ private[kafka] object KafkaConsumer {
             partitions.dequeue.interruptWhen(fiber.join.attempt)
         }
       }
-
-      override val parallelPartitionedStream: Stream[F, Stream[F, CommittableMessage[F, K, V]]] =
-        partitionedStream
 
       override val stream: Stream[F, CommittableMessage[F, K, V]] = {
         val requestAssignment: F[SortedSet[TopicPartition]] =

--- a/src/test/scala/fs2/kafka/KafkaConsumerSpec.scala
+++ b/src/test/scala/fs2/kafka/KafkaConsumerSpec.scala
@@ -10,8 +10,8 @@ final class KafkaConsumerSpec extends BaseKafkaSpec {
     tests(_.stream)
   }
 
-  describe("KafkaConsumer#parallelPartitionedStream") {
-    tests(_.parallelPartitionedStream.parJoin(partitions))
+  describe("KafkaConsumer#partitionedStream") {
+    tests(_.partitionedStream.parJoin(partitions))
   }
 
   val partitions = 3


### PR DESCRIPTION
#19 made `parallelPartitionedStream` an alias of `partitionedStream` for binary compatibility reasons, but we're now removing the alias as part of 0.17.0.