### PR TITLE
Change to replace sinks with pipes

### DIFF
--- a/docs/src/main/mdoc/quick-example.md
+++ b/docs/src/main/mdoc/quick-example.md
@@ -56,7 +56,7 @@ object Main extends IOApp {
             }
             .evalMap(producer.produceBatched)
             .map(_.map(_.passthrough))
-            .to(commitBatchWithinF(500, 15.seconds))
+            .through(commitBatchWithinF(500, 15.seconds))
         }
 
     stream.compile.drain.as(ExitCode.Success)

--- a/src/main/scala/fs2/kafka/CommittableMessage.scala
+++ b/src/main/scala/fs2/kafka/CommittableMessage.scala
@@ -25,7 +25,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord
   * [[CommittableMessage]] is a Kafka record along with an instance of
   * [[CommittableOffset]], which can be used commit the record offset
   * to Kafka. Offsets are normally committed in batches, either using
-  * [[CommittableOffsetBatch]] or via sinks, like [[commitBatch]] and
+  * [[CommittableOffsetBatch]] or via pipes, like [[commitBatch]] and
   * [[commitBatchWithin]]. If you are not committing offsets to Kafka
   * then you can use [[record]] to get the underlying record and also
   * discard the [[committableOffset]].<br>
@@ -45,7 +45,7 @@ sealed abstract class CommittableMessage[F[_], K, V] {
   /**
     * A [[CommittableOffset]] instance, providing a way to commit the
     * [[record]] offset to Kafka. This is normally done in batches as
-    * it achieves better performance. Sinks like [[commitBatch]] and
+    * it achieves better performance. Pipes like [[commitBatch]] and
     * [[commitBatchWithin]] use [[CommittableOffsetBatch]] to batch
     * and commit offsets.
     */

--- a/src/main/scala/fs2/kafka/CommittableOffset.scala
+++ b/src/main/scala/fs2/kafka/CommittableOffset.scala
@@ -26,7 +26,7 @@ import org.apache.kafka.common.TopicPartition
   * [[CommittableOffset]] represents an [[offsetAndMetadata]] for a
   * [[topicPartition]], along with the ability to commit that offset
   * to Kafka with [[commit]]. Note that offsets are normally committed
-  * in batches for performance reasons. Sinks like [[commitBatch]] and
+  * in batches for performance reasons. Pipes like [[commitBatch]] and
   * [[commitBatchWithin]] use [[CommittableOffsetBatch]] to commit the
   * offsets in batches.<br>
   * <br>
@@ -66,7 +66,7 @@ sealed abstract class CommittableOffset[F[_]] {
   /**
     * Commits the [[offsetAndMetadata]] for the [[topicPartition]] to
     * Kafka. Note that offsets are normally committed in batches for
-    * performance reasons. Prefer to use sinks like [[commitBatch]]
+    * performance reasons. Prefer to use pipes like [[commitBatch]]
     * or [[commitBatchWithin]], or [[CommittableOffsetBatch]] for
     * that reason.
     */

--- a/src/main/scala/fs2/kafka/CommittableOffsetBatch.scala
+++ b/src/main/scala/fs2/kafka/CommittableOffsetBatch.scala
@@ -40,7 +40,7 @@ import org.apache.kafka.common.TopicPartition
   * them together using [[CommittableOffsetBatch#empty]] and `updated`,
   * or you can use [[CommittableOffsetBatch#fromFoldable]]. Generally,
   * prefer to use `fromFoldable`, as it has better performance. Provided
-  * sinks like [[commitBatch]] and [[commitBatchWithin]] are also to be
+  * pipes like [[commitBatch]] and [[commitBatchWithin]] are also to be
   * preferred, as they also achieve better performance.
   */
 sealed abstract class CommittableOffsetBatch[F[_]] {

--- a/src/main/scala/fs2/kafka/KafkaConsumer.scala
+++ b/src/main/scala/fs2/kafka/KafkaConsumer.scala
@@ -63,7 +63,7 @@ import scala.util.matching.Regex
   * which provide [[CommittableOffset]]s with the ability to commit
   * record offsets to Kafka. For performance reasons, offsets are
   * usually committed in batches using [[CommittableOffsetBatch]].
-  * Provided `Sink`s, like [[commitBatch]] or [[commitBatchWithin]]
+  * Provided `Pipe`s, like [[commitBatch]] or [[commitBatchWithin]]
   * are available for batch committing offsets. If you are not
   * committing offsets to Kafka, you can simply discard the
   * [[CommittableOffset]], and only make use of the record.<br>

--- a/src/main/scala/fs2/kafka/package.scala
+++ b/src/main/scala/fs2/kafka/package.scala
@@ -42,8 +42,8 @@ package object kafka {
     */
   def commitBatch[F[_]](
     implicit F: Applicative[F]
-  ): Sink[F, CommittableOffset[F]] =
-    _.chunks.to(commitBatchChunk)
+  ): Pipe[F, CommittableOffset[F], Unit] =
+    _.chunks.through(commitBatchChunk)
 
   /**
     * Commits offsets in batches determined by the `Chunk`s of the
@@ -63,8 +63,8 @@ package object kafka {
     */
   def commitBatchF[F[_]](
     implicit F: Applicative[F]
-  ): Sink[F, F[CommittableOffset[F]]] =
-    _.chunks.to(commitBatchChunkF)
+  ): Pipe[F, F[CommittableOffset[F]], Unit] =
+    _.chunks.through(commitBatchChunkF)
 
   /**
     * Commits offsets in batches determined by the `Chunks` of the
@@ -86,8 +86,8 @@ package object kafka {
     */
   def commitBatchOption[F[_]](
     implicit F: Applicative[F]
-  ): Sink[F, Option[CommittableOffset[F]]] =
-    _.chunks.to(commitBatchChunkOption)
+  ): Pipe[F, Option[CommittableOffset[F]], Unit] =
+    _.chunks.through(commitBatchChunkOption)
 
   /**
     * Commits offsets in batches determined by the `Chunks` of the
@@ -113,8 +113,8 @@ package object kafka {
     */
   def commitBatchOptionF[F[_]](
     implicit F: Applicative[F]
-  ): Sink[F, F[Option[CommittableOffset[F]]]] =
-    _.chunks.to(commitBatchChunkOptionF)
+  ): Pipe[F, F[Option[CommittableOffset[F]]], Unit] =
+    _.chunks.through(commitBatchChunkOptionF)
 
   /**
     * Commits offsets in batches determined by `Chunk`s. This allows
@@ -131,7 +131,7 @@ package object kafka {
     */
   def commitBatchChunk[F[_]](
     implicit F: Applicative[F]
-  ): Sink[F, Chunk[CommittableOffset[F]]] =
+  ): Pipe[F, Chunk[CommittableOffset[F]], Unit] =
     _.evalMap(CommittableOffsetBatch.fromFoldable(_).commit)
 
   /**
@@ -153,8 +153,8 @@ package object kafka {
     */
   def commitBatchChunkF[F[_]](
     implicit F: Applicative[F]
-  ): Sink[F, Chunk[F[CommittableOffset[F]]]] =
-    _.evalMap(_.sequence).to(commitBatchChunk)
+  ): Pipe[F, Chunk[F[CommittableOffset[F]]], Unit] =
+    _.evalMap(_.sequence).through(commitBatchChunk)
 
   /**
     * Commits offsets in batches determined by `Chunk`s. This allows
@@ -176,7 +176,7 @@ package object kafka {
     */
   def commitBatchChunkOption[F[_]](
     implicit F: Applicative[F]
-  ): Sink[F, Chunk[Option[CommittableOffset[F]]]] =
+  ): Pipe[F, Chunk[Option[CommittableOffset[F]]], Unit] =
     _.evalMap(CommittableOffsetBatch.fromFoldableOption(_).commit)
 
   /**
@@ -203,8 +203,8 @@ package object kafka {
     */
   def commitBatchChunkOptionF[F[_]](
     implicit F: Applicative[F]
-  ): Sink[F, Chunk[F[Option[CommittableOffset[F]]]]] =
-    _.evalMap(_.sequence).to(commitBatchChunkOption)
+  ): Pipe[F, Chunk[F[Option[CommittableOffset[F]]]], Unit] =
+    _.evalMap(_.sequence).through(commitBatchChunkOption)
 
   /**
     * Commits offsets in batches of every `n` offsets or time window
@@ -224,8 +224,8 @@ package object kafka {
   def commitBatchWithin[F[_]](n: Int, d: FiniteDuration)(
     implicit F: Concurrent[F],
     timer: Timer[F]
-  ): Sink[F, CommittableOffset[F]] =
-    _.groupWithin(n, d).to(commitBatchChunk)
+  ): Pipe[F, CommittableOffset[F], Unit] =
+    _.groupWithin(n, d).through(commitBatchChunk)
 
   /**
     * Commits offsets in batches of every `n` offsets or time window
@@ -249,8 +249,8 @@ package object kafka {
   def commitBatchWithinF[F[_]](n: Int, d: FiniteDuration)(
     implicit F: Concurrent[F],
     timer: Timer[F]
-  ): Sink[F, F[CommittableOffset[F]]] =
-    _.groupWithin(n, d).to(commitBatchChunkF)
+  ): Pipe[F, F[CommittableOffset[F]], Unit] =
+    _.groupWithin(n, d).through(commitBatchChunkF)
 
   /**
     * Commits offsets in batches of every `n` offsets or time window
@@ -275,8 +275,8 @@ package object kafka {
   def commitBatchOptionWithin[F[_]](n: Int, d: FiniteDuration)(
     implicit F: Concurrent[F],
     timer: Timer[F]
-  ): Sink[F, Option[CommittableOffset[F]]] =
-    _.groupWithin(n, d).to(commitBatchChunkOption)
+  ): Pipe[F, Option[CommittableOffset[F]], Unit] =
+    _.groupWithin(n, d).through(commitBatchChunkOption)
 
   /**
     * Commits offsets in batches of every `n` offsets or time window
@@ -305,8 +305,8 @@ package object kafka {
   def commitBatchOptionWithinF[F[_]](n: Int, d: FiniteDuration)(
     implicit F: Concurrent[F],
     timer: Timer[F]
-  ): Sink[F, F[Option[CommittableOffset[F]]]] =
-    _.groupWithin(n, d).to(commitBatchChunkOptionF)
+  ): Pipe[F, F[Option[CommittableOffset[F]]], Unit] =
+    _.groupWithin(n, d).through(commitBatchChunkOptionF)
 
   /**
     * Creates a new [[KafkaAdminClient]] in the `Resource` context,

--- a/src/test/scala/fs2/kafka/KafkaAdminClientSpec.scala
+++ b/src/test/scala/fs2/kafka/KafkaAdminClientSpec.scala
@@ -18,7 +18,7 @@ final class KafkaAdminClientSpec extends BaseKafkaSpec {
           .flatMap(_.stream)
           .take(produced.size.toLong)
           .map(_.committableOffset)
-          .to(commitBatch)
+          .through(commitBatch)
           .compile
           .lastOrError
           .unsafeRunSync

--- a/src/test/scala/fs2/kafka/KafkaConsumerSpec.scala
+++ b/src/test/scala/fs2/kafka/KafkaConsumerSpec.scala
@@ -260,7 +260,7 @@ final class KafkaConsumerSpec extends BaseKafkaSpec {
             stream(consumer)
               .take(produced.size.toLong)
               .map(_.committableOffset)
-              .to(commitBatch)
+              .through(commitBatch)
           }
           .evalTap { consumer =>
             for {

--- a/src/test/scala/fs2/kafka/KafkaSpec.scala
+++ b/src/test/scala/fs2/kafka/KafkaSpec.scala
@@ -19,7 +19,7 @@ final class KafkaSpec extends BaseAsyncSpec {
           _ <- Stream
             .chunk(offsets)
             .covary[IO]
-            .to(commitBatch)
+            .through(commitBatch)
           result <- Stream.eval(ref.get)
         } yield result).compile.lastOrError.unsafeRunSync
 
@@ -38,7 +38,7 @@ final class KafkaSpec extends BaseAsyncSpec {
             .chunk(offsets)
             .covary[IO]
             .map(IO.pure)
-            .to(commitBatchF)
+            .through(commitBatchF)
           result <- Stream.eval(ref.get)
         } yield result).compile.lastOrError.unsafeRunSync
 
@@ -56,7 +56,7 @@ final class KafkaSpec extends BaseAsyncSpec {
           _ <- Stream
             .chunk(offsets)
             .covary[IO]
-            .to(commitBatchOption)
+            .through(commitBatchOption)
           result <- Stream.eval(ref.get)
         } yield result).compile.lastOrError.unsafeRunSync
 
@@ -75,7 +75,7 @@ final class KafkaSpec extends BaseAsyncSpec {
             .chunk(offsets)
             .covary[IO]
             .map(IO.pure)
-            .to(commitBatchOptionF)
+            .through(commitBatchOptionF)
           result <- Stream.eval(ref.get)
         } yield result).compile.lastOrError.unsafeRunSync
 
@@ -93,7 +93,7 @@ final class KafkaSpec extends BaseAsyncSpec {
           _ <- Stream
             .chunk(offsets)
             .covary[IO]
-            .to(commitBatchWithin(offsets.size, 10.seconds))
+            .through(commitBatchWithin(offsets.size, 10.seconds))
           result <- Stream.eval(ref.get)
         } yield result).compile.lastOrError.unsafeRunSync
 
@@ -112,7 +112,7 @@ final class KafkaSpec extends BaseAsyncSpec {
             .chunk(offsets)
             .covary[IO]
             .map(IO.pure)
-            .to(commitBatchWithinF(offsets.size, 10.seconds))
+            .through(commitBatchWithinF(offsets.size, 10.seconds))
           result <- Stream.eval(ref.get)
         } yield result).compile.lastOrError.unsafeRunSync
 
@@ -130,7 +130,7 @@ final class KafkaSpec extends BaseAsyncSpec {
           _ <- Stream
             .chunk(offsets)
             .covary[IO]
-            .to(commitBatchOptionWithin(offsets.size, 10.seconds))
+            .through(commitBatchOptionWithin(offsets.size, 10.seconds))
           result <- Stream.eval(ref.get)
         } yield result).compile.lastOrError.unsafeRunSync
 
@@ -149,7 +149,7 @@ final class KafkaSpec extends BaseAsyncSpec {
             .chunk(offsets)
             .covary[IO]
             .map(IO.pure)
-            .to(commitBatchOptionWithinF(offsets.size, 10.seconds))
+            .through(commitBatchOptionWithinF(offsets.size, 10.seconds))
           result <- Stream.eval(ref.get)
         } yield result).compile.lastOrError.unsafeRunSync
 


### PR DESCRIPTION
`Sink` and `Stream#to` are deprecated in the next fs2 release.
Refer to https://github.com/functional-streams-for-scala/fs2/pull/1386 for more details.