### PR TITLE
Change to seal KafkaConsumer and KafkaProducer

### DIFF
--- a/src/main/scala/fs2/kafka/KafkaConsumer.scala
+++ b/src/main/scala/fs2/kafka/KafkaConsumer.scala
@@ -76,7 +76,7 @@ import scala.util.matching.Regex
   * per [[KafkaConsumer]], and if you want to start a new stream if the first
   * one finishes, let the [[KafkaConsumer]] shutdown and create a new one.
   */
-abstract class KafkaConsumer[F[_], K, V] {
+sealed abstract class KafkaConsumer[F[_], K, V] {
 
   /**
     * `Stream` where the elements are Kafka messages and where ordering

--- a/src/main/scala/fs2/kafka/KafkaProducer.scala
+++ b/src/main/scala/fs2/kafka/KafkaProducer.scala
@@ -37,7 +37,7 @@ import org.apache.kafka.clients.producer._
   * useful for keeping the [[CommittableOffset]]s of consumed messages,
   * but any values can be used as passthrough values.
   */
-abstract class KafkaProducer[F[_], K, V] {
+sealed abstract class KafkaProducer[F[_], K, V] {
 
   /**
     * Produces the `ProducerRecord`s in the specified [[ProducerMessage]]


### PR DESCRIPTION
To be able to evolve `KafkaConsumer` and `KafkaProducer` without breaking binary compatibility.