### PR TITLE
Change to attempt KafkaConsumer requests

### DIFF
--- a/src/main/scala/fs2/kafka/ConsumerShutdownException.scala
+++ b/src/main/scala/fs2/kafka/ConsumerShutdownException.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018 OVO Energy Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fs2.kafka
+
+import org.apache.kafka.common.KafkaException
+
+/**
+  * [[ConsumerShutdownException]] indicates that a request could
+  * not be completed because the consumer has already shutdown.
+  */
+sealed abstract class ConsumerShutdownException
+    extends KafkaException("consumer has already shutdown")
+
+private[kafka] object ConsumerShutdownException {
+  def apply(): ConsumerShutdownException =
+    new ConsumerShutdownException {
+      override def toString: String =
+        s"fs2.kafka.ConsumerShutdownException: $getMessage"
+    }
+}

--- a/src/main/scala/fs2/kafka/KafkaConsumer.scala
+++ b/src/main/scala/fs2/kafka/KafkaConsumer.scala
@@ -306,7 +306,7 @@ private[kafka] object KafkaConsumer {
         actorFiber combine pollsFiber
       }
 
-      override val partitionedStream: Stream[F, Stream[F, CommittableMessage[F, K, V]]] = {
+      override def partitionedStream: Stream[F, Stream[F, CommittableMessage[F, K, V]]] = {
         val chunkQueue: F[Queue[F, Option[Chunk[CommittableMessage[F, K, V]]]]] =
           Queue.bounded[F, Option[Chunk[CommittableMessage[F, K, V]]]](1)
 
@@ -405,7 +405,7 @@ private[kafka] object KafkaConsumer {
         }
       }
 
-      override val stream: Stream[F, CommittableMessage[F, K, V]] = {
+      override def stream: Stream[F, CommittableMessage[F, K, V]] = {
         val requestAssignment: F[SortedSet[TopicPartition]] =
           Deferred[F, Either[Throwable, SortedSet[TopicPartition]]].flatMap { deferred =>
             val request = Request.Assignment[F, K, V](deferred, onRebalance = None)


### PR DESCRIPTION
- All `KafkaConsumer` requests now check to ensure the consumer has not already shutdown.
- All `KafkaConsumer` requests are now attempted, and errors returned in the returned effect.
- `KafkaConsumer#stream` and `partitionedStream` are now `def`s rather than `val`s.