### PR TITLE
Add initial KafkaAdminClient

### DIFF
--- a/src/main/scala/fs2/kafka/AdminClientFactory.scala
+++ b/src/main/scala/fs2/kafka/AdminClientFactory.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2018 OVO Energy Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fs2.kafka
+
+import cats.effect.Sync
+import org.apache.kafka.clients.admin.AdminClient
+
+import scala.collection.JavaConverters._
+
+/**
+  * [[AdminClientFactory]] represents the ability to create a
+  * new Kafka `AdminClient` given [[AdminClientSettings]]. We
+  * normally do not need a custom [[AdminClientFactory]], but
+  * it can be useful for testing purposes. If you can instead
+  * have a custom trait or class with only the required parts
+  * from [[KafkaAdminClient]] for testing, then prefer that.<br>
+  * <br>
+  * To create a new [[AdminClientFactory]], simply create a
+  * new instance and implement the [[create]] function with
+  * the desired behaviour. To use a custom instance, set it
+  * with [[AdminClientSettings#withAdminClientFactory]].<br>
+  * <br>
+  * [[AdminClientFactory#Default]] is the default instance,
+  * and it creates a default `AdminClient` instance from
+  * the provided [[AdminClientSettings]].
+  */
+abstract class AdminClientFactory {
+  def create[F[_]](
+    settings: AdminClientSettings
+  )(implicit F: Sync[F]): F[AdminClient]
+}
+
+object AdminClientFactory {
+
+  /**
+    * The default [[AdminClientFactory]] used in [[AdminClientSettings]]
+    * unless a different instance has been specified. Default instance
+    * creates `AdminClient` instances from provided settings.
+    */
+  val Default: AdminClientFactory =
+    new AdminClientFactory {
+      override def create[F[_]](
+        settings: AdminClientSettings
+      )(implicit F: Sync[F]): F[AdminClient] =
+        F.delay {
+          AdminClient.create {
+            (settings.properties: Map[String, AnyRef]).asJava
+          }
+        }
+
+      override def toString: String =
+        "Default"
+    }
+}

--- a/src/main/scala/fs2/kafka/AdminClientSettings.scala
+++ b/src/main/scala/fs2/kafka/AdminClientSettings.scala
@@ -1,0 +1,285 @@
+/*
+ * Copyright 2018 OVO Energy Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fs2.kafka
+
+import cats.Show
+import org.apache.kafka.clients.admin.AdminClientConfig
+
+import scala.concurrent.duration._
+
+/**
+  * [[AdminClientSettings]] contain settings necessary to create a
+  * [[KafkaAdminClient]]. Several convenience functions are provided
+  * so that you don't have to work with `String` values and keys from
+  * `AdminClientConfig`. It's still possible to set `AdminClientConfig`
+  * values with functions like [[withProperty]].<br>
+  * <br>
+  * [[AdminClientSettings]] instances are immutable and all modification
+  * functions return a new [[AdminClientSettings]] instance.<br>
+  * <br>
+  * Use [[AdminClientSettings#Default]] for the default settings, and
+  * then apply any desired modifications on top of that instance.
+  */
+sealed abstract class AdminClientSettings {
+
+  /**
+    * Properties which can be provided when creating a Java `KafkaAdminClient`
+    * instance. Numerous functions in [[AdminClientSettings]] add properties
+    * here if the settings are used by the Java `KafkaAdminClient`.
+    */
+  def properties: Map[String, String]
+
+  /**
+    * Returns a new [[AdminClientSettings]] instance with the specified
+    * bootstrap servers. This is equivalent to setting the following
+    * property using the [[withProperty]] function.
+    *
+    * {{{
+    * AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG
+    * }}}
+    */
+  def withBootstrapServers(bootstrapServers: String): AdminClientSettings
+
+  /**
+    * Returns a new [[AdminClientSettings]] instance with the specified
+    * client id. This is equivalent to setting the following property
+    * using the [[withProperty]] function.
+    *
+    * {{{
+    * AdminClientConfig.CLIENT_ID_CONFIG
+    * }}}
+    */
+  def withClientId(clientId: String): AdminClientSettings
+
+  /**
+    * Returns a new [[AdminClientSettings]] instance with the specified
+    * reconnect backoff. This is equivalent to setting the following
+    * property using the [[withProperty]] function, except you can
+    * specify it with a `FiniteDuration` instead of a `String`.
+    *
+    * {{{
+    * AdminClientConfig.RECONNECT_BACKOFF_MS_CONFIG
+    * }}}
+    */
+  def withReconnectBackoff(reconnectBackoff: FiniteDuration): AdminClientSettings
+
+  /**
+    * Returns a new [[AdminClientSettings]] instance with the specified
+    * max reconnect backoff. This is equivalent to setting the following
+    * property using the [[withProperty]] function, except you can
+    * specify it with a `FiniteDuration` instead of a `String`.
+    *
+    * {{{
+    * AdminClientConfig.RECONNECT_BACKOFF_MAX_MS_CONFIG
+    * }}}
+    */
+  def withReconnectBackoffMax(reconnectBackoffMax: FiniteDuration): AdminClientSettings
+
+  /**
+    * Returns a new [[AdminClientSettings]] instance with the specified
+    * retry backoff. This is equivalent to setting the following property
+    * using the [[withProperty]] function, except you can specify it with
+    * a `FiniteDuration` instead of a `String`.
+    *
+    * {{{
+    * AdminClientConfig.RETRY_BACKOFF_MS_CONFIG
+    * }}}
+    */
+  def withRetryBackoff(retryBackoff: FiniteDuration): AdminClientSettings
+
+  /**
+    * Returns a new [[AdminClientSettings]] instance with the specified
+    * max connection idle time. This is equivalent to setting the following
+    * property using the [[withProperty]] function, except you can specify
+    * it with a `FiniteDuration` instead of a `String`.
+    *
+    * {{{
+    * AdminClientConfig.CONNECTIONS_MAX_IDLE_MS_CONFIG
+    * }}}
+    */
+  def withConnectionsMaxIdle(connectionsMaxIdle: FiniteDuration): AdminClientSettings
+
+  /**
+    * Returns a new [[AdminClientSettings]] instance with the specified
+    * request timeout. This is equivalent to setting the following
+    * property using the [[withProperty]] function, except you can
+    * specify it with a `FiniteDuration` instead of a `String`.
+    *
+    * {{{
+    * AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG
+    * }}}
+    */
+  def withRequestTimeout(requestTimeout: FiniteDuration): AdminClientSettings
+
+  /**
+    * Returns a new [[AdminClientSettings]] instance with the specified
+    * max metadata age. This is equivalent to setting the following
+    * property using the [[withProperty]] function, except you can
+    * specify it with a `FiniteDuration` instead of a `String`.
+    *
+    * {{{
+    * AdminClientConfig.METADATA_MAX_AGE_CONFIG
+    * }}}
+    */
+  def withMetadataMaxAge(metadataMaxAge: FiniteDuration): AdminClientSettings
+
+  /**
+    * Returns a new [[AdminClientSettings]] instance with the specified
+    * retries. This is equivalent to setting the following property
+    * using the [[withProperty]] function, except you can specify
+    * it with an `Int` instead of a `String`.
+    *
+    * {{{
+    * AdminClientConfig.RETRIES_CONFIG
+    * }}}
+    */
+  def withRetries(retries: Int): AdminClientSettings
+
+  /**
+    * Includes a property with the specified `key` and `value`.
+    * The key should be one of the keys in `AdminClientConfig`,
+    * and the value should be a valid choice for the key.
+    */
+  def withProperty(key: String, value: String): AdminClientSettings
+
+  /**
+    * Includes the specified keys and values as properties. The
+    * keys should be part of the `AdminClientConfig` keys, and
+    * the values should be valid choices for the keys.
+    */
+  def withProperties(properties: (String, String)*): AdminClientSettings
+
+  /**
+    * Includes the specified keys and values as properties. The
+    * keys should be part of the `AdminClientConfig` keys, and
+    * the values should be valid choices for the keys.
+    */
+  def withProperties(properties: Map[String, String]): AdminClientSettings
+
+  /**
+    * The time to wait for the Java `KafkaAdminClient` to shutdown.<br>
+    * <br>
+    * The default value is 20 seconds.
+    */
+  def closeTimeout: FiniteDuration
+
+  /**
+    * Creates a new [[AdminClientSettings]] with the specified [[closeTimeout]].
+    */
+  def withCloseTimeout(closeTimeout: FiniteDuration): AdminClientSettings
+
+  /**
+    * The [[AdminClientFactory]] for creating the Java `AdminClient`.<br>
+    * <br>
+    * The default is [[AdminClientFactory#Default]].<br>
+    * <br>
+    * Note that under normal usage you don't need to have a custom
+    * [[AdminClientFactory]] instance. For testing, you should prefer
+    * to use a custom trait or class similar to [[KafkaAdminClient]].
+    */
+  def adminClientFactory: AdminClientFactory
+
+  /**
+    * Creates a new [[AdminClientSettings]] with the specified
+    * [[AdminClientFactory]] as the [[adminClientFactory]].<br>
+    * <br>
+    * Note that under normal usage you don't need to have a custom
+    * [[AdminClientFactory]] instance. For testing, you should prefer
+    * to use a custom trait or class similar to [[KafkaAdminClient]].
+    */
+  def withAdminClientFactory(adminClientFactory: AdminClientFactory): AdminClientSettings
+}
+
+object AdminClientSettings {
+  private[this] final case class AdminClientSettingsImpl(
+    override val properties: Map[String, String],
+    override val closeTimeout: FiniteDuration,
+    override val adminClientFactory: AdminClientFactory
+  ) extends AdminClientSettings {
+    override def withBootstrapServers(bootstrapServers: String): AdminClientSettings =
+      withProperty(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers)
+
+    override def withClientId(clientId: String): AdminClientSettings =
+      withProperty(AdminClientConfig.CLIENT_ID_CONFIG, clientId)
+
+    override def withReconnectBackoff(reconnectBackoff: FiniteDuration): AdminClientSettings =
+      withProperty(
+        AdminClientConfig.RECONNECT_BACKOFF_MS_CONFIG,
+        reconnectBackoff.toMillis.toString
+      )
+
+    override def withReconnectBackoffMax(reconnectBackoffMax: FiniteDuration): AdminClientSettings =
+      withProperty(
+        AdminClientConfig.RECONNECT_BACKOFF_MAX_MS_CONFIG,
+        reconnectBackoffMax.toMillis.toString
+      )
+
+    override def withRetryBackoff(retryBackoff: FiniteDuration): AdminClientSettings =
+      withProperty(AdminClientConfig.RETRY_BACKOFF_MS_CONFIG, retryBackoff.toMillis.toString)
+
+    override def withConnectionsMaxIdle(connectionsMaxIdle: FiniteDuration): AdminClientSettings =
+      withProperty(
+        AdminClientConfig.CONNECTIONS_MAX_IDLE_MS_CONFIG,
+        connectionsMaxIdle.toMillis.toString
+      )
+
+    override def withRequestTimeout(requestTimeout: FiniteDuration): AdminClientSettings =
+      withProperty(AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG, requestTimeout.toMillis.toString)
+
+    override def withMetadataMaxAge(metadataMaxAge: FiniteDuration): AdminClientSettings =
+      withProperty(AdminClientConfig.METADATA_MAX_AGE_CONFIG, metadataMaxAge.toMillis.toString)
+
+    override def withRetries(retries: Int): AdminClientSettings =
+      withProperty(AdminClientConfig.RETRIES_CONFIG, retries.toString)
+
+    override def withProperty(key: String, value: String): AdminClientSettings =
+      copy(properties = properties.updated(key, value))
+
+    override def withProperties(properties: (String, String)*): AdminClientSettings =
+      copy(properties = this.properties ++ properties.toMap)
+
+    override def withProperties(properties: Map[String, String]): AdminClientSettings =
+      copy(properties = this.properties ++ properties)
+
+    override def withCloseTimeout(closeTimeout: FiniteDuration): AdminClientSettings =
+      copy(closeTimeout = closeTimeout)
+
+    override def withAdminClientFactory(
+      adminClientFactory: AdminClientFactory
+    ): AdminClientSettings =
+      copy(adminClientFactory = adminClientFactory)
+
+    override def toString: String =
+      Show[AdminClientSettings].show(this)
+  }
+
+  /**
+    * The default [[AdminClientSettings]] instance. You can use this
+    * instance as a base for creating custom [[AdminClientSettings]].
+    */
+  val Default: AdminClientSettings =
+    AdminClientSettingsImpl(
+      properties = Map.empty,
+      closeTimeout = 20.seconds,
+      adminClientFactory = AdminClientFactory.Default
+    )
+
+  implicit val adminClientSettingsShow: Show[AdminClientSettings] =
+    Show.show { s =>
+      s"AdminClientSettings(closeTimeout = ${s.closeTimeout}, adminClientFactory = ${s.adminClientFactory})"
+    }
+}

--- a/src/main/scala/fs2/kafka/KafkaAdminClient.scala
+++ b/src/main/scala/fs2/kafka/KafkaAdminClient.scala
@@ -1,0 +1,336 @@
+/*
+ * Copyright 2018 OVO Energy Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fs2.kafka
+
+import cats.Foldable
+import cats.effect.syntax.concurrent._
+import cats.effect.{Concurrent, Resource}
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+import fs2.kafka.KafkaAdminClient._
+import fs2.kafka.internal.syntax._
+import org.apache.kafka.clients.admin._
+import org.apache.kafka.clients.consumer.OffsetAndMetadata
+import org.apache.kafka.common.{KafkaFuture, TopicPartition}
+
+/**
+  * [[KafkaAdminClient]] represents an admin client for Kafka, which is able to
+  * describe queries about topics, consumer groups, offsets, and other entities
+  * related to Kafka.<br>
+  * <br>
+  * Use [[adminClientResource]] or [[adminClientStream]] to create an instance.
+  */
+sealed abstract class KafkaAdminClient[F[_]] {
+
+  /**
+    * Describes the consumer groups with the specified group ids, returning a
+    * `Map` with group ids as keys, and `ConsumerGroupDescription`s as values.
+    */
+  def describeConsumerGroups[G[_]](groupIds: G[String])(
+    implicit G: Foldable[G]
+  ): F[Map[String, ConsumerGroupDescription]]
+
+  /**
+    * Describes the topics with the specified topic names, returning a
+    * `Map` with topic names as keys, and `TopicDescription`s as values.
+    */
+  def describeTopics[G[_]](topics: G[String])(
+    implicit G: Foldable[G]
+  ): F[Map[String, TopicDescription]]
+
+  /**
+    * Lists consumer groups. Returns group ids using:
+    *
+    * {{{
+    * listConsumerGroups.groupIds
+    * }}}
+    *
+    * or `ConsumerGroupListing`s using the following.
+    *
+    * {{{
+    * listConsumerGroups.listings
+    * }}}
+    */
+  def listConsumerGroups: ListConsumerGroups[F]
+
+  /**
+    * Lists consumer group offsets. Returns offsets per topic-partition using:
+    *
+    * {{{
+    * listConsumerGroupOffsets(groupId)
+    *   .partitionsToOffsetAndMetadata
+    * }}}
+    *
+    * or only offsets for specified topic-partitions using the following.
+    *
+    * {{{
+    * listConsumerGroupOffsets(groupId)
+    *   .forPartitions(topicPartitions)
+    *   .partitionsToOffsetAndMetadata
+    * }}}
+    */
+  def listConsumerGroupOffsets(groupId: String): ListConsumerGroupOffsets[F]
+
+  /**
+    * Lists topics. Returns topic names using:
+    *
+    * {{{
+    * listTopics.names
+    * }}}
+    *
+    * or `TopicListing`s using:
+    *
+    * {{{
+    * listTopics.listings
+    * }}}
+    *
+    * or a `Map` of topic names to `TopicListing`s using the following.
+    *
+    * {{{
+    * listTopics.namesToListings
+    * }}}
+    *
+    * If you want to include internal topics, first use `includeInternal`.
+    *
+    * {{{
+    * listTopics.includeInternal.listings
+    * }}}
+    */
+  def listTopics: ListTopics[F]
+}
+
+object KafkaAdminClient {
+  private[this] def describeConsumerGroupsWith[F[_], G[_]](
+    client: Client[F],
+    groupIds: G[String]
+  )(implicit G: Foldable[G]): F[Map[String, ConsumerGroupDescription]] =
+    client(_.describeConsumerGroups(groupIds.asJava).all.map(_.toMap))
+
+  private[this] def describeTopicsWith[F[_], G[_]](
+    client: Client[F],
+    topics: G[String]
+  )(implicit G: Foldable[G]): F[Map[String, TopicDescription]] =
+    client(_.describeTopics(topics.asJava).all.map(_.toMap))
+
+  sealed abstract class ListTopics[F[_]] {
+
+    /** Lists topic names. */
+    def names: F[Set[String]]
+
+    /** Lists topics as `TopicListing`s. */
+    def listings: F[List[TopicListing]]
+
+    /** Lists topics as a `Map` from topic names to `TopicListing`s. */
+    def namesToListings: F[Map[String, TopicListing]]
+
+    /** Include internal topics in the listing. */
+    def includeInternal: ListTopicsIncludeInternal[F]
+  }
+
+  sealed abstract class ListTopicsIncludeInternal[F[_]] {
+
+    /** Lists topic names. Includes internal topics. */
+    def names: F[Set[String]]
+
+    /** Lists topics as `TopicListing`s. Includes internal topics. */
+    def listings: F[List[TopicListing]]
+
+    /** Lists topics as a `Map` from topic names to `TopicListing`s. Includes internal topics. */
+    def namesToListings: F[Map[String, TopicListing]]
+  }
+
+  private[this] def listTopicsWith[F[_]](
+    client: Client[F]
+  ): ListTopics[F] =
+    new ListTopics[F] {
+      override def names: F[Set[String]] =
+        client(_.listTopics.names.map(_.toSet))
+
+      override def listings: F[List[TopicListing]] =
+        client(_.listTopics.listings.map(_.toList))
+
+      override def namesToListings: F[Map[String, TopicListing]] =
+        client(_.listTopics.namesToListings.map(_.toMap))
+
+      override def includeInternal: ListTopicsIncludeInternal[F] =
+        listTopicsIncludeInternalWith(client)
+
+      override def toString: String =
+        "ListTopics$" + System.identityHashCode(this)
+    }
+
+  private[this] def listTopicsIncludeInternalWith[F[_]](
+    client: Client[F]
+  ): ListTopicsIncludeInternal[F] =
+    new ListTopicsIncludeInternal[F] {
+      private[this] def options: ListTopicsOptions =
+        new ListTopicsOptions().listInternal(true)
+
+      override def names: F[Set[String]] =
+        client(_.listTopics(options).names.map(_.toSet))
+
+      override def listings: F[List[TopicListing]] =
+        client(_.listTopics(options).listings.map(_.toList))
+
+      override def namesToListings: F[Map[String, TopicListing]] =
+        client(_.listTopics(options).namesToListings.map(_.toMap))
+
+      override def toString: String =
+        "ListTopicsIncludeInternal$" + System.identityHashCode(this)
+    }
+
+  sealed abstract class ListConsumerGroups[F[_]] {
+
+    /** Lists the available consumer group ids. */
+    def groupIds: F[List[String]]
+
+    /** List the available consumer groups as `ConsumerGroupListing`s. */
+    def listings: F[List[ConsumerGroupListing]]
+  }
+
+  private[this] def listConsumerGroupsWith[F[_]](
+    client: Client[F]
+  ): ListConsumerGroups[F] =
+    new ListConsumerGroups[F] {
+      override def groupIds: F[List[String]] =
+        client(_.listConsumerGroups.all.map(_.mapToList(_.groupId)))
+
+      override def listings: F[List[ConsumerGroupListing]] =
+        client(_.listConsumerGroups.all.map(_.toList))
+
+      override def toString: String =
+        "ListConsumerGroups$" + System.identityHashCode(this)
+    }
+
+  sealed abstract class ListConsumerGroupOffsets[F[_]] {
+
+    /** Lists consumer group offsets for the consumer group. */
+    def partitionsToOffsetAndMetadata: F[Map[TopicPartition, OffsetAndMetadata]]
+
+    /** Only includes consumer group offsets for specified topic-partitions. */
+    def forPartitions[G[_]](
+      partitions: G[TopicPartition]
+    )(implicit G: Foldable[G]): ListConsumerGroupOffsetsForPartitions[F]
+  }
+
+  sealed abstract class ListConsumerGroupOffsetsForPartitions[F[_]] {
+
+    /** Lists consumer group offsets on specified partitions for the consumer group. */
+    def partitionsToOffsetAndMetadata: F[Map[TopicPartition, OffsetAndMetadata]]
+  }
+
+  private[this] def listConsumerGroupOffsetsWith[F[_]](
+    client: Client[F],
+    groupId: String
+  ): ListConsumerGroupOffsets[F] =
+    new ListConsumerGroupOffsets[F] {
+      override def partitionsToOffsetAndMetadata: F[Map[TopicPartition, OffsetAndMetadata]] =
+        client { adminClient =>
+          adminClient
+            .listConsumerGroupOffsets(groupId)
+            .partitionsToOffsetAndMetadata
+            .map(_.toMap)
+        }
+
+      override def forPartitions[G[_]](
+        partitions: G[TopicPartition]
+      )(implicit G: Foldable[G]): ListConsumerGroupOffsetsForPartitions[F] =
+        listConsumerGroupOffsetsForPartitionsWith(client, groupId, partitions)
+
+      override def toString: String =
+        s"ListConsumerGroupOffsets(groupId = $groupId)"
+    }
+
+  private[this] def listConsumerGroupOffsetsForPartitionsWith[F[_], G[_]](
+    client: Client[F],
+    groupId: String,
+    partitions: G[TopicPartition]
+  )(implicit G: Foldable[G]): ListConsumerGroupOffsetsForPartitions[F] =
+    new ListConsumerGroupOffsetsForPartitions[F] {
+      private[this] def options: ListConsumerGroupOffsetsOptions =
+        new ListConsumerGroupOffsetsOptions().topicPartitions(partitions.asJava)
+
+      override def partitionsToOffsetAndMetadata: F[Map[TopicPartition, OffsetAndMetadata]] =
+        client { adminClient =>
+          adminClient
+            .listConsumerGroupOffsets(groupId, options)
+            .partitionsToOffsetAndMetadata
+            .map(_.toMap)
+        }
+
+      override def toString: String =
+        s"ListConsumerGroupOffsetsForPartitions(groupId = $groupId, partitions = $partitions)"
+    }
+
+  private[this] def createAdminClient[F[_]](
+    settings: AdminClientSettings
+  )(implicit F: Concurrent[F]): Resource[F, Client[F]] =
+    Resource
+      .make[F, AdminClient] {
+        settings.adminClientFactory
+          .create(settings)
+      } { adminClient =>
+        F.delay {
+            adminClient.close(
+              settings.closeTimeout.length,
+              settings.closeTimeout.unit
+            )
+          }
+          .start
+          .flatMap(_.join)
+      }
+      .map(new Client(_))
+
+  private[this] final class Client[F[_]](
+    adminClient: AdminClient
+  )(implicit F: Concurrent[F]) {
+    def apply[A](f: AdminClient => KafkaFuture[A]): F[A] =
+      F.suspend(f(adminClient).cancelable)
+
+    override def toString: String =
+      "Client$" + System.identityHashCode(this)
+  }
+
+  private[kafka] def adminClientResource[F[_]](
+    settings: AdminClientSettings
+  )(implicit F: Concurrent[F]): Resource[F, KafkaAdminClient[F]] =
+    createAdminClient(settings).map { client =>
+      new KafkaAdminClient[F] {
+        def describeConsumerGroups[G[_]](groupIds: G[String])(
+          implicit G: Foldable[G]
+        ): F[Map[String, ConsumerGroupDescription]] =
+          describeConsumerGroupsWith(client, groupIds)
+
+        def describeTopics[G[_]](topics: G[String])(
+          implicit G: Foldable[G]
+        ): F[Map[String, TopicDescription]] =
+          describeTopicsWith(client, topics)
+
+        override def listConsumerGroups: ListConsumerGroups[F] =
+          listConsumerGroupsWith(client)
+
+        override def listConsumerGroupOffsets(groupId: String): ListConsumerGroupOffsets[F] =
+          listConsumerGroupOffsetsWith(client, groupId)
+
+        override def listTopics: ListTopics[F] =
+          listTopicsWith(client)
+
+        override def toString: String =
+          "KafkaAdminClient$" + System.identityHashCode(this)
+      }
+    }
+}

--- a/src/main/scala/fs2/kafka/package.scala
+++ b/src/main/scala/fs2/kafka/package.scala
@@ -309,6 +309,27 @@ package object kafka {
     _.groupWithin(n, d).to(commitBatchChunkOptionF)
 
   /**
+    * Creates a new [[KafkaAdminClient]] in the `Resource` context,
+    * using the specified [[AdminClientSettings]]. If working in a
+    * `Stream` context, you might prefer [[adminClientStream]].
+    */
+  def adminClientResource[F[_]](settings: AdminClientSettings)(
+    implicit F: Concurrent[F]
+  ): Resource[F, KafkaAdminClient[F]] =
+    KafkaAdminClient.adminClientResource(settings)
+
+  /**
+    * Creates a new [[KafkaAdminClient]] in the `Stream` context,
+    * using the specified [[AdminClientSettings]]. If you're not
+    * working in a `Stream` context, you might instead prefer to
+    * use the [[adminClientResource]] function.
+    */
+  def adminClientStream[F[_]](settings: AdminClientSettings)(
+    implicit F: Concurrent[F]
+  ): Stream[F, KafkaAdminClient[F]] =
+    Stream.resource(adminClientResource(settings))
+
+  /**
     * Creates a new [[KafkaConsumer]] in the `Resource` context,
     * using the specified [[ConsumerSettings]]. Note that there
     * is another version where `F[_]` is specified explicitly and

--- a/src/test/scala/fs2/kafka/BaseKafkaSpec.scala
+++ b/src/test/scala/fs2/kafka/BaseKafkaSpec.scala
@@ -5,6 +5,7 @@ import java.util.UUID
 import cats.effect.IO
 import fs2.Stream
 import net.manub.embeddedkafka.{EmbeddedKafka, EmbeddedKafkaConfig}
+import org.apache.kafka.clients.admin.AdminClientConfig
 import org.apache.kafka.clients.consumer.{ConsumerConfig, KafkaConsumer => KConsumer}
 import org.apache.kafka.clients.producer.ProducerConfig
 import org.apache.kafka.common.serialization._
@@ -17,6 +18,12 @@ abstract class BaseKafkaSpec extends BaseAsyncSpec with EmbeddedKafka {
 
   implicit final val stringDeserializer: Deserializer[String] =
     new StringDeserializer
+
+  final def adminClientSettings(
+    config: EmbeddedKafkaConfig
+  ): AdminClientSettings =
+    AdminClientSettings.Default
+      .withProperties(adminClientProperties(config))
 
   final def consumerSettings(
     config: EmbeddedKafkaConfig
@@ -37,6 +44,9 @@ abstract class BaseKafkaSpec extends BaseAsyncSpec with EmbeddedKafka {
       keySerializer = new StringSerializer,
       valueSerializer = new StringSerializer
     ).withProperties(producerProperties(config))
+
+  final def adminClientProperties(config: EmbeddedKafkaConfig): Map[String, String] =
+    Map(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG -> s"localhost:${config.kafkaPort}")
 
   final def consumerProperties(config: EmbeddedKafkaConfig): Map[String, String] =
     Map(

--- a/src/test/scala/fs2/kafka/KafkaAdminClientSpec.scala
+++ b/src/test/scala/fs2/kafka/KafkaAdminClientSpec.scala
@@ -1,0 +1,67 @@
+package fs2.kafka
+
+import cats.effect.IO
+import cats.implicits._
+import org.apache.kafka.common.TopicPartition
+
+final class KafkaAdminClientSpec extends BaseKafkaSpec {
+  describe("KafkaAdminClient") {
+    it("should support all defined functionality") {
+      withKafka { (config, topic) =>
+        createCustomTopic(topic, partitions = 3)
+        val produced = (0 until 100).map(n => s"key-$n" -> s"value->$n")
+        publishToKafka(topic, produced)
+
+        (for {
+          consumerSettings <- consumerSettings(config)
+          consumer <- consumerStream[IO].using(consumerSettings)
+          _ <- consumer.subscribe(topic.r)
+          _ <- consumer.stream
+            .take(produced.size.toLong)
+            .map(_.committableOffset)
+            .to(commitBatch)
+        } yield ()).compile.lastOrError.unsafeRunSync
+
+        adminClientResource[IO](adminClientSettings(config)).use { adminClient =>
+          for {
+            consumerGroupIds <- adminClient.listConsumerGroups.groupIds
+            _ <- IO(assert(consumerGroupIds.size == 1))
+            consumerGroupListings <- adminClient.listConsumerGroups.listings
+            _ <- IO(assert(consumerGroupListings.size == 1))
+            describedConsumerGroups <- adminClient.describeConsumerGroups(consumerGroupIds)
+            _ <- IO(assert(describedConsumerGroups.size == 1))
+            consumerGroupOffsets <- consumerGroupIds.parTraverse { groupId =>
+              adminClient
+                .listConsumerGroupOffsets(groupId)
+                .partitionsToOffsetAndMetadata
+                .map((groupId, _))
+            }
+            _ <- IO(assert(consumerGroupOffsets.size == 1))
+            consumerGroupOffsetsPartitions <- consumerGroupIds.parTraverse { groupId =>
+              adminClient
+                .listConsumerGroupOffsets(groupId)
+                .forPartitions(List.empty[TopicPartition])
+                .partitionsToOffsetAndMetadata
+                .map((groupId, _))
+            }
+            _ <- IO(assert(consumerGroupOffsetsPartitions.size == 1))
+            topicNames <- adminClient.listTopics.names
+            _ <- IO(assert(topicNames.size == 1))
+            topicListings <- adminClient.listTopics.listings
+            _ <- IO(assert(topicListings.size == 1))
+            topicNamesToListings <- adminClient.listTopics.namesToListings
+            _ <- IO(assert(topicNamesToListings.size == 1))
+            topicNamesInternal <- adminClient.listTopics.includeInternal.names
+            _ <- IO(assert(topicNamesInternal.size == 2))
+            topicListingsInternal <- adminClient.listTopics.includeInternal.listings
+            _ <- IO(assert(topicListingsInternal.size == 2))
+            topicNamesToListingsInternal <- adminClient.listTopics.includeInternal.namesToListings
+            _ <- IO(assert(topicNamesToListingsInternal.size == 2))
+            describedTopics <- adminClient.describeTopics(topicNames.toList)
+            _ <- IO(assert(describedTopics.size == 1))
+          } yield ()
+        }.unsafeRunSync
+      }
+    }
+  }
+}


### PR DESCRIPTION
This pull request adds an initial `KafkaAdminClient` which abstracts away the Java `AdminClient`, like the existing `KafkaConsumer` and `KafkaProducer`. Initially, not all operations from the Java client are supported. The following operations are currently supported, with more to be added as necessary.

- List consumer groups, consumer group offsets, and topics.
- Describe consumer groups and topics.

Following is an example of how to list all consumer groups and fetch their committed offsets.

```scala
import cats.effect.{ExitCode, IO, IOApp}
import cats.implicits._
import fs2.kafka._

object Main extends IOApp {
  override def run(args: List[String]): IO[ExitCode] = {
    val settings = AdminClientSettings.Default
      .withBootstrapServers("localhost")

    adminClientResource[IO](settings).use { client =>
      for {
        groupIds <- client.listConsumerGroups.groupIds
        offsets <- groupIds.parTraverse { groupId =>
          client
            .listConsumerGroupOffsets(groupId)
            .partitionsToOffsetAndMetadata
            .map((groupId, _))
        }
        _ <- IO(offsets.foreach(println))
      } yield ExitCode.Success
    }
  }
}
```