### PR TITLE
Alternative Producer{Message,Result} encodings

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -74,7 +74,7 @@ object Main extends IOApp {
                   val record = new ProducerRecord("topic", key, value)
                   ProducerMessage.single(record, message.committableOffset)
               })
-            .evalMap(producer.produceBatched(_))
+            .evalMap(producer.produceBatched)
             .map(_.map(_.passthrough))
             .to(commitBatchWithinF(500, 15.seconds))
       } yield ()

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -27,10 +27,9 @@ Start with `import fs2.kafka._` and use `consumerStream` and `producerStream` to
 import cats.data.NonEmptyList
 import cats.effect.{ExitCode, IO, IOApp}
 import cats.syntax.functor._
-import cats.syntax.traverse._
 import fs2.kafka._
-import org.apache.kafka.clients.consumer.{ConsumerConfig, ConsumerRecord}
-import org.apache.kafka.clients.producer.{ProducerConfig, ProducerRecord}
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.serialization.{StringDeserializer, StringSerializer}
 
 import scala.concurrent.ExecutionContext
@@ -75,7 +74,7 @@ object Main extends IOApp {
                   val record = new ProducerRecord("topic", key, value)
                   ProducerMessage.single(record, message.committableOffset)
               })
-            .evalMap(producer.produceBatched)
+            .evalMap(producer.produceBatched(_))
             .map(_.map(_.passthrough))
             .to(commitBatchWithinF(500, 15.seconds))
       } yield ()

--- a/src/main/scala/fs2/kafka/CommitTimeoutException.scala
+++ b/src/main/scala/fs2/kafka/CommitTimeoutException.scala
@@ -16,9 +16,11 @@
 
 package fs2.kafka
 
+import cats.instances.list._
 import cats.instances.string._
 import cats.syntax.show._
 import fs2.kafka.internal.instances._
+import fs2.kafka.internal.syntax._
 import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import org.apache.kafka.common.{KafkaException, TopicPartition}
 
@@ -33,19 +35,16 @@ sealed abstract class CommitTimeoutException(
   timeout: FiniteDuration,
   offsets: Map[TopicPartition, OffsetAndMetadata]
 ) extends KafkaException({
-      val builder = new StringBuilder(s"offset commit timeout after $timeout for offsets: ")
-      val sorted = offsets.toList.sorted
-      var first = true
-
-      sorted.foreach {
-        case (tp, oam) =>
-          if (first) first = false
-          else builder.append(", ")
-
-          builder.append(tp.show).append(" -> ").append(oam.show)
-      }
-
-      builder.toString
+      offsets.toList.sorted.mkStringAppend {
+        case (append, (tp, oam)) =>
+          append(tp.show)
+          append(" -> ")
+          append(oam.show)
+      }(
+        start = s"offset commit timeout after $timeout for offsets: ",
+        sep = ", ",
+        end = ""
+      )
     }) {
 
   override def toString: String =

--- a/src/main/scala/fs2/kafka/CommittableOffsetBatch.scala
+++ b/src/main/scala/fs2/kafka/CommittableOffsetBatch.scala
@@ -16,10 +16,12 @@
 
 package fs2.kafka
 
+import cats.instances.list._
 import cats.syntax.foldable._
 import cats.syntax.show._
 import cats.{Applicative, Foldable, Show}
 import fs2.kafka.internal.instances._
+import fs2.kafka.internal.syntax._
 import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import org.apache.kafka.common.TopicPartition
 
@@ -199,19 +201,16 @@ object CommittableOffsetBatch {
     Show.show { cob =>
       if (cob.offsets.isEmpty) "CommittableOffsetBatch(<empty>)"
       else {
-        val builder = new StringBuilder("CommittableOffsetBatch(")
-        val offsets = cob.offsets.toList.sorted
-        var first = true
-
-        offsets.foreach {
-          case (tp, oam) =>
-            if (first) first = false
-            else builder.append(", ")
-
-            builder.append(tp.show).append(" -> ").append(oam.show)
-        }
-
-        builder.append(')').toString
+        cob.offsets.toList.sorted.mkStringAppend {
+          case (append, (tp, oam)) =>
+            append(tp.show)
+            append(" -> ")
+            append(oam.show)
+        }(
+          start = "CommittableOffsetBatch(",
+          sep = ", ",
+          end = ")"
+        )
       }
     }
 }

--- a/src/main/scala/fs2/kafka/ProducerMessage.scala
+++ b/src/main/scala/fs2/kafka/ProducerMessage.scala
@@ -49,7 +49,7 @@ sealed abstract class ProducerMessage[+F[_], +K, +V, +P] {
 }
 
 object ProducerMessage {
-  sealed abstract class Single[F[_], K, V, P](
+  private[this] final class Single[F[_], K, V, P](
     val record: ProducerRecord[K, V],
     override val passthrough: P
   ) extends ProducerMessage[F, K, V, P] {
@@ -66,7 +66,7 @@ object ProducerMessage {
     }
   }
 
-  sealed abstract class Multiple[F[_], K, V, P](
+  private[this] final class Multiple[F[_], K, V, P](
     val records: F[ProducerRecord[K, V]],
     override val passthrough: P
   )(implicit F: Foldable[F])
@@ -85,7 +85,7 @@ object ProducerMessage {
     }
   }
 
-  sealed abstract class Passthrough[F[_], K, V, P](
+  private[this] final class Passthrough[F[_], K, V, P](
     override val passthrough: P
   ) extends ProducerMessage[F, K, V, P] {
     override def toString: String =
@@ -113,7 +113,7 @@ object ProducerMessage {
     record: ProducerRecord[K, V],
     passthrough: P
   ): ProducerMessage[F, K, V, P] =
-    new Single(record, passthrough) {}
+    new Single(record, passthrough)
 
   /**
     * Creates a new [[ProducerMessage]] for producing exactly one
@@ -142,7 +142,7 @@ object ProducerMessage {
   )(
     implicit F: Foldable[F]
   ): ProducerMessage[F, K, V, P] =
-    new Multiple(records, passthrough) {}
+    new Multiple(records, passthrough)
 
   /**
     * Creates a new [[ProducerMessage]] for producing zero or more
@@ -170,7 +170,7 @@ object ProducerMessage {
   def passthrough[F[_], K, V, P](
     passthrough: P
   ): ProducerMessage[F, K, V, P] =
-    new Passthrough[F, K, V, P](passthrough) {}
+    new Passthrough[F, K, V, P](passthrough)
 
   implicit def producerMessageShow[F[_], K, V, P](
     implicit

--- a/src/main/scala/fs2/kafka/ProducerMessage.scala
+++ b/src/main/scala/fs2/kafka/ProducerMessage.scala
@@ -18,173 +18,132 @@ package fs2.kafka
 
 import cats.syntax.foldable._
 import cats.syntax.show._
-import cats.{Foldable, Show}
+import cats.{Applicative, MonoidK, Show, Traverse}
 import fs2.kafka.internal.instances._
 import fs2.kafka.internal.syntax._
 import org.apache.kafka.clients.producer.ProducerRecord
 
 /**
-  * [[ProducerMessage]] represents zero or more `ProducerRecord`s
-  * together with an arbitrary passthrough value, which together
-  * can be used with [[KafkaProducer]]. A [[ProducerMessage]] can
-  * be created using one of the following options.<br>
+  * [[ProducerMessage]] represents zero or more `ProducerRecord`s,
+  * together with an arbitrary passthrough value, all of which can
+  * be used with [[KafkaProducer]]. [[ProducerMessage]]s can be
+  * created using one of the following options.<br>
   * <br>
   * - `ProducerMessage#single` to produce exactly one record and
-  * then emit a [[ProducerResult#Single]] with the result and the
+  * then emit a [[ProducerResult]] with the result and specified
   * passthrough value.<br>
   * - `ProducerMessage#multiple` to produce zero or more records
-  * and then emit a [[ProducerResult#Multiple]] with the results
-  * and the passthrough value.<br>
-  * - `ProducerMessage#passthrough` to produce exactly zero records,
-  * simply emitting a [[ProducerResult#Passthrough]] with the specified
-  * passthrough value.<br>
+  * and then emit a [[ProducerResult]] with the results and
+  * specified passthrough value.<br>
+  * - `ProducerMessage#passthrough` to produce exactly zero
+  * records, only emitting a [[ProducerResult]] with the
+  * specified passthrough value.<br>
   * <br>
-  * While normally not necessary, the passthrough of a [[ProducerMessage]]
-  * can be accessed via [[passthrough]]. There are also extractors for the
-  * three cases: [[ProducerMessage#Single]], [[ProducerMessage#Multiple]],
-  * and [[ProducerMessage#Passthrough]].
+  * The [[passthrough]] and [[records]] can be retrieved from an
+  * existing [[ProducerMessage]] instance.<br>
+  * <br>
+  * For a [[ProducerMessage]] to be usable by [[KafkaProducer]],
+  * it needs a `Traverse` instance. This requirement is captured
+  * in [[ProducerMessage]] via [[traverse]].
   */
-sealed abstract class ProducerMessage[+F[_], +K, +V, +P] {
+sealed abstract class ProducerMessage[F[_], K, V, +P] {
+
+  /** The records to produce. Can be empty for passthrough-only. */
+  def records: F[ProducerRecord[K, V]]
+
+  /** The passthrough to emit once all [[records]] have been produced. */
   def passthrough: P
+
+  /** The traverse instance for `F[_]`. Used by [[KafkaProducer]]. */
+  def traverse: Traverse[F]
 }
 
 object ProducerMessage {
-  private[this] final class Single[F[_], K, V, P](
-    val record: ProducerRecord[K, V],
-    override val passthrough: P
+  private[this] final class ProducerMessageImpl[F[_], K, V, +P](
+    override val records: F[ProducerRecord[K, V]],
+    override val passthrough: P,
+    override val traverse: Traverse[F]
   ) extends ProducerMessage[F, K, V, P] {
-    override def toString: String =
-      s"Single($record, $passthrough)"
-  }
-
-  object Single {
-    def unapply[F[_], K, V, P](
-      message: ProducerMessage[F, K, V, P]
-    ): Option[(ProducerRecord[K, V], P)] = message match {
-      case single: Single[F, K, V, P] => Some((single.record, single.passthrough))
-      case _                          => None
-    }
-  }
-
-  private[this] final class Multiple[F[_], K, V, P](
-    val records: F[ProducerRecord[K, V]],
-    override val passthrough: P
-  )(implicit F: Foldable[F])
-      extends ProducerMessage[F, K, V, P] {
-    override def toString: String =
-      if (records.isEmpty) s"Multiple(<empty>, $passthrough)"
-      else records.mkString("Multiple(", ", ", s", $passthrough)")
-  }
-
-  object Multiple {
-    def unapply[F[_], K, V, P](
-      message: ProducerMessage[F, K, V, P]
-    ): Option[(F[ProducerRecord[K, V]], P)] = message match {
-      case multiple: Multiple[F, K, V, P] => Some((multiple.records, multiple.passthrough))
-      case _                              => None
-    }
-  }
-
-  private[this] final class Passthrough[F[_], K, V, P](
-    override val passthrough: P
-  ) extends ProducerMessage[F, K, V, P] {
-    override def toString: String =
-      s"Passthrough($passthrough)"
-  }
-
-  object Passthrough {
-    def unapply[F[_], K, V, P](
-      message: ProducerMessage[F, K, V, P]
-    ): Option[P] = message match {
-      case passthrough: Passthrough[F, K, V, P] => Some(passthrough.passthrough)
-      case _                                    => None
+    override def toString: String = {
+      implicit val F: Traverse[F] = traverse
+      if (records.isEmpty) s"ProducerMessage(<empty>, $passthrough)"
+      else records.mkString("ProducerMessage(", ", ", s", $passthrough)")
     }
   }
 
   /**
     * Creates a new [[ProducerMessage]] for producing exactly one
-    * `ProducerRecord`, then emitting a [[ProducerResult#Single]]
-    * with the result and specified passthrough value.<br>
-    * <br>
-    * [[ProducerMessage#Single]] can be used to extract instances
-    * created with this function.
+    * `ProducerRecord`, then emitting a [[ProducerResult]] with
+    * the result and specified passthrough value.
     */
   def single[F[_], K, V, P](
     record: ProducerRecord[K, V],
     passthrough: P
+  )(
+    implicit F: Traverse[F],
+    A: Applicative[F]
   ): ProducerMessage[F, K, V, P] =
-    new Single(record, passthrough)
+    multiple(A.pure(record), passthrough)
 
   /**
     * Creates a new [[ProducerMessage]] for producing exactly one
-    * `ProducerRecord`, then emitting a [[ProducerResult#Single]]
-    * with the result and `Unit` passthrough value.<br>
-    * <br>
-    * [[ProducerMessage#Single]] can be used to extract instances
-    * created with this function.
+    * `ProducerRecord`, then emitting a [[ProducerResult]] with
+    * the result and `Unit` passthrough value.
     */
   def single[F[_], K, V](
     record: ProducerRecord[K, V]
+  )(
+    implicit F: Traverse[F],
+    A: Applicative[F]
   ): ProducerMessage[F, K, V, Unit] =
     single(record, ())
 
   /**
     * Creates a new [[ProducerMessage]] for producing zero or more
-    * `ProducerRecords`s, then emitting a [[ProducerResult#Multiple]]
-    * with the results and specified passthrough value.<br>
-    * <br>
-    * [[ProducerMessage#Multiple]] can be used to extract instances
-    * created with this function.
+    * `ProducerRecords`s, then emitting a [[ProducerResult]] with
+    * the results and specified passthrough value.
     */
   def multiple[F[_], K, V, P](
     records: F[ProducerRecord[K, V]],
     passthrough: P
   )(
-    implicit F: Foldable[F]
+    implicit F: Traverse[F]
   ): ProducerMessage[F, K, V, P] =
-    new Multiple(records, passthrough)
+    new ProducerMessageImpl(records, passthrough, F)
 
   /**
     * Creates a new [[ProducerMessage]] for producing zero or more
-    * `ProducerRecords`s, then emitting a [[ProducerResult#Multiple]]
-    * with the results and `Unit` passthrough value.<br>
-    * <br>
-    * [[ProducerMessage#Multiple]] can be used to extract instances
-    * created with this function.
+    * `ProducerRecords`s, then emitting a [[ProducerResult]] with
+    * the results and `Unit` passthrough value.
     */
   def multiple[F[_], K, V](
     records: F[ProducerRecord[K, V]]
   )(
-    implicit F: Foldable[F]
+    implicit F: Traverse[F]
   ): ProducerMessage[F, K, V, Unit] =
     multiple(records, ())
 
   /**
     * Creates a new [[ProducerMessage]] for producing exactly zero
-    * `ProducerRecord`s, emitting a [[ProducerResult#passthrough]]
-    * with the specified passthrough value.<br>
-    * <br>
-    * [[ProducerMessage#Passthrough]] can be used to extract instances
-    * created with this function.
+    * `ProducerRecord`s, emitting a [[ProducerResult]] with the
+    * specified passthrough value.
     */
   def passthrough[F[_], K, V, P](
     passthrough: P
+  )(
+    implicit F: Traverse[F],
+    M: MonoidK[F]
   ): ProducerMessage[F, K, V, P] =
-    new Passthrough[F, K, V, P](passthrough)
+    multiple(M.empty, passthrough)
 
   implicit def producerMessageShow[F[_], K, V, P](
     implicit
-    F: Foldable[F],
     K: Show[K],
     V: Show[V],
     P: Show[P]
-  ): Show[ProducerMessage[F, K, V, P]] = Show.show {
-    case Single(record, passthrough) =>
-      show"Single($record, $passthrough)"
-    case Multiple(records, passthrough) =>
-      if (records.isEmpty) show"Multiple(<empty>, $passthrough)"
-      else records.mkStringShow("Multiple(", ", ", s", $passthrough)")
-    case Passthrough(passthrough) =>
-      show"Passthrough($passthrough)"
+  ): Show[ProducerMessage[F, K, V, P]] = Show.show { message =>
+    implicit val F: Traverse[F] = message.traverse
+    if (message.records.isEmpty) show"ProducerMessage(<empty>, ${message.passthrough})"
+    else message.records.mkStringShow("ProducerMessage(", ", ", s", ${message.passthrough})")
   }
 }

--- a/src/main/scala/fs2/kafka/ProducerResult.scala
+++ b/src/main/scala/fs2/kafka/ProducerResult.scala
@@ -25,188 +25,63 @@ import org.apache.kafka.clients.producer.{ProducerRecord, RecordMetadata}
 
 /**
   * [[ProducerResult]] represents the result of having produced zero
-  * or more `ProducerRecord`s in the form of [[ProducerMessage]]s,
-  * while keeping an arbitrary passthrough value. [[ProducerResult]]s
-  * can be created using one of the following options.<br>
+  * or more `ProducerRecord`s from a [[ProducerMessage]]. Finally, a
+  * passthrough value and `ProducerRecord`s along with respective
+  * `RecordMetadata` are emitted in a [[ProducerResult]].<br>
   * <br>
-  * - `ProducerResult#single` for when exactly one record has been
-  * produced using `ProducerMessage#single`.<br>
-  * - `ProducerResult#multiple` when zero or more records have been
-  * produced with `ProducerMessage#multiple`.<br>
-  * - `ProducerResult#passthrough` when exactly zero records have been
-  * produced using `ProducerMessage#passthrough`.<br>
+  * The [[passthrough]] and [[records]] can be retrieved from an
+  * existing [[ProducerResult]] instance.<br>
   * <br>
-  * Most often, only the [[passthrough]] value needs to be accessed.
-  * If you need to access the `RecordMetadata` from having produced
-  * some records, or the `ProducerRecord`s themselves, then there are
-  * also extractors for the three cases: [[ProducerResult#Single]],
-  * [[ProducerResult#Multiple]], [[ProducerResult#Passthrough]].
+  * Use [[ProducerResult#apply]] to create a new [[ProducerResult]].
   */
-sealed abstract class ProducerResult[+F[_], +K, +V, +P] {
+sealed abstract class ProducerResult[F[_], K, V, +P] {
+
+  /**
+    * The records produced along with respective metadata.
+    * Can be empty for passthrough-only.
+    */
+  def records: F[(ProducerRecord[K, V], RecordMetadata)]
+
+  /** The passthrough value. */
   def passthrough: P
 }
 
 object ProducerResult {
-  private[this] final class Single[F[_], K, V, P](
-    val metadata: RecordMetadata,
-    val record: ProducerRecord[K, V],
-    override val passthrough: P
-  ) extends ProducerResult[F, K, V, P] {
-    override def toString: String =
-      s"Single($metadata -> $record, $passthrough)"
-  }
-
-  object Single {
-    def unapply[F[_], K, V, P](
-      result: ProducerResult[F, K, V, P]
-    ): Option[(RecordMetadata, ProducerRecord[K, V], P)] = result match {
-      case single: Single[F, K, V, P] => Some((single.metadata, single.record, single.passthrough))
-      case _                          => None
-    }
-  }
-
-  sealed abstract class MultiplePart[K, V] {
-    def metadata: RecordMetadata
-
-    def record: ProducerRecord[K, V]
-  }
-
-  object MultiplePart {
-    def unapply[K, V](
-      part: MultiplePart[K, V]
-    ): Option[(RecordMetadata, ProducerRecord[K, V])] =
-      Some((part.metadata, part.record))
-
-    implicit def multiplePartShow[K, V](
-      implicit
-      K: Show[K],
-      V: Show[V]
-    ): Show[MultiplePart[K, V]] = Show.show { mp =>
-      show"${mp.metadata} -> ${mp.record}"
-    }
-  }
-
-  private[this] final class Multiple[F[_], K, V, P](
-    val parts: F[MultiplePart[K, V]],
+  private[this] final class ProducerResultImpl[F[_], K, V, +P](
+    override val records: F[(ProducerRecord[K, V], RecordMetadata)],
     override val passthrough: P
   )(implicit F: Foldable[F])
       extends ProducerResult[F, K, V, P] {
-    override def toString: String =
-      if (parts.isEmpty) s"Multiple(<empty>, $passthrough)"
-      else parts.mkString("Multiple(", ", ", s", $passthrough)")
-  }
 
-  object Multiple {
-    def unapply[F[_], K, V, P](
-      result: ProducerResult[F, K, V, P]
-    ): Option[(F[MultiplePart[K, V]], P)] = result match {
-      case multiple: Multiple[F, K, V, P] => Some((multiple.parts, multiple.passthrough))
-      case _                              => None
-    }
-  }
-
-  private[this] final class Passthrough[F[_], K, V, P](
-    override val passthrough: P
-  ) extends ProducerResult[F, K, V, P] {
-    override def toString: String =
-      s"Passthrough($passthrough)"
-  }
-
-  object Passthrough {
-    def unapply[F[_], K, V, P](
-      result: ProducerResult[F, K, V, P]
-    ): Option[P] = result match {
-      case passthrough: Passthrough[F, K, V, P] => Some(passthrough.passthrough)
-      case _                                    => None
+    override def toString: String = {
+      if (records.isEmpty)
+        s"ProducerResult(<empty>, $passthrough)"
+      else
+        records.mkStringAppend {
+          case (append, (record, metadata)) =>
+            append(metadata.toString)
+            append(" -> ")
+            append(record.toString)
+        }(
+          start = "ProducerResult(",
+          sep = ", ",
+          end = s", $passthrough)"
+        )
     }
   }
 
   /**
-    * Creates a new [[ProducerResult]] for the result of having produced
-    * exactly one `ProducerRecord` using `ProducerMessage#single`.
-    * [[ProducerResult#Single]] can be used to extract instances
-    * created with this function.
+    * Creates a new [[ProducerResult]] for having produced zero
+    * or more `ProducerRecord`s, finally emitting a passthrough
+    * value and the `ProducerRecord`s with `RecordMetadata`.
     */
-  def single[F[_], K, V, P](
-    metadata: RecordMetadata,
-    record: ProducerRecord[K, V],
-    passthrough: P
-  ): ProducerResult[F, K, V, P] =
-    new Single(metadata, record, passthrough)
-
-  /**
-    * Creates a new [[ProducerResult]] for the result of having produced
-    * exactly one `ProducerRecord` using `ProducerMessage#single`.
-    * [[ProducerResult#Single]] can be used to extract instances
-    * created with this function.
-    */
-  def single[F[_], K, V](
-    metadata: RecordMetadata,
-    record: ProducerRecord[K, V]
-  ): ProducerResult[F, K, V, Unit] =
-    single(metadata, record, ())
-
-  /**
-    * Creates a new [[ProducerResult]] for the result of having produced
-    * zero or more `ProducerRecord`s using `ProducerMessage#multiple`.
-    * The parts can be created using [[ProducerResult#multiplePart]].
-    * [[ProducerResult#Multiple]] can be used to extract instances
-    * created with this function.
-    */
-  def multiple[F[_], K, V, P](
-    parts: F[MultiplePart[K, V]],
+  def apply[F[_], K, V, P](
+    records: F[(ProducerRecord[K, V], RecordMetadata)],
     passthrough: P
   )(
     implicit F: Foldable[F]
   ): ProducerResult[F, K, V, P] =
-    new Multiple(parts, passthrough)
-
-  /**
-    * Creates a new [[ProducerResult]] for the result of having produced
-    * zero or more `ProducerRecord`s using `ProducerMessage#multiple`.
-    * The parts can be created using [[ProducerResult#multiplePart]].
-    * [[ProducerResult#Multiple]] can be used to extract instances
-    * created with this function.
-    */
-  def multiple[F[_], K, V](
-    parts: F[MultiplePart[K, V]]
-  )(
-    implicit F: Foldable[F]
-  ): ProducerResult[F, K, V, Unit] =
-    multiple(parts, ())
-
-  /**
-    * Creates a new [[MultiplePart]] for use with `ProducerResult#multiple`.
-    * Each part consists of the `ProducerRecord` and `RecordMetadata` metadata
-    * from having produced a single record.
-    */
-  def multiplePart[K, V](
-    metadata: RecordMetadata,
-    record: ProducerRecord[K, V]
-  ): MultiplePart[K, V] = {
-    val _metadata = metadata
-    val _record = record
-
-    new MultiplePart[K, V] {
-      override val metadata: RecordMetadata = _metadata
-
-      override val record: ProducerRecord[K, V] = _record
-
-      override def toString: String =
-        s"${_metadata} -> ${_record}"
-    }
-  }
-
-  /**
-    * Creates a new [[ProducerResult]] for the result of having produced
-    * exactly zero `ProducerRecord`s using `ProducerMessage#passthrough`.
-    * [[ProducerResult#Passthrough]] can be used to extract instances
-    * created with this function.
-    */
-  def passthrough[F[_], K, V, P](
-    passthrough: P
-  ): ProducerResult[F, K, V, P] =
-    new Passthrough[F, K, V, P](passthrough)
+    new ProducerResultImpl(records, passthrough)
 
   implicit def producerResultShow[F[_], K, V, P](
     implicit
@@ -214,13 +89,19 @@ object ProducerResult {
     K: Show[K],
     V: Show[V],
     P: Show[P]
-  ): Show[ProducerResult[F, K, V, P]] = Show.show {
-    case Single(metadata, record, passthrough) =>
-      show"Single($metadata -> $record, $passthrough)"
-    case Multiple(parts, passthrough) =>
-      if (parts.isEmpty) show"Multiple(<empty>, $passthrough)"
-      else parts.mkStringShow("Multiple(", ", ", s", $passthrough)")
-    case Passthrough(passthrough) =>
-      show"Passthrough($passthrough)"
+  ): Show[ProducerResult[F, K, V, P]] = Show.show { result =>
+    if (result.records.isEmpty)
+      show"ProducerResult(<empty>, ${result.passthrough})"
+    else
+      result.records.mkStringAppend {
+        case (append, (record, metadata)) =>
+          append(metadata.show)
+          append(" -> ")
+          append(record.show)
+      }(
+        start = "ProducerResult(",
+        sep = ", ",
+        end = show", ${result.passthrough})"
+      )
   }
 }

--- a/src/main/scala/fs2/kafka/internal/syntax.scala
+++ b/src/main/scala/fs2/kafka/internal/syntax.scala
@@ -21,6 +21,10 @@ import java.time.temporal.ChronoUnit
 import java.util
 import java.util.concurrent.TimeUnit
 
+import cats.syntax.foldable._
+import cats.syntax.show._
+import cats.{Foldable, Show}
+
 import scala.collection.immutable.SortedSet
 import scala.concurrent.duration.FiniteDuration
 
@@ -40,6 +44,34 @@ private[kafka] object syntax {
           case TimeUnit.MICROSECONDS => Duration.of(duration.length, ChronoUnit.MICROS)
           case TimeUnit.NANOSECONDS  => Duration.ofNanos(duration.length)
         }
+  }
+
+  implicit final class FoldableSyntax[F[_], A](
+    private val fa: F[A]
+  ) extends AnyVal {
+    def mkStringMap(f: A => String)(start: String, sep: String, end: String)(
+      implicit F: Foldable[F]
+    ): String = {
+      var first = true
+      fa.foldLeft(new java.lang.StringBuilder(start)) { (b, a) =>
+        if (first) {
+          first = false
+          b.append(f(a))
+        } else {
+          b.append(sep)
+          b.append(f(a))
+        }
+      }.append(end).toString
+    }
+
+    def mkString(start: String, sep: String, end: String)(
+      implicit F: Foldable[F]
+    ): String = mkStringMap(_.toString)(start, sep, end)
+
+    def mkStringShow(start: String, sep: String, end: String)(
+      implicit F: Foldable[F],
+      A: Show[A]
+    ): String = mkStringMap(_.show)(start, sep, end)
   }
 
   implicit final class MapSyntax[K, V](

--- a/src/test/scala/fs2/kafka/KafkaProducerSpec.scala
+++ b/src/test/scala/fs2/kafka/KafkaProducerSpec.scala
@@ -48,14 +48,13 @@ final class KafkaProducerSpec extends BaseKafkaSpec {
           result <- Stream.eval(producer.produce(message))
         } yield result).compile.lastOrError.unsafeRunSync
 
-      produced match {
-        case ProducerResult.Multiple(parts, passthrough) =>
-          val produced = parts.map(part => (part.record.key, part.record.value))
-          assert(produced == toProduce && passthrough == toPassthrough)
+      val records =
+        produced.records.map {
+          case (record, _) =>
+            record.key -> record.value
+        }
 
-        case result =>
-          fail(s"unexpected producer result: $result")
-      }
+      assert(records == toProduce && produced.passthrough == toPassthrough)
 
       val consumed =
         consumeNumberKeyedMessagesFrom[String, String](topic, toProduce.size)

--- a/src/test/scala/fs2/kafka/KafkaProducerSpec.scala
+++ b/src/test/scala/fs2/kafka/KafkaProducerSpec.scala
@@ -1,6 +1,7 @@
 package fs2.kafka
 
 import cats.effect.IO
+import cats.instances.list._
 import fs2.{Chunk, Stream}
 import org.apache.kafka.clients.producer.ProducerRecord
 


### PR DESCRIPTION
The previous encoding of `ProducerMessage` and `ProducerResult` had two limitations:

- `ProducerMessage#Multiple` could only support `List[ProducerRecord[K, V]]`, and
- due to their encodings, exhaustiveness checks could not be done for pattern matches.

The second limitation could be relaxed by changing the encoding slightly to use `final case class`es. This is not great from a binary compatibility perspective. However, if we want to relax the first limitation, we would have to parameterize by `F[_]`, and then pattern matching stops working due to type system limitations with GADTs.

Having to rely on pattern matching for `ProducerResult` is an annoyance for users. This pull request therefore introduces an alternative encoding of `ProducerMessage` and `ProducerResult` with a single case, removing the need for three different cases.

`ProducerMessage` becomes:

```scala
sealed abstract class ProducerMessage[F[_], K, V, +P] {
  def records: F[ProducerRecord[K, V]]
  def passthrough: P
  def traverse: Traverse[F]
}
```

and `ProducerResult` becomes as follows.

```scala
sealed abstract class ProducerResult[F[_], K, V, +P] {
  def records: F[(ProducerRecord[K, V], RecordMetadata)]
  def passthrough: P
}
```

The reason `Traverse` is on `ProducerMessage`, is so we can have a `KafkaProducer` which doesn't need to require an implicit `Traverse` instance, which would break perfectly fine code like:

```scala
Stream#evalMap(producer.produceBatched)
```

where you would have to use `Stream#evalMap(producer.produceBatched(_))`.

This pull request also unifies some `String` building using the internal `mkStringAppend`.