### PR TITLE
Change to create new NotSubscribedException

### DIFF
--- a/src/main/scala/fs2/kafka/CommitTimeoutException.scala
+++ b/src/main/scala/fs2/kafka/CommitTimeoutException.scala
@@ -47,8 +47,8 @@ sealed abstract class CommitTimeoutException(
       )
     })
 
-object CommitTimeoutException {
-  private[kafka] def apply(
+private[kafka] object CommitTimeoutException {
+  def apply(
     timeout: FiniteDuration,
     offsets: Map[TopicPartition, OffsetAndMetadata]
   ): CommitTimeoutException =

--- a/src/main/scala/fs2/kafka/NotSubscribedException.scala
+++ b/src/main/scala/fs2/kafka/NotSubscribedException.scala
@@ -26,7 +26,10 @@ import org.apache.kafka.common.KafkaException
 sealed abstract class NotSubscribedException
     extends KafkaException("consumer is not subscribed to any topics")
 
-case object NotSubscribedException extends NotSubscribedException {
-  override def toString: String =
-    s"fs2.kafka.NotSubscribedException: $getMessage"
+private[kafka] object NotSubscribedException {
+  def apply(): NotSubscribedException =
+    new NotSubscribedException {
+      override def toString: String =
+        s"fs2.kafka.NotSubscribedException: $getMessage"
+    }
 }

--- a/src/main/scala/fs2/kafka/internal/KafkaConsumerActor.scala
+++ b/src/main/scala/fs2/kafka/internal/KafkaConsumerActor.scala
@@ -247,7 +247,7 @@ private[kafka] final class KafkaConsumerActor[F[_], K, V](
       val assigned: F[Either[Throwable, SortedSet[TopicPartition]]] =
         if (state.subscribed) withConsumer { consumer =>
           F.delay(Right(consumer.assignment.toSortedSet))
-        } else F.pure(Left(NotSubscribedException))
+        } else F.pure(Left(NotSubscribedException()))
 
       val withOnRebalance =
         onRebalance.fold(F.unit)(on => ref.update(_.withOnRebalance(on)))

--- a/src/test/scala/fs2/kafka/KafkaConsumerSpec.scala
+++ b/src/test/scala/fs2/kafka/KafkaConsumerSpec.scala
@@ -105,7 +105,7 @@ final class KafkaConsumerSpec extends BaseKafkaSpec {
             .attempt
             .unsafeRunSync
 
-        assert(consumed.left.toOption.contains(NotSubscribedException))
+        assert(consumed.left.toOption.map(_.toString).contains(NotSubscribedException().toString))
       }
     }
 


### PR DESCRIPTION
Since exceptions are mutable, we should not use a `case object` for `NotSubscribedException`.