### PR TITLE
Add support for setting number of ExecutionContext threads

### DIFF
--- a/src/main/scala/fs2/kafka/ConsumerSettings.scala
+++ b/src/main/scala/fs2/kafka/ConsumerSettings.scala
@@ -421,7 +421,7 @@ object ConsumerSettings {
     * <br>
     * Since some Kafka operations are blocking, these operations should be run
     * on a dedicated `ExecutionContext`. If you need such an `ExecutionContext`,
-    * the [[consumerExecutionContextStream]] provides a sensible default option.
+    * `consumerExecutionContextStream` provides a sensible default option.
     */
   def apply[K, V](
     keyDeserializer: Deserializer[K],


### PR DESCRIPTION
Add `consumerExecutionContextResource` and `consumerExecutionContextStream` with an option to specify the number of threads. This is mainly useful when running multiple `KafkaConsumer`s in the same application, at the same time.