### PR TITLE
Add subscribeTo and generic subscribe

### DIFF
--- a/docs/quick-example.md
+++ b/docs/quick-example.md
@@ -14,6 +14,7 @@ import cats.Id
 import cats.data.NonEmptyList
 import cats.effect.{ExitCode, IO, IOApp}
 import cats.syntax.functor._
+import fs2.Stream
 import fs2.kafka._
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.clients.producer.ProducerRecord
@@ -44,7 +45,7 @@ object Main extends IOApp {
           )
           .withBootstrapServers("localhost")
         }
-        _ <- consumer.subscribe(NonEmptyList.one("topic"))
+        _ <- Stream.eval(consumer.subscribe(NonEmptyList.one("topic")))
         _ <- consumer.stream
           .mapAsync(25)(message =>
             processRecord(message.record)

--- a/src/test/scala/fs2/kafka/KafkaAdminClientSpec.scala
+++ b/src/test/scala/fs2/kafka/KafkaAdminClientSpec.scala
@@ -2,6 +2,7 @@ package fs2.kafka
 
 import cats.effect.IO
 import cats.implicits._
+import fs2.Stream
 import org.apache.kafka.common.TopicPartition
 
 final class KafkaAdminClientSpec extends BaseKafkaSpec {
@@ -15,7 +16,7 @@ final class KafkaAdminClientSpec extends BaseKafkaSpec {
         (for {
           consumerSettings <- consumerSettings(config)
           consumer <- consumerStream[IO].using(consumerSettings)
-          _ <- consumer.subscribe(topic.r)
+          _ <- Stream.eval(consumer.subscribe(topic.r))
           _ <- consumer.stream
             .take(produced.size.toLong)
             .map(_.committableOffset)

--- a/src/test/scala/fs2/kafka/KafkaConsumerSpec.scala
+++ b/src/test/scala/fs2/kafka/KafkaConsumerSpec.scala
@@ -32,7 +32,7 @@ final class KafkaConsumerSpec extends BaseKafkaSpec {
           (for {
             consumerSettings <- consumerSettings(config)
             consumer <- consumerStream[IO].using(consumerSettings)
-            _ <- consumer.subscribe(NonEmptyList.of(topic))
+            _ <- Stream.eval(consumer.subscribe(NonEmptyList.of(topic)))
             consumed <- f(consumer).take(produced.size.toLong)
             record = consumed.record
           } yield record.key -> record.value).compile.toVector.unsafeRunSync
@@ -51,7 +51,7 @@ final class KafkaConsumerSpec extends BaseKafkaSpec {
           (for {
             consumerSettings <- consumerSettings(config)
             consumer <- consumerStream[IO].using(consumerSettings)
-            _ <- consumer.subscribe(topic.r)
+            _ <- Stream.eval(consumer.subscribe(topic.r))
             offsets <- f(consumer)
               .take(produced.size.toLong)
               .map(_.committableOffset)
@@ -77,7 +77,7 @@ final class KafkaConsumerSpec extends BaseKafkaSpec {
           (for {
             consumerSettings <- consumerSettings(config)
             consumer <- consumerStream[IO].using(consumerSettings)
-            _ <- consumer.subscribe(NonEmptyList.of(topic))
+            _ <- Stream.eval(consumer.subscribe(NonEmptyList.of(topic)))
             _ <- Stream.eval(consumer.fiber.cancel)
             _ <- f(consumer)
             _ <- Stream.eval(consumer.fiber.join)
@@ -111,7 +111,7 @@ final class KafkaConsumerSpec extends BaseKafkaSpec {
             consumerSettings <- consumerSettings(config)
               .map(_.withAutoOffsetReset(AutoOffsetReset.None))
             consumer <- consumerStream[IO].using(consumerSettings)
-            _ <- consumer.subscribe(NonEmptyList.of(topic))
+            _ <- Stream.eval(consumer.subscribe(NonEmptyList.of(topic)))
             _ <- f(consumer)
           } yield ()).compile.lastOrError.attempt.unsafeRunSync
 
@@ -136,7 +136,7 @@ final class KafkaConsumerSpec extends BaseKafkaSpec {
         (for {
           consumerSettings <- consumerSettings(config)
           consumer <- consumerStream[IO].using(consumerSettings)
-          _ <- consumer.subscribe(NonEmptyList.of(topic))
+          _ <- Stream.eval(consumer.subscribe(NonEmptyList.of(topic)))
           _ <- f(consumer)
             .take(produced.size.toLong)
             .map(_.committableOffset)


### PR DESCRIPTION
- Add `KafkaConsumer#subscribeTo` for subscribing to topics with varargs.
- Change `subscribe` to work for any `Reducible`, not only `NonEmptyList`.
- Change `subscribe`s to return `F[Unit]` instead of `Stream[F, Unit]`.