### PR TITLE
Add more tests for missing coverage

### DIFF
--- a/src/main/scala/fs2/kafka/KafkaAdminClient.scala
+++ b/src/main/scala/fs2/kafka/KafkaAdminClient.scala
@@ -300,9 +300,6 @@ object KafkaAdminClient {
   )(implicit F: Concurrent[F]) {
     def apply[A](f: AdminClient => KafkaFuture[A]): F[A] =
       F.suspend(f(adminClient).cancelable)
-
-    override def toString: String =
-      "Client$" + System.identityHashCode(this)
   }
 
   private[kafka] def adminClientResource[F[_]](

--- a/src/main/scala/fs2/kafka/internal/instances.scala
+++ b/src/main/scala/fs2/kafka/internal/instances.scala
@@ -79,7 +79,8 @@ private[kafka] object instances {
     val key = if (r.key != null) r.key.show else "null"
     val value = if (r.value != null) r.value.show else "null"
     val timestamp = if (r.timestamp != null) (r.timestamp: Long).show else "null"
-    show"ProducerRecord(topic = ${r.topic}, partition = ${(r.partition: Int).show}, headers = $headers, key = $key, value = $value, timestamp = $timestamp)"
+    val partition = if (r.partition != null) (r.partition: Int).show else "null"
+    show"ProducerRecord(topic = ${r.topic}, partition = $partition, headers = $headers, key = $key, value = $value, timestamp = $timestamp)"
   }
 
   implicit val recordMetadataShow: Show[RecordMetadata] =

--- a/src/test/scala/fs2/kafka/AdminClientSettingsSpec.scala
+++ b/src/test/scala/fs2/kafka/AdminClientSettingsSpec.scala
@@ -1,0 +1,139 @@
+package fs2.kafka
+
+import cats.implicits._
+import org.apache.kafka.clients.admin.AdminClientConfig
+
+import scala.concurrent.duration._
+
+final class AdminClientSettingsSpec extends BaseSpec {
+  describe("AdminClientSettings") {
+    it("should provide withBootstrapServers") {
+      assert {
+        settings
+          .withBootstrapServers("localhost")
+          .properties(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG)
+          .contains("localhost")
+      }
+    }
+
+    it("should provide withClientId") {
+      assert {
+        settings
+          .withClientId("client")
+          .properties(AdminClientConfig.CLIENT_ID_CONFIG)
+          .contains("client")
+      }
+    }
+
+    it("should provide withReconnectBackoff") {
+      assert {
+        settings
+          .withReconnectBackoff(10.seconds)
+          .properties(AdminClientConfig.RECONNECT_BACKOFF_MS_CONFIG)
+          .contains("10000")
+      }
+    }
+
+    it("should provide withReconnectBackoffMax") {
+      assert {
+        settings
+          .withReconnectBackoffMax(10.seconds)
+          .properties(AdminClientConfig.RECONNECT_BACKOFF_MAX_MS_CONFIG)
+          .contains("10000")
+      }
+    }
+
+    it("should provide withRetryBackoff") {
+      assert {
+        settings
+          .withRetryBackoff(10.seconds)
+          .properties(AdminClientConfig.RETRY_BACKOFF_MS_CONFIG)
+          .contains("10000")
+      }
+    }
+
+    it("should provide withConnectionsMaxIdle") {
+      assert {
+        settings
+          .withConnectionsMaxIdle(10.seconds)
+          .properties(AdminClientConfig.CONNECTIONS_MAX_IDLE_MS_CONFIG)
+          .contains("10000")
+      }
+    }
+
+    it("should provide withRequestTimeout") {
+      assert {
+        settings
+          .withRequestTimeout(10.seconds)
+          .properties(AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG)
+          .contains("10000")
+      }
+    }
+
+    it("should provide withMetadataMaxAge") {
+      assert {
+        settings
+          .withMetadataMaxAge(10.seconds)
+          .properties(AdminClientConfig.METADATA_MAX_AGE_CONFIG)
+          .contains("10000")
+      }
+    }
+
+    it("should provide withRetries") {
+      assert {
+        settings
+          .withRetries(10)
+          .properties(AdminClientConfig.RETRIES_CONFIG)
+          .contains("10")
+      }
+    }
+
+    it("should provide withProperty") {
+      assert {
+        settings
+          .withProperty("a", "b")
+          .properties("a")
+          .contains("b")
+      }
+    }
+
+    it("should provide withProperties") {
+      assert {
+        settings
+          .withProperties("a" -> "b")
+          .properties("a")
+          .contains("b") &&
+        settings
+          .withProperties(Map("a" -> "b"))
+          .properties("a")
+          .contains("b")
+      }
+    }
+
+    it("should provide withCloseTimeout") {
+      assert {
+        settings
+          .withCloseTimeout(10.seconds)
+          .closeTimeout == 10.seconds
+      }
+    }
+
+    it("should provide withAdminClientFactory") {
+      assert {
+        settings
+          .withAdminClientFactory(AdminClientFactory.Default)
+          .adminClientFactory == AdminClientFactory.Default
+      }
+    }
+
+    it("should have a Show instance and matching toString") {
+      assert {
+        settings.toString == "AdminClientSettings(closeTimeout = 20 seconds, adminClientFactory = Default)" &&
+        settings.show == settings.toString
+      }
+    }
+  }
+
+  val settings =
+    AdminClientSettings.Default
+}

--- a/src/test/scala/fs2/kafka/BaseKafkaSpec.scala
+++ b/src/test/scala/fs2/kafka/BaseKafkaSpec.scala
@@ -2,6 +2,8 @@ package fs2.kafka
 
 import java.util.UUID
 
+import cats.effect.IO
+import fs2.Stream
 import net.manub.embeddedkafka.{EmbeddedKafka, EmbeddedKafkaConfig}
 import org.apache.kafka.clients.admin.AdminClientConfig
 import org.apache.kafka.clients.consumer.{ConsumerConfig, KafkaConsumer => KConsumer}
@@ -31,6 +33,18 @@ abstract class BaseKafkaSpec extends BaseAsyncSpec with EmbeddedKafka {
       valueDeserializer = new StringDeserializer
     ).withProperties(consumerProperties(config))
       .withRecordMetadata(_.timestamp.toString)
+
+  final def consumerSettingsExecutionContext(
+    config: EmbeddedKafkaConfig
+  ): Stream[IO, ConsumerSettings[String, String]] =
+    consumerExecutionContextStream[IO].map { executionContext =>
+      ConsumerSettings(
+        keyDeserializer = new StringDeserializer,
+        valueDeserializer = new StringDeserializer,
+        executionContext = executionContext
+      ).withProperties(consumerProperties(config))
+        .withRecordMetadata(_.timestamp.toString)
+    }
 
   final def producerSettings(
     config: EmbeddedKafkaConfig

--- a/src/test/scala/fs2/kafka/CommitTimeoutExceptionSpec.scala
+++ b/src/test/scala/fs2/kafka/CommitTimeoutExceptionSpec.scala
@@ -1,0 +1,26 @@
+package fs2.kafka
+
+import org.apache.kafka.clients.consumer.OffsetAndMetadata
+import org.apache.kafka.common.TopicPartition
+
+import scala.concurrent.duration._
+
+final class CommitTimeoutExceptionSpec extends BaseSpec {
+  describe("CommitTimeoutException") {
+    it("should have expected message and toString") {
+      val exception =
+        CommitTimeoutException(
+          10.seconds,
+          Map(
+            new TopicPartition("topic", 0) -> new OffsetAndMetadata(0L),
+            new TopicPartition("topic", 1) -> new OffsetAndMetadata(1L)
+          )
+        )
+
+      assert {
+        exception.getMessage == "offset commit timeout after 10 seconds for offsets: topic-0 -> 0, topic-1 -> 1" &&
+        exception.toString == "fs2.kafka.CommitTimeoutException: offset commit timeout after 10 seconds for offsets: topic-0 -> 0, topic-1 -> 1"
+      }
+    }
+  }
+}

--- a/src/test/scala/fs2/kafka/CommittableMessageSpec.scala
+++ b/src/test/scala/fs2/kafka/CommittableMessageSpec.scala
@@ -1,0 +1,27 @@
+package fs2.kafka
+
+import cats.Id
+import cats.implicits._
+import org.apache.kafka.clients.consumer.{ConsumerRecord, OffsetAndMetadata}
+import org.apache.kafka.common.TopicPartition
+
+final class CommittableMessageSpec extends BaseSpec {
+  describe("CommittableMessage") {
+    it("should have a Show instance and matching toString") {
+      val message =
+        CommittableMessage(
+          new ConsumerRecord("topic", 0, 0L, "key", "value"),
+          CommittableOffset[Id](
+            topicPartition = new TopicPartition("topic", 0),
+            offsetAndMetadata = new OffsetAndMetadata(0L),
+            commit = _ => ()
+          )
+        )
+
+      assert {
+        message.toString == "CommittableMessage(ConsumerRecord(topic = topic, partition = 0, offset = 0, NoTimestampType = -1, serialized key size = -1, serialized value size = -1, headers = RecordHeaders(headers = [], isReadOnly = false), key = key, value = value), CommittableOffset(topic-0 -> 0))" &&
+        message.show == "CommittableMessage(ConsumerRecord(topic = topic, partition = 0, offset = 0, NoTimestampType = -1, serialized key size = -1, serialized value size = -1, headers = Headers(<empty>), key = key, value = value), CommittableOffset(topic-0 -> 0))"
+      }
+    }
+  }
+}

--- a/src/test/scala/fs2/kafka/CommittableOffsetSpec.scala
+++ b/src/test/scala/fs2/kafka/CommittableOffsetSpec.scala
@@ -1,0 +1,45 @@
+package fs2.kafka
+
+import cats.Id
+import cats.implicits._
+import org.apache.kafka.clients.consumer.OffsetAndMetadata
+import org.apache.kafka.common.TopicPartition
+
+final class CommittableOffsetSpec extends BaseSpec {
+  describe("CommittableOffset") {
+    it("should be able to commit the offset") {
+      val partition = new TopicPartition("topic", 0)
+      val offsetAndMetadata = new OffsetAndMetadata(0L, "metadata")
+      var committed: Map[TopicPartition, OffsetAndMetadata] = null
+
+      CommittableOffset[Id](
+        partition,
+        offsetAndMetadata,
+        committed = _
+      ).commit
+
+      assert(committed == Map(partition -> offsetAndMetadata))
+    }
+
+    it("should have a Show instance and matching toString") {
+      val partition = new TopicPartition("topic", 0)
+
+      assert {
+        val offsetAndMetadata = new OffsetAndMetadata(0L, "metadata")
+        val offset = CommittableOffset[Id](partition, offsetAndMetadata, _ => ())
+
+        offset.toString == "CommittableOffset(topic-0 -> (0, metadata))" &&
+        offset.show == offset.toString
+      }
+
+      assert {
+        val offsetAndMetadata = new OffsetAndMetadata(0L)
+        val offset = CommittableOffset[Id](partition, offsetAndMetadata, _ => ())
+
+        offset.toString == "CommittableOffset(topic-0 -> 0)" &&
+        offset.show == offset.toString
+      }
+    }
+  }
+
+}

--- a/src/test/scala/fs2/kafka/ConsumerSettingsSpec.scala
+++ b/src/test/scala/fs2/kafka/ConsumerSettingsSpec.scala
@@ -1,0 +1,239 @@
+package fs2.kafka
+
+import cats.implicits._
+import org.apache.kafka.clients.consumer.{ConsumerConfig, ConsumerRecord}
+import org.apache.kafka.common.serialization.StringDeserializer
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+
+final class ConsumerSettingsSpec extends BaseSpec {
+  describe("ConsumerSettings") {
+    it("should be able to override execution context") {
+      assert {
+        settings.executionContext.isEmpty &&
+        settingsWithContext.executionContext.nonEmpty
+      }
+    }
+
+    it("should provide withBootstrapServers") {
+      assert {
+        settings
+          .withBootstrapServers("localhost")
+          .properties(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG)
+          .contains("localhost")
+      }
+    }
+
+    it("should provide withAutoOffsetReset") {
+      assert {
+        settings
+          .withAutoOffsetReset(AutoOffsetReset.Earliest)
+          .properties(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG)
+          .contains("earliest") &&
+        settings
+          .withAutoOffsetReset(AutoOffsetReset.Latest)
+          .properties(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG)
+          .contains("latest") &&
+        settings
+          .withAutoOffsetReset(AutoOffsetReset.None)
+          .properties(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG)
+          .contains("none")
+      }
+    }
+
+    it("should provide withClientId") {
+      assert {
+        settings
+          .withClientId("client")
+          .properties(ConsumerConfig.CLIENT_ID_CONFIG)
+          .contains("client")
+      }
+    }
+
+    it("should provide withGroupId") {
+      assert {
+        settings
+          .withGroupId("group")
+          .properties(ConsumerConfig.GROUP_ID_CONFIG)
+          .contains("group")
+      }
+    }
+
+    it("should provide withMaxPollRecords") {
+      assert {
+        settings
+          .withMaxPollRecords(10)
+          .properties(ConsumerConfig.MAX_POLL_RECORDS_CONFIG)
+          .contains("10")
+      }
+    }
+
+    it("should provide withMaxPollInterval") {
+      assert {
+        settings
+          .withMaxPollInterval(10.seconds)
+          .properties(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG)
+          .contains("10000")
+      }
+    }
+
+    it("should provide withSessionTimeout") {
+      assert {
+        settings
+          .withSessionTimeout(10.seconds)
+          .properties(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG)
+          .contains("10000")
+      }
+    }
+
+    it("should provide withHeartbeatInterval") {
+      assert {
+        settings
+          .withHeartbeatInterval(10.seconds)
+          .properties(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG)
+          .contains("10000")
+      }
+    }
+
+    it("should provide withEnableAutoCommit") {
+      assert {
+        settings
+          .withEnableAutoCommit(true)
+          .properties(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG)
+          .contains("true") &&
+        settings
+          .withEnableAutoCommit(false)
+          .properties(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG)
+          .contains("false")
+      }
+    }
+
+    it("should provide withAutoCommitInterval") {
+      assert {
+        settings
+          .withAutoCommitInterval(10.seconds)
+          .properties(ConsumerConfig.AUTO_COMMIT_INTERVAL_MS_CONFIG)
+          .contains("10000")
+      }
+    }
+
+    it("should provide withRequestTimeout") {
+      assert {
+        settings
+          .withRequestTimeout(10.seconds)
+          .properties(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG)
+          .contains("10000")
+      }
+    }
+
+    it("should provide withDefaultApiTimeout") {
+      assert {
+        settings
+          .withDefaultApiTimeout(10.seconds)
+          .properties(ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG)
+          .contains("10000")
+      }
+    }
+
+    it("should provide withProperty") {
+      assert {
+        settings.withProperty("a", "b").properties("a").contains("b")
+      }
+    }
+
+    it("should provide withProperties") {
+      assert {
+        settings.withProperties("a" -> "b").properties("a").contains("b") &&
+        settings.withProperties(Map("a" -> "b")).properties("a").contains("b")
+      }
+    }
+
+    it("should provide withCloseTimeout") {
+      assert {
+        settings
+          .withCloseTimeout(50.millis)
+          .closeTimeout == 50.millis
+      }
+    }
+
+    it("should provide withCommitTimeout") {
+      assert {
+        settings
+          .withCommitTimeout(50.millis)
+          .commitTimeout == 50.millis
+      }
+    }
+
+    it("should provide withFetchTimeout") {
+      assert {
+        settings
+          .withFetchTimeout(50.millis)
+          .fetchTimeout == 50.millis
+      }
+    }
+
+    it("should provide withPollInterval") {
+      assert {
+        settings
+          .withPollInterval(50.millis)
+          .pollInterval == 50.millis
+      }
+    }
+
+    it("should provide withPollTimeout") {
+      assert {
+        settings
+          .withPollTimeout(50.millis)
+          .pollTimeout == 50.millis
+      }
+    }
+
+    it("should provide withCommitRecovery") {
+      assert {
+        settings
+          .withCommitRecovery(CommitRecovery.Default)
+          .commitRecovery == CommitRecovery.Default
+      }
+    }
+
+    it("should provide withConsumerFactory") {
+      assert {
+        settings
+          .withConsumerFactory(ConsumerFactory.Default)
+          .consumerFactory == ConsumerFactory.Default
+      }
+    }
+
+    it("should provide withRecordMetadata") {
+      val record = new ConsumerRecord("topic", 0, 0L, "key", "value")
+
+      assert {
+        settings.recordMetadata(record) == "" &&
+        settings
+          .withRecordMetadata(_ => "ok")
+          .recordMetadata(record) == "ok"
+      }
+    }
+
+    it("should have a Show instance and matching toString") {
+      assert {
+        settings.show == "ConsumerSettings(closeTimeout = 20 seconds, commitTimeout = 15 seconds, fetchTimeout = 500 milliseconds, pollInterval = 50 milliseconds, pollTimeout = 50 milliseconds, commitRecovery = Default, consumerFactory = Default)" &&
+        settings.show == settings.toString
+      }
+    }
+  }
+
+  val settings =
+    ConsumerSettings(
+      keyDeserializer = new StringDeserializer,
+      valueDeserializer = new StringDeserializer
+    )
+
+  val settingsWithContext =
+    ConsumerSettings(
+      keyDeserializer = new StringDeserializer,
+      valueDeserializer = new StringDeserializer,
+      executionContext = ExecutionContext.global
+    )
+}

--- a/src/test/scala/fs2/kafka/ConsumerShutdownExceptionSpec.scala
+++ b/src/test/scala/fs2/kafka/ConsumerShutdownExceptionSpec.scala
@@ -1,0 +1,13 @@
+package fs2.kafka
+
+final class ConsumerShutdownExceptionSpec extends BaseSpec {
+  describe("ConsumerShutdownException") {
+    it("should have expected message and toString") {
+      val exception = ConsumerShutdownException()
+      assert(
+        exception.getMessage == "consumer has already shutdown" &&
+          exception.toString == "fs2.kafka.ConsumerShutdownException: consumer has already shutdown"
+      )
+    }
+  }
+}

--- a/src/test/scala/fs2/kafka/KafkaAdminClientSpec.scala
+++ b/src/test/scala/fs2/kafka/KafkaAdminClientSpec.scala
@@ -60,6 +60,31 @@ final class KafkaAdminClientSpec extends BaseKafkaSpec {
             _ <- IO(assert(topicNamesToListingsInternal.size == 2))
             describedTopics <- adminClient.describeTopics(topicNames.toList)
             _ <- IO(assert(describedTopics.size == 1))
+            _ <- IO {
+              adminClient.toString should startWith("KafkaAdminClient$")
+            }
+            _ <- IO {
+              adminClient.listTopics.toString should startWith("ListTopics$")
+            }
+            _ <- IO {
+              adminClient.listTopics.includeInternal.toString should
+                startWith("ListTopicsIncludeInternal$")
+            }
+            _ <- IO {
+              adminClient.listConsumerGroups.toString should
+                startWith("ListConsumerGroups$")
+            }
+            _ <- IO {
+              adminClient
+                .listConsumerGroupOffsets("group")
+                .toString shouldBe "ListConsumerGroupOffsets(groupId = group)"
+            }
+            _ <- IO {
+              adminClient
+                .listConsumerGroupOffsets("group")
+                .forPartitions(List(new TopicPartition("topic", 0)))
+                .toString shouldBe "ListConsumerGroupOffsetsForPartitions(groupId = group, partitions = List(topic-0))"
+            }
           } yield ()
         }.unsafeRunSync
       }

--- a/src/test/scala/fs2/kafka/KafkaProducerSpec.scala
+++ b/src/test/scala/fs2/kafka/KafkaProducerSpec.scala
@@ -14,6 +14,7 @@ final class KafkaProducerSpec extends BaseKafkaSpec {
       val produced =
         (for {
           producer <- producerStream[IO].using(producerSettings(config))
+          _ <- Stream.eval(IO(producer.toString should startWith("KafkaProducer$")))
           message <- Stream.chunk(Chunk.seq(toProduce).map {
             case passthrough @ (key, value) =>
               ProducerMessage.single(new ProducerRecord(topic, key, value), passthrough)

--- a/src/test/scala/fs2/kafka/PackageSpec.scala
+++ b/src/test/scala/fs2/kafka/PackageSpec.scala
@@ -1,0 +1,62 @@
+package fs2.kafka
+import cats.effect.IO
+import org.apache.kafka.common.serialization.{StringDeserializer, StringSerializer}
+
+final class PackageSpec extends BaseKafkaSpec {
+  describe("creating admin clients") {
+    it("should support defined syntax") {
+      val settings =
+        AdminClientSettings.Default
+
+      adminClientResource[IO](settings)
+      adminClientStream[IO](settings)
+    }
+  }
+
+  describe("creating consumers") {
+    it("should support defined syntax") {
+      val settings =
+        ConsumerSettings(
+          keyDeserializer = new StringDeserializer,
+          valueDeserializer = new StringDeserializer
+        )
+
+      consumerResource[IO, String, String](settings)
+      consumerResource[IO].toString should startWith("ConsumerResource$")
+      consumerResource[IO].using(settings)
+
+      consumerStream[IO, String, String](settings)
+      consumerStream[IO].toString should startWith("ConsumerStream$")
+      consumerStream[IO].using(settings)
+    }
+  }
+
+  describe("creating producers") {
+    it("should support defined syntax") {
+      val settings =
+        ProducerSettings(
+          keySerializer = new StringSerializer,
+          valueSerializer = new StringSerializer
+        )
+
+      producerResource[IO, String, String](settings)
+      producerResource[IO].toString should startWith("ProducerResource$")
+      producerResource[IO].using(settings)
+
+      producerStream[IO, String, String](settings)
+      producerStream[IO].toString should startWith("ProducerStream$")
+      producerStream[IO].using(settings)
+    }
+  }
+
+  describe("creating consumer execution contexts") {
+    it("should support defined syntax") {
+
+      consumerExecutionContextResource[IO]
+      consumerExecutionContextResource[IO](1)
+
+      consumerExecutionContextStream[IO]
+      consumerExecutionContextStream[IO](1)
+    }
+  }
+}

--- a/src/test/scala/fs2/kafka/ProducerMessageSpec.scala
+++ b/src/test/scala/fs2/kafka/ProducerMessageSpec.scala
@@ -1,0 +1,125 @@
+package fs2.kafka
+
+import cats.Id
+import cats.implicits._
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.common.header.Header
+import scala.collection.JavaConverters._
+
+final class ProducerMessageSpec extends BaseSpec {
+  describe("ProducerMessage") {
+    it("should be able to create with one record") {
+      def header(_key: String, _value: String): Header =
+        new Header {
+          override def key(): String = _key
+          override def value(): Array[Byte] = _value.getBytes
+        }
+
+      val record = new ProducerRecord("topic", "key", "value")
+
+      val headers1 = List(header("key1", "value1"))
+      val recordHeader1 = new ProducerRecord("topic", 0, 0L, "key", "value", headers1.asJava)
+
+      val headers2 = List(header("key1", "value1"), header("key2", "value2"))
+      val recordHeader2 = new ProducerRecord("topic", 0, 0L, "key", "value", headers2.asJava)
+
+      assert {
+        ProducerMessage
+          .single[Id, String, String, Int](record, 123)
+          .toString == "ProducerMessage(ProducerRecord(topic=topic, partition=null, headers=RecordHeaders(headers = [], isReadOnly = false), key=key, value=value, timestamp=null), 123)" &&
+        ProducerMessage
+          .single[Id, String, String, Int](record, 123)
+          .show == "ProducerMessage(ProducerRecord(topic = topic, partition = null, headers = Headers(<empty>), key = key, value = value, timestamp = null), 123)" &&
+        ProducerMessage
+          .single[Id, String, String](record)
+          .toString == "ProducerMessage(ProducerRecord(topic=topic, partition=null, headers=RecordHeaders(headers = [], isReadOnly = false), key=key, value=value, timestamp=null), ())" &&
+        ProducerMessage
+          .single[Id, String, String](record)
+          .show == "ProducerMessage(ProducerRecord(topic = topic, partition = null, headers = Headers(<empty>), key = key, value = value, timestamp = null), ())" &&
+        ProducerMessage
+          .single[Id]
+          .of(record, 123)
+          .toString == "ProducerMessage(ProducerRecord(topic=topic, partition=null, headers=RecordHeaders(headers = [], isReadOnly = false), key=key, value=value, timestamp=null), 123)" &&
+        ProducerMessage
+          .single[Id]
+          .of(record, 123)
+          .show == "ProducerMessage(ProducerRecord(topic = topic, partition = null, headers = Headers(<empty>), key = key, value = value, timestamp = null), 123)" &&
+        ProducerMessage
+          .single[Id]
+          .of(record)
+          .toString == "ProducerMessage(ProducerRecord(topic=topic, partition=null, headers=RecordHeaders(headers = [], isReadOnly = false), key=key, value=value, timestamp=null), ())" &&
+        ProducerMessage
+          .single[Id]
+          .of(record)
+          .show == "ProducerMessage(ProducerRecord(topic = topic, partition = null, headers = Headers(<empty>), key = key, value = value, timestamp = null), ())" &&
+        ProducerMessage
+          .single[Id]
+          .of(recordHeader1)
+          .show == "ProducerMessage(ProducerRecord(topic = topic, partition = 0, headers = Headers(key1 -> [118, 97, 108, 117, 101, 49]), key = key, value = value, timestamp = 0), ())" &&
+        ProducerMessage
+          .single[Id]
+          .of(recordHeader2)
+          .show == "ProducerMessage(ProducerRecord(topic = topic, partition = 0, headers = Headers(key1 -> [118, 97, 108, 117, 101, 49], key2 -> [118, 97, 108, 117, 101, 50]), key = key, value = value, timestamp = 0), ())"
+      }
+    }
+
+    it("should be able to create with multiple records") {
+      val records = List(new ProducerRecord("topic", "key", "value"))
+      assert {
+        ProducerMessage
+          .multiple[List, String, String, Int](records, 123)
+          .toString == "ProducerMessage(ProducerRecord(topic=topic, partition=null, headers=RecordHeaders(headers = [], isReadOnly = false), key=key, value=value, timestamp=null), 123)" &&
+        ProducerMessage
+          .multiple[List, String, String, Int](records, 123)
+          .show == "ProducerMessage(ProducerRecord(topic = topic, partition = null, headers = Headers(<empty>), key = key, value = value, timestamp = null), 123)" &&
+        ProducerMessage
+          .multiple[List, String, String](records)
+          .toString == "ProducerMessage(ProducerRecord(topic=topic, partition=null, headers=RecordHeaders(headers = [], isReadOnly = false), key=key, value=value, timestamp=null), ())" &&
+        ProducerMessage
+          .multiple[List, String, String](records)
+          .show == "ProducerMessage(ProducerRecord(topic = topic, partition = null, headers = Headers(<empty>), key = key, value = value, timestamp = null), ())" &&
+        ProducerMessage
+          .multiple[List]
+          .of(records, 123)
+          .toString == "ProducerMessage(ProducerRecord(topic=topic, partition=null, headers=RecordHeaders(headers = [], isReadOnly = false), key=key, value=value, timestamp=null), 123)" &&
+        ProducerMessage
+          .multiple[List]
+          .of(records, 123)
+          .show == "ProducerMessage(ProducerRecord(topic = topic, partition = null, headers = Headers(<empty>), key = key, value = value, timestamp = null), 123)" &&
+        ProducerMessage
+          .multiple[List]
+          .of(records)
+          .toString == "ProducerMessage(ProducerRecord(topic=topic, partition=null, headers=RecordHeaders(headers = [], isReadOnly = false), key=key, value=value, timestamp=null), ())" &&
+        ProducerMessage
+          .multiple[List]
+          .of(records)
+          .show == "ProducerMessage(ProducerRecord(topic = topic, partition = null, headers = Headers(<empty>), key = key, value = value, timestamp = null), ())"
+      }
+    }
+
+    it("should be able to create with passthrough only") {
+      assert {
+        ProducerMessage
+          .passthrough[List, String, String, Int](123)
+          .toString == "ProducerMessage(<empty>, 123)" &&
+        ProducerMessage
+          .passthrough[List, String, String, Int](123)
+          .show == "ProducerMessage(<empty>, 123)" &&
+        ProducerMessage
+          .passthrough[List]
+          .withKeyAndValue[String, String]
+          .of(123)
+          .toString == "ProducerMessage(<empty>, 123)" &&
+        ProducerMessage
+          .passthrough[List]
+          .withKeyAndValue[String, String]
+          .of(123)
+          .show == "ProducerMessage(<empty>, 123)" &&
+        ProducerMessage
+          .passthrough[List]
+          .of(123)
+          .toString == "ProducerMessage(<empty>, 123)"
+      }
+    }
+  }
+}

--- a/src/test/scala/fs2/kafka/ProducerResultSpec.scala
+++ b/src/test/scala/fs2/kafka/ProducerResultSpec.scala
@@ -1,0 +1,42 @@
+package fs2.kafka
+
+import cats.implicits._
+import org.apache.kafka.clients.producer.{ProducerRecord, RecordMetadata}
+import org.apache.kafka.common.TopicPartition
+
+final class ProducerResultSpec extends BaseSpec {
+  describe("ProducerResult") {
+    it("should have a Show instance and matching toString") {
+      val empty: List[(ProducerRecord[String, String], RecordMetadata)] = Nil
+
+      assert {
+        ProducerResult(empty, 123).toString == "ProducerResult(<empty>, 123)" &&
+        ProducerResult(empty, 123).show == ProducerResult(empty, 123).toString
+      }
+
+      val one: List[(ProducerRecord[String, String], RecordMetadata)] =
+        List(
+          new ProducerRecord("topic", 0, 0L, "key", "value") ->
+            new RecordMetadata(new TopicPartition("topic", 0), 0L, 0L, 0L, 0L, 0, 0)
+        )
+
+      assert {
+        ProducerResult(one, 123).toString == "ProducerResult(topic-0@0 -> ProducerRecord(topic=topic, partition=0, headers=RecordHeaders(headers = [], isReadOnly = false), key=key, value=value, timestamp=0), 123)" &&
+        ProducerResult(one, 123).show == "ProducerResult(topic-0@0 -> ProducerRecord(topic = topic, partition = 0, headers = Headers(<empty>), key = key, value = value, timestamp = 0), 123)"
+      }
+
+      val two: List[(ProducerRecord[String, String], RecordMetadata)] =
+        List(
+          new ProducerRecord("topic", 0, 0L, "key", "value") ->
+            new RecordMetadata(new TopicPartition("topic", 0), 0L, 0L, 0L, 0L, 0, 0),
+          new ProducerRecord("topic", 1, 0L, "key", "value") ->
+            new RecordMetadata(new TopicPartition("topic", 1), 0L, 0L, 0L, 0L, 0, 0)
+        )
+
+      assert {
+        ProducerResult(two, 123).toString == "ProducerResult(topic-0@0 -> ProducerRecord(topic=topic, partition=0, headers=RecordHeaders(headers = [], isReadOnly = false), key=key, value=value, timestamp=0), topic-1@0 -> ProducerRecord(topic=topic, partition=1, headers=RecordHeaders(headers = [], isReadOnly = false), key=key, value=value, timestamp=0), 123)" &&
+        ProducerResult(two, 123).show == "ProducerResult(topic-0@0 -> ProducerRecord(topic = topic, partition = 0, headers = Headers(<empty>), key = key, value = value, timestamp = 0), topic-1@0 -> ProducerRecord(topic = topic, partition = 1, headers = Headers(<empty>), key = key, value = value, timestamp = 0), 123)"
+      }
+    }
+  }
+}

--- a/src/test/scala/fs2/kafka/ProducerSettingsSpec.scala
+++ b/src/test/scala/fs2/kafka/ProducerSettingsSpec.scala
@@ -1,0 +1,137 @@
+package fs2.kafka
+
+import cats.implicits._
+import org.apache.kafka.clients.producer.ProducerConfig
+import org.apache.kafka.common.serialization.StringSerializer
+
+import scala.concurrent.duration._
+
+final class ProducerSettingsSpec extends BaseSpec {
+  describe("ProducerSettings") {
+    it("should provide withBootstrapServers") {
+      assert {
+        settings
+          .withBootstrapServers("localhost")
+          .properties(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG)
+          .contains("localhost")
+      }
+    }
+
+    it("should provide withAcks") {
+      assert {
+        settings
+          .withAcks(Acks.All)
+          .properties(ProducerConfig.ACKS_CONFIG)
+          .contains("all") &&
+        settings
+          .withAcks(Acks.One)
+          .properties(ProducerConfig.ACKS_CONFIG)
+          .contains("1") &&
+        settings
+          .withAcks(Acks.Zero)
+          .properties(ProducerConfig.ACKS_CONFIG)
+          .contains("0")
+      }
+    }
+
+    it("should provide withBatchSize") {
+      assert {
+        settings
+          .withBatchSize(10)
+          .properties(ProducerConfig.BATCH_SIZE_CONFIG)
+          .contains("10")
+      }
+    }
+
+    it("should provide withClientId") {
+      assert {
+        settings
+          .withClientId("clientId")
+          .properties(ProducerConfig.CLIENT_ID_CONFIG)
+          .contains("clientId")
+      }
+    }
+
+    it("should provide withRetries") {
+      assert {
+        settings
+          .withRetries(10)
+          .properties(ProducerConfig.RETRIES_CONFIG)
+          .contains("10")
+      }
+    }
+
+    it("should provide withMaxInFlightRequestsPerConnection") {
+      assert {
+        settings
+          .withMaxInFlightRequestsPerConnection(10)
+          .properties(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION)
+          .contains("10")
+      }
+    }
+
+    it("should provide withEnableIdempotence") {
+      assert {
+        settings
+          .withEnableIdempotence(true)
+          .properties(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG)
+          .contains("true") &&
+        settings
+          .withEnableIdempotence(false)
+          .properties(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG)
+          .contains("false")
+      }
+    }
+
+    it("should provide withLinger") {
+      assert {
+        settings
+          .withLinger(10.seconds)
+          .properties(ProducerConfig.LINGER_MS_CONFIG)
+          .contains("10000")
+      }
+    }
+
+    it("should provide withRequestTimeout") {
+      assert {
+        settings
+          .withRequestTimeout(10.seconds)
+          .properties(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG)
+          .contains("10000")
+      }
+    }
+
+    it("should provide withProperty/withProperties") {
+      assert {
+        settings.withProperty("a", "b").properties("a").contains("b") &&
+        settings.withProperties("a" -> "b").properties("a").contains("b") &&
+        settings.withProperties(Map("a" -> "b")).properties("a").contains("b")
+      }
+    }
+
+    it("should provide withCloseTimeout") {
+      assert(settings.withCloseTimeout(30.seconds).closeTimeout == 30.seconds)
+    }
+
+    it("should provide withProducerFactory") {
+      assert(
+        settings
+          .withProducerFactory(ProducerFactory.Default)
+          .producerFactory == ProducerFactory.Default)
+    }
+
+    it("should have a Show instance and matching toString") {
+      val shown = settings.show
+
+      assert(
+        shown == "ProducerSettings(closeTimeout = 60 seconds, producerFactory = Default)" &&
+          shown == settings.toString
+      )
+    }
+  }
+
+  val settings = ProducerSettings(
+    keySerializer = new StringSerializer,
+    valueSerializer = new StringSerializer
+  )
+}

--- a/src/test/scala/fs2/kafka/internal/SyntaxSpec.scala
+++ b/src/test/scala/fs2/kafka/internal/SyntaxSpec.scala
@@ -1,0 +1,30 @@
+package fs2.kafka.internal
+
+import java.time.temporal.ChronoUnit.MICROS
+
+import fs2.kafka.BaseSpec
+import fs2.kafka.internal.syntax._
+
+import scala.concurrent.duration._
+
+final class SyntaxSpec extends BaseSpec {
+  describe("FiniteDuration#asJava") {
+    it("should convert days") { assert(1.day.asJava == java.time.Duration.ofDays(1)) }
+    it("should convert hours") { assert(1.hour.asJava == java.time.Duration.ofHours(1)) }
+    it("should convert minutes") { assert(1.minute.asJava == java.time.Duration.ofMinutes(1)) }
+    it("should convert seconds") { assert(1.second.asJava == java.time.Duration.ofSeconds(1)) }
+    it("should convert millis") { assert(1.milli.asJava == java.time.Duration.ofMillis(1)) }
+    it("should convert micros") { assert(1.micro.asJava == java.time.Duration.of(1, MICROS)) }
+    it("should convert nanos") { assert(1.nanos.asJava == java.time.Duration.ofNanos(1)) }
+  }
+
+  describe("Map#filterKeysStrictValuesList") {
+    it("should be the same as filterKeys(p).values.toList") {
+      forAll { (m: Map[Int, Int], p: Int => Boolean) =>
+        assert {
+          m.filterKeysStrictValuesList(p) == m.filterKeys(p).values.toList
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes `Show[ProducerRecord[K, V]]` when partition is `null`.