### PR TITLE
Expose `seek` function in KafkaConsumer

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -136,7 +136,8 @@ lazy val mimaSettings = Seq(
       ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.KafkaConsumer.endOffsets"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.KafkaConsumer.endOffsets"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.KafkaConsumer.beginningOffsets"),
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.KafkaConsumer.beginningOffsets")
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.KafkaConsumer.beginningOffsets"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.KafkaConsumer.seek")
     )
     // format: on
   }

--- a/src/main/scala/fs2/kafka/KafkaConsumer.scala
+++ b/src/main/scala/fs2/kafka/KafkaConsumer.scala
@@ -128,7 +128,7 @@ sealed abstract class KafkaConsumer[F[_], K, V] {
     * offset is negative, or an [[IllegalStateException]] if the provided
     * TopicPartition is not assigned to this consumer.
     */
-  def seek(topicPartition: TopicPartition, offset: Long): Stream[F, Unit]
+  def seek(partition: TopicPartition, offset: Long): F[Unit]
 
   /**
     * Subscribes the consumer to the specified topics. Note that you have to
@@ -451,8 +451,8 @@ private[kafka] object KafkaConsumer {
           .interruptWhen(fiber.join.attempt)
       }
 
-      override def seek(partition: TopicPartition, offset: Long): Stream[F, Unit] =
-        Stream.eval(requests.enqueue1(Request.Seek(partition, offset)))
+      override def seek(partition: TopicPartition, offset: Long): F[Unit] =
+        requests.enqueue1(Request.Seek(partition, offset))
 
       override def subscribe(topics: NonEmptyList[String]): Stream[F, Unit] =
         Stream.eval(requests.enqueue1(Request.SubscribeTopics(topics)))

--- a/src/main/scala/fs2/kafka/KafkaConsumer.scala
+++ b/src/main/scala/fs2/kafka/KafkaConsumer.scala
@@ -124,8 +124,8 @@ sealed abstract class KafkaConsumer[F[_], K, V] {
     * arbitrarily used in the middle of consumption to reset the fetch offsets.
     *
     * The stream obtained from [[stream]] or [[partitionedStream]] will raise
-    * an [[IllegalArgumentException]] if the provided offset is negative, or an
-    * [[IllegalStateException]] if the provided TopicPartition is not assigned
+    * an `IllegalArgumentException` if the provided offset is negative, or an
+    * `IllegalStateException` if the provided TopicPartition is not assigned
     * to this consumer.
     */
   def seek(partition: TopicPartition, offset: Long): F[Unit]

--- a/src/main/scala/fs2/kafka/KafkaConsumer.scala
+++ b/src/main/scala/fs2/kafka/KafkaConsumer.scala
@@ -118,15 +118,15 @@ sealed abstract class KafkaConsumer[F[_], K, V] {
   def partitionedStream: Stream[F, Stream[F, CommittableMessage[F, K, V]]]
 
   /**
-    * Overrides the fetch offsets that the consumer will use on the next poll.
-    * If this API is invoked for the same partition more than once, the latest
-    * offset will be used on the next poll(). Note that you may lose data if
-    * this API is arbitrarily used in the middle of consumption, to reset the
-    * fetch offsets.
+    * Overrides the fetch offsets that the consumer will use when reading the
+    * next message. If this API is invoked for the same partition more than once,
+    * the latest offset will be used. Note that you may lose data if this API is
+    * arbitrarily used in the middle of consumption to reset the fetch offsets.
     *
-    * The stream will raise an [[IllegalArgumentException]] if the provided
-    * offset is negative, or an [[IllegalStateException]] if the provided
-    * TopicPartition is not assigned to this consumer.
+    * The stream obtained from [[stream]] or [[partitionedStream]] will raise
+    * an [[IllegalArgumentException]] if the provided offset is negative, or an
+    * [[IllegalStateException]] if the provided TopicPartition is not assigned
+    * to this consumer.
     */
   def seek(partition: TopicPartition, offset: Long): F[Unit]
 

--- a/src/test/scala/fs2/kafka/KafkaConsumerSpec.scala
+++ b/src/test/scala/fs2/kafka/KafkaConsumerSpec.scala
@@ -4,8 +4,10 @@ import cats.data.NonEmptyList
 import cats.effect.IO
 import cats.implicits._
 import fs2.Stream
+import net.manub.embeddedkafka.EmbeddedKafkaConfig
 import org.apache.kafka.clients.consumer.NoOffsetForPartitionException
 import org.apache.kafka.common.TopicPartition
+
 import scala.concurrent.duration._
 
 final class KafkaConsumerSpec extends BaseKafkaSpec {
@@ -42,37 +44,20 @@ final class KafkaConsumerSpec extends BaseKafkaSpec {
     }
 
     it("should read from the given offset") {
-      withKafka { (config, topic) =>
-        createCustomTopic(topic)
+      withKafka {
+        seekTest(numMessages = 100, readOffset = 90)
+      }
+    }
 
-        val numMessages = 100l
-        val readOffset = 90
+    it("should fail to read from a negative offset") {
+      withKafka {
+        an[IllegalArgumentException] should be thrownBy seekTest(numMessages = 100, readOffset = -1)(_, _)
+      }
+    }
 
-        val produced = (0l until numMessages).map(n => s"key-$n" -> s"value->$n")
-        publishToKafka(topic, produced)
-
-        val consumed =
-          consumerSettings(config).flatMap { consumerSettings =>
-            consumerStream[IO].using(consumerSettings).flatMap { consumer =>
-
-              val input = f(consumer)
-
-              val setOffset = for {
-                consumed <- (consumer.subscribe(NonEmptyList.one(topic)).drain ++ input.take(produced.size.toLong)).compile.toList
-                co        = consumed(readOffset-1).committableOffset
-                _        <- consumer.seek(co.topicPartition, co.offsetAndMetadata.offset())
-              } yield ()
-
-              val consume = input.take(numMessages-readOffset)
-
-              (Stream.eval_(setOffset) ++ consume)
-                .map(_.record)
-                .map(record => record.key -> record.value())
-
-            }
-          }.compile.toVector.unsafeRunSync()
-
-        consumed should contain theSameElementsAs produced.drop(readOffset)
+    it("should fail to read from a partition not assigned to this consumer") {
+      withKafka {
+        an[IllegalStateException] should be thrownBy seekTest(numMessages = 100, readOffset = 90, partition = Some(123))(_, _)
       }
     }
 
@@ -190,5 +175,49 @@ final class KafkaConsumerSpec extends BaseKafkaSpec {
         } yield ()).compile.drain.unsafeRunSync
       }
     }
+
+    def seekTest(numMessages: Long, readOffset: Long, partition: Option[Int] = None)(config: EmbeddedKafkaConfig, topic: String) = {
+      createCustomTopic(topic)
+
+      val produced = (0l until numMessages).map(n => s"key-$n" -> s"value->$n")
+      publishToKafka(topic, produced)
+
+      val consumed =
+          consumerSettings(config).flatMap { consumerSettings =>
+            consumerStream[IO].using(consumerSettings).flatMap { consumer =>
+
+              val validSeekParams =
+                f(consumer)
+                  .take(Math.max(readOffset, 1))
+                  .map(_.committableOffset).compile.toList.map(_.last)
+                  .map(co => (co.topicPartition, co.offsetAndMetadata.offset()))
+
+              val seekParams =
+                validSeekParams.map { case (topicPartition, offset) =>
+                  val p = partition.map(new TopicPartition(topic, _)).getOrElse(topicPartition)
+                  val o = Math.min(readOffset, offset)
+
+                  (p, o)
+                }
+
+              val setOffset =
+                seekParams.flatMap { case (tp, o) => consumer.seek(tp, o) }
+
+              val consume = f(consumer).take(numMessages-readOffset)
+
+              consumer.subscribe(NonEmptyList.one(topic)).drain ++
+              (Stream.eval_(setOffset) ++ consume)
+                .map(_.record)
+                .map(record => record.key -> record.value())
+
+            }
+          }.compile.toVector.unsafeRunSync()
+
+        consumed should contain theSameElementsAs produced.drop(readOffset.toInt)
+      }
+
   }
+
+
+
 }

--- a/src/test/scala/fs2/kafka/KafkaConsumerSpec.scala
+++ b/src/test/scala/fs2/kafka/KafkaConsumerSpec.scala
@@ -60,7 +60,7 @@ final class KafkaConsumerSpec extends BaseKafkaSpec {
               val setOffset = for {
                 consumed <- (consumer.subscribe(NonEmptyList.one(topic)).drain ++ input.take(produced.size.toLong)).compile.toList
                 co        = consumed(readOffset-1).committableOffset
-                _        <- consumer.seek(co.topicPartition, co.offsetAndMetadata.offset()).compile.drain
+                _        <- consumer.seek(co.topicPartition, co.offsetAndMetadata.offset())
               } yield ()
 
               val consume = input.take(numMessages-readOffset)


### PR DESCRIPTION
Hi, 

for our application we need to be able to set the offset from which to start reading. I found that the `seek` function exists in the Java client but is not exposed in this library. 