### PR TITLE
Change to check all binary-compatible releases

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -98,14 +98,11 @@ lazy val publishSettings =
 
 lazy val mimaSettings = Seq(
   mimaPreviousArtifacts := {
-    def isPublishing = publishArtifact.value
-
-    latestBinaryCompatibleVersion.value match {
-      case Some(version) if isPublishing =>
-        Set(organization.value %% moduleName.value % version)
-      case _ =>
-        Set.empty
-    }
+    if (publishArtifact.value)
+      binaryCompatibleVersions.value
+        .map(version => organization.value %% moduleName.value % version)
+    else
+      Set.empty
   },
   mimaBinaryIssueFilters ++= {
     import com.typesafe.tools.mima.core._

--- a/latestVersion.sbt
+++ b/latestVersion.sbt
@@ -1,2 +1,6 @@
 latestVersion in ThisBuild := "0.17.1"
-latestBinaryCompatibleVersion in ThisBuild := Some("0.17.1")
+
+binaryCompatibleVersions in ThisBuild := Set(
+  "0.17.0",
+  "0.17.1"
+)

--- a/project/LatestVersion.scala
+++ b/project/LatestVersion.scala
@@ -9,18 +9,39 @@ object LatestVersion extends AutoPlugin {
     lazy val latestVersion: SettingKey[String] =
       settingKey[String]("Latest released version")
 
-    lazy val latestBinaryCompatibleVersion: SettingKey[Option[String]] =
-      settingKey[Option[String]]("Latest released binary-compatible version")
+    lazy val binaryCompatibleVersions: SettingKey[Set[String]] =
+      settingKey[Set[String]]("Released binary-compatible versions")
 
     lazy val setLatestVersion: ReleaseStep = { state: State =>
       val extracted = Project.extract(state)
 
-      val newLatestVersion = extracted.get(version in ThisBuild)
+      val newLatestVersion =
+        extracted.get(version in ThisBuild)
+
+      state.log.info(s"Setting latest version to '$newLatestVersion'.")
+
+      val newLatestVersionString =
+        "\"" + newLatestVersion + "\""
+
+      val newBinaryCompatibleVersions =
+        extracted.get(binaryCompatibleVersions in ThisBuild) + newLatestVersion
+
+      val newBinaryCompatibleVersionsString =
+        newBinaryCompatibleVersions.toList
+          .sortBy { version =>
+            val Array(major, minor, patch) =
+              version.split('.').map(_.toInt)
+            (major, minor, patch)
+          }
+          .map(version => "\"" + version + "\"")
+          .mkString("Set(\n  ", ",\n  ", "\n)")
+
       val latestVersionFile = file("latestVersion.sbt")
       val latestVersionFileContents =
         s"""
-          |latestVersion in ThisBuild := "$newLatestVersion"
-          |latestBinaryCompatibleVersion in ThisBuild := Some("$newLatestVersion")
+          |latestVersion in ThisBuild := $newLatestVersionString
+          |
+          |binaryCompatibleVersions in ThisBuild := $newBinaryCompatibleVersionsString
          """.stripMargin.trim + "\n"
 
       IO.write(latestVersionFile, latestVersionFileContents)
@@ -29,7 +50,13 @@ object LatestVersion extends AutoPlugin {
         vcs.commit(s"Set latest version to $newLatestVersion", sign = true) !! state.log
       }
 
-      reapply(Seq(latestVersion in ThisBuild := newLatestVersion), state)
+      reapply(
+        Seq(
+          latestVersion in ThisBuild := newLatestVersion,
+          binaryCompatibleVersions in ThisBuild := newBinaryCompatibleVersions
+        ),
+        state
+      )
     }
   }
 }


### PR DESCRIPTION
When checking binary-compatibility against previous releases, check all releases which should be binary-compatible, rather than just the latest release.