### PR TITLE
Add ProducerMessage functions for partial type application

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -22,6 +22,7 @@ For example, `@LATEST_MINOR_VERSION@x` is backwards binary compatible with `@LAT
 Start with `import fs2.kafka._` and use `consumerStream` and `producerStream` to create a consumer and producer, by providing a `ConsumerSettings` and `ProducerSettings`, respectively. The consumer is similar to `committableSource` in Alpakka Kafka, wrapping records in `CommittableMessage`. The producer accepts records wrapped in `ProducerMessage`, allowing offsets, and other elements, as passthrough values.
 
 ```scala mdoc
+import cats.Id
 import cats.data.NonEmptyList
 import cats.effect.{ExitCode, IO, IOApp}
 import cats.syntax.functor._
@@ -70,7 +71,7 @@ object Main extends IOApp {
               .map {
                 case (key, value) =>
                   val record = new ProducerRecord("topic", key, value)
-                  ProducerMessage.single(record, message.committableOffset)
+                  ProducerMessage.single[Id].of(record, message.committableOffset)
               })
             .evalMap(producer.produceBatched)
             .map(_.map(_.passthrough))


### PR DESCRIPTION
When creating `ProducerMessage`s, type inference sometimes fails because there are multiple possible options for `F[_]` available. This especially happens when multiple cats instances are imported into scope. Without these, however, the type is correctly inferred as `Id`.

Here are some examples where `F[_]` cannot be inferred correctly.

```scala
import org.apache.kafka.clients.producer.ProducerRecord
import cats.implicits._
import fs2.kafka._

val record = new ProducerRecord("topic", "key", "value")

val passthrough = "passthrough"

ProducerMessage.single(record)

ProducerMessage.multiple(record)

ProducerMessage.passthrough(passthrough)
```

This pull request adds functions for partial type application, to explicitly specify `F[_]`.

```scala
import cats.Id

ProducerMessage.single[Id].of(record)
ProducerMessage.single[Id].of(record, passthrough)

ProducerMessage.multiple[Id].of(record)
ProducerMessage.multiple[Id].of(record, passthrough)

ProducerMessage.passthrough[List].of(passthrough)
```

Since the key and value types are invariant, and can't generally be inferred for `passthrough`, they can instead be explicitly specified using `withKeyAndValue`.

```scala
ProducerMessage
  .passthrough[List]
  .withKeyAndValue[String, String]
  .of(passthrough)
```

The readme example has been updated to use partial type application, because users can be surprised to find that `F[_]` no longer infers correctly when they import cats instances.