### PR TITLE
Change KafkaProducer and ProducerMessage usage

### DIFF
--- a/docs/src/main/mdoc/quick-example.md
+++ b/docs/src/main/mdoc/quick-example.md
@@ -51,11 +51,10 @@ object Main extends IOApp {
               processRecord(message.record)
                 .map { case (key, value) =>
                   val record = new ProducerRecord("topic", key, value)
-                  ProducerMessage.single(record, message.committableOffset)
+                  ProducerMessage.one(record, message.committableOffset)
                 }
             }
-            .evalMap(producer.produceBatched)
-            .map(_.map(_.passthrough))
+            .evalMap(producer.producePassthrough)
             .through(commitBatchWithinF(500, 15.seconds))
         }
 

--- a/src/main/scala/fs2/kafka/package.scala
+++ b/src/main/scala/fs2/kafka/package.scala
@@ -34,8 +34,8 @@ package object kafka {
     * how batches are created, instead use [[commitBatchChunk]].<br>
     * <br>
     * If your [[CommittableOffset]]s are wrapped in an effect `F[_]`,
-    * like the produce effect from [[KafkaProducer.produceBatched]],
-    * then there is a [[commitBatchF]] function for that instead.
+    * like the produce effect from [[KafkaProducer.produce]], then
+    * there is a [[commitBatchF]] function for that instead.
     *
     * @see [[commitBatchWithin]] for committing offset batches every `n`
     *      offsets or time window of length `d`, whichever happens first
@@ -51,11 +51,11 @@ package object kafka {
     * how batches are created, instead use [[commitBatchChunkF]].<br>
     * <br>
     * Note that in order to enable offset commits in batches when also
-    * producing records, you can use [[KafkaProducer.produceBatched]]
-    * and keep the [[CommittableOffset]] as passthrough value.<br>
+    * producing records, you can use [[KafkaProducer.produce]] and
+    * keep the [[CommittableOffset]] as passthrough value.<br>
     * <br>
     * If your [[CommittableOffset]]s are not wrapped in an effect `F[_]`,
-    * like the produce effect from `produceBatched`, then there is a
+    * like the produce effect from `produce`, then there is a
     * [[commitBatch]] function for that instead.
     *
     * @see [[commitBatchWithinF]] for committing offset batches every `n`
@@ -78,8 +78,8 @@ package object kafka {
     * be committed once all of the messages have been produced.<br>
     * <br>
     * If your [[CommittableOffset]]s are wrapped in an effect `F[_]`,
-    * like the produce effect from [[KafkaProducer.produceBatched]],
-    * then there is a [[commitBatchOptionF]] function for that instead.
+    * like the produce effect from [[KafkaProducer.produce]], then
+    * there is a [[commitBatchOptionF]] function for that instead.
     *
     * @see [[commitBatchOptionWithin]] for committing offset batches every
     *     `n` offsets or time window of length `d`, whichever happens first
@@ -101,11 +101,11 @@ package object kafka {
     * be committed once all of the messages have been produced.<br>
     * <br>
     * Note that in order to enable offset commits in batches when also
-    * producing records, you can use [[KafkaProducer.produceBatched]]
-    * and keep the [[CommittableOffset]] as passthrough value.<br>
+    * producing records, you can use [[KafkaProducer.produce]] and
+    * keep the [[CommittableOffset]] as passthrough value.<br>
     * <br>
     * If your [[CommittableOffset]]s are not wrapped in an effect `F[_]`,
-    * like the produce effect from `produceBatched`, then there is a
+    * like the produce effect from `produce`, then there is a
     * [[commitBatchOption]] function for that instead.
     *
     * @see [[commitBatchOptionWithinF]] for committing offset batches every
@@ -123,8 +123,8 @@ package object kafka {
     * use [[commitBatch]] instead.<br>
     * <br>
     * If your [[CommittableOffset]]s are wrapped in an effect `F[_]`,
-    * like the produce effect from [[KafkaProducer.produceBatched]],
-    * then there is a [[commitBatchChunkF]] function for that instead.
+    * like the produce effect from [[KafkaProducer.produce]], then
+    * there is a [[commitBatchChunkF]] function for that instead.
     *
     * @see [[commitBatchWithin]] for committing offset batches every `n`
     *      offsets or time window of length `d`, whichever happens first
@@ -141,11 +141,11 @@ package object kafka {
     * use [[commitBatchF]] instead.<br>
     * <br>
     * Note that in order to enable offset commits in batches when also
-    * producing records, you can use [[KafkaProducer.produceBatched]]
-    * and keep the [[CommittableOffset]] as passthrough value.<br>
+    * producing records, you can use [[KafkaProducer.produce]] and
+    * keep the [[CommittableOffset]] as passthrough value.<br>
     * <br>
     * If your [[CommittableOffset]]s are not wrapped in an effect `F[_]`,
-    * like the produce effect from `produceBatched`, then there is a
+    * like the produce effect from `produce`, then there is a
     * [[commitBatchChunk]] function for that instead.
     *
     * @see [[commitBatchWithinF]] for committing offset batches every `n`
@@ -168,8 +168,8 @@ package object kafka {
     * be committed once all of the messages have been produced.<br>
     * <br>
     * If your [[CommittableOffset]]s are wrapped in an effect `F[_]`,
-    * like the produce effect from [[KafkaProducer.produceBatched]],
-    * then there is a [[commitBatchChunkOptionF]] for that instead.
+    * like the produce effect from [[KafkaProducer.produce]], then
+    * there is a [[commitBatchChunkOptionF]] for that instead.
     *
     * @see [[commitBatchOptionWithin]] for committing offset batches every
     *     `n` offsets or time window of length `d`, whichever happens first
@@ -191,11 +191,11 @@ package object kafka {
     * be committed once all of the messages have been produced.<br>
     * <br>
     * Note that in order to enable offset commits in batches when also
-    * producing records, you can use [[KafkaProducer.produceBatched]]
-    * and keep the [[CommittableOffset]] as passthrough value.<br>
+    * producing records, you can use [[KafkaProducer.produce]] and
+    * keep the [[CommittableOffset]] as passthrough value.<br>
     * <br>
     * If your [[CommittableOffset]]s are not wrapped in an effect `F[_]`,
-    * like the produce effect from `produceBatched`, then there is a
+    * like the produce effect from `produce`, then there is a
     * [[commitBatchChunkOption]] function for that instead.
     *
     * @see [[commitBatchOptionWithinF]] for committing offset batches every
@@ -213,8 +213,8 @@ package object kafka {
     * offsets for that time window.<br>
     * <br>
     * If your [[CommittableOffset]]s are wrapped in an effect `F[_]`,
-    * like the produce effect from [[KafkaProducer.produceBatched]],
-    * then there is a [[commitBatchWithinF]] function for that instead.
+    * like the produce effect from [[KafkaProducer.produce]], then
+    * there is a [[commitBatchWithinF]] function for that instead.
     *
     * @see [[commitBatch]] for using the underlying `Chunk`s of
     *      the `Stream` as offset commit batches
@@ -234,11 +234,11 @@ package object kafka {
     * offsets for that time window.<br>
     * <br>
     * Note that in order to enable offset commits in batches when also
-    * producing records, you can use [[KafkaProducer.produceBatched]]
-    * and keep the [[CommittableOffset]] as passthrough value.<br>
+    * producing records, you can use [[KafkaProducer.produce]] and
+    * keep the [[CommittableOffset]] as passthrough value.<br>
     * <br>
     * If your [[CommittableOffset]]s are not wrapped in an effect `F[_]`,
-    * like the produce effect from `produceBatched`, then there is a
+    * like the produce effect from `produce`, then there is a
     * [[commitBatchWithin]] function for that instead.
     *
     * @see [[commitBatchF]] for using the underlying `Chunk`s of
@@ -264,8 +264,8 @@ package object kafka {
     * be committed once all of the messages have been produced.<br>
     * <br>
     * If your [[CommittableOffset]]s are wrapped in an effect `F[_]`,
-    * like the produce effect from [[KafkaProducer.produceBatched]],
-    * then there is a [[commitBatchOptionWithinF]] for that instead.
+    * like the produce effect from [[KafkaProducer.produce]], then
+    * there is a [[commitBatchOptionWithinF]] for that instead.
     *
     * @see [[commitBatchOption]] for using the underlying `Chunk`s of
     *      the `Stream` as offset commit batches
@@ -290,11 +290,11 @@ package object kafka {
     * be committed once all of the messages have been produced.<br>
     * <br>
     * Note that in order to enable offset commits in batches when also
-    * producing records, you can use [[KafkaProducer.produceBatched]]
-    * and keep the [[CommittableOffset]] as passthrough value.<br>
+    * producing records, you can use [[KafkaProducer.produce]] and
+    * keep the [[CommittableOffset]] as passthrough value.<br>
     * <br>
     * If your [[CommittableOffset]]s are not wrapped in an effect `F[_]`,
-    * like the produce effect from `produceBatched`, then there is a
+    * like the produce effect from `produce`, then there is a
     * [[commitBatchOptionWithin]] function for that instead.
     *
     * @see [[commitBatchOptionF]] for using the underlying `Chunk`s of

--- a/src/test/scala/fs2/kafka/ProducerMessageSpec.scala
+++ b/src/test/scala/fs2/kafka/ProducerMessageSpec.scala
@@ -1,97 +1,46 @@
 package fs2.kafka
 
-import cats.Id
 import cats.implicits._
 import org.apache.kafka.clients.producer.ProducerRecord
-import org.apache.kafka.common.header.Header
-import scala.collection.JavaConverters._
 
 final class ProducerMessageSpec extends BaseSpec {
   describe("ProducerMessage") {
     it("should be able to create with one record") {
-      def header(_key: String, _value: String): Header =
-        new Header {
-          override def key(): String = _key
-          override def value(): Array[Byte] = _value.getBytes
-        }
-
       val record = new ProducerRecord("topic", "key", "value")
-
-      val headers1 = List(header("key1", "value1"))
-      val recordHeader1 = new ProducerRecord("topic", 0, 0L, "key", "value", headers1.asJava)
-
-      val headers2 = List(header("key1", "value1"), header("key2", "value2"))
-      val recordHeader2 = new ProducerRecord("topic", 0, 0L, "key", "value", headers2.asJava)
 
       assert {
         ProducerMessage
-          .single[Id, String, String, Int](record, 123)
+          .one[String, String, Int](record, 123)
           .toString == "ProducerMessage(ProducerRecord(topic=topic, partition=null, headers=RecordHeaders(headers = [], isReadOnly = false), key=key, value=value, timestamp=null), 123)" &&
         ProducerMessage
-          .single[Id, String, String, Int](record, 123)
+          .one[String, String, Int](record, 123)
           .show == "ProducerMessage(ProducerRecord(topic = topic, partition = null, headers = Headers(<empty>), key = key, value = value, timestamp = null), 123)" &&
         ProducerMessage
-          .single[Id, String, String](record)
+          .one[String, String](record)
           .toString == "ProducerMessage(ProducerRecord(topic=topic, partition=null, headers=RecordHeaders(headers = [], isReadOnly = false), key=key, value=value, timestamp=null), ())" &&
         ProducerMessage
-          .single[Id, String, String](record)
-          .show == "ProducerMessage(ProducerRecord(topic = topic, partition = null, headers = Headers(<empty>), key = key, value = value, timestamp = null), ())" &&
-        ProducerMessage
-          .single[Id]
-          .of(record, 123)
-          .toString == "ProducerMessage(ProducerRecord(topic=topic, partition=null, headers=RecordHeaders(headers = [], isReadOnly = false), key=key, value=value, timestamp=null), 123)" &&
-        ProducerMessage
-          .single[Id]
-          .of(record, 123)
-          .show == "ProducerMessage(ProducerRecord(topic = topic, partition = null, headers = Headers(<empty>), key = key, value = value, timestamp = null), 123)" &&
-        ProducerMessage
-          .single[Id]
-          .of(record)
-          .toString == "ProducerMessage(ProducerRecord(topic=topic, partition=null, headers=RecordHeaders(headers = [], isReadOnly = false), key=key, value=value, timestamp=null), ())" &&
-        ProducerMessage
-          .single[Id]
-          .of(record)
-          .show == "ProducerMessage(ProducerRecord(topic = topic, partition = null, headers = Headers(<empty>), key = key, value = value, timestamp = null), ())" &&
-        ProducerMessage
-          .single[Id]
-          .of(recordHeader1)
-          .show == "ProducerMessage(ProducerRecord(topic = topic, partition = 0, headers = Headers(key1 -> [118, 97, 108, 117, 101, 49]), key = key, value = value, timestamp = 0), ())" &&
-        ProducerMessage
-          .single[Id]
-          .of(recordHeader2)
-          .show == "ProducerMessage(ProducerRecord(topic = topic, partition = 0, headers = Headers(key1 -> [118, 97, 108, 117, 101, 49], key2 -> [118, 97, 108, 117, 101, 50]), key = key, value = value, timestamp = 0), ())"
+          .one[String, String](record)
+          .show == "ProducerMessage(ProducerRecord(topic = topic, partition = null, headers = Headers(<empty>), key = key, value = value, timestamp = null), ())"
       }
     }
 
     it("should be able to create with multiple records") {
       val records = List(new ProducerRecord("topic", "key", "value"))
       assert {
-        ProducerMessage
-          .multiple[List, String, String, Int](records, 123)
-          .toString == "ProducerMessage(ProducerRecord(topic=topic, partition=null, headers=RecordHeaders(headers = [], isReadOnly = false), key=key, value=value, timestamp=null), 123)" &&
-        ProducerMessage
-          .multiple[List, String, String, Int](records, 123)
-          .show == "ProducerMessage(ProducerRecord(topic = topic, partition = null, headers = Headers(<empty>), key = key, value = value, timestamp = null), 123)" &&
-        ProducerMessage
-          .multiple[List, String, String](records)
-          .toString == "ProducerMessage(ProducerRecord(topic=topic, partition=null, headers=RecordHeaders(headers = [], isReadOnly = false), key=key, value=value, timestamp=null), ())" &&
-        ProducerMessage
-          .multiple[List, String, String](records)
-          .show == "ProducerMessage(ProducerRecord(topic = topic, partition = null, headers = Headers(<empty>), key = key, value = value, timestamp = null), ())" &&
-        ProducerMessage
-          .multiple[List]
+        ProducerMessage[List, String, String, Int](records, 123).toString == "ProducerMessage(ProducerRecord(topic=topic, partition=null, headers=RecordHeaders(headers = [], isReadOnly = false), key=key, value=value, timestamp=null), 123)" &&
+        ProducerMessage[List, String, String, Int](records, 123).show == "ProducerMessage(ProducerRecord(topic = topic, partition = null, headers = Headers(<empty>), key = key, value = value, timestamp = null), 123)" &&
+        ProducerMessage[List, String, String](records).toString == "ProducerMessage(ProducerRecord(topic=topic, partition=null, headers=RecordHeaders(headers = [], isReadOnly = false), key=key, value=value, timestamp=null), ())" &&
+        ProducerMessage[List, String, String](records).show == "ProducerMessage(ProducerRecord(topic = topic, partition = null, headers = Headers(<empty>), key = key, value = value, timestamp = null), ())" &&
+        ProducerMessage[List]
           .of(records, 123)
           .toString == "ProducerMessage(ProducerRecord(topic=topic, partition=null, headers=RecordHeaders(headers = [], isReadOnly = false), key=key, value=value, timestamp=null), 123)" &&
-        ProducerMessage
-          .multiple[List]
+        ProducerMessage[List]
           .of(records, 123)
           .show == "ProducerMessage(ProducerRecord(topic = topic, partition = null, headers = Headers(<empty>), key = key, value = value, timestamp = null), 123)" &&
-        ProducerMessage
-          .multiple[List]
+        ProducerMessage[List]
           .of(records)
           .toString == "ProducerMessage(ProducerRecord(topic=topic, partition=null, headers=RecordHeaders(headers = [], isReadOnly = false), key=key, value=value, timestamp=null), ())" &&
-        ProducerMessage
-          .multiple[List]
+        ProducerMessage[List]
           .of(records)
           .show == "ProducerMessage(ProducerRecord(topic = topic, partition = null, headers = Headers(<empty>), key = key, value = value, timestamp = null), ())"
       }
@@ -99,26 +48,8 @@ final class ProducerMessageSpec extends BaseSpec {
 
     it("should be able to create with passthrough only") {
       assert {
-        ProducerMessage
-          .passthrough[List, String, String, Int](123)
-          .toString == "ProducerMessage(<empty>, 123)" &&
-        ProducerMessage
-          .passthrough[List, String, String, Int](123)
-          .show == "ProducerMessage(<empty>, 123)" &&
-        ProducerMessage
-          .passthrough[List]
-          .withKeyAndValue[String, String]
-          .of(123)
-          .toString == "ProducerMessage(<empty>, 123)" &&
-        ProducerMessage
-          .passthrough[List]
-          .withKeyAndValue[String, String]
-          .of(123)
-          .show == "ProducerMessage(<empty>, 123)" &&
-        ProducerMessage
-          .passthrough[List]
-          .of(123)
-          .toString == "ProducerMessage(<empty>, 123)"
+        ProducerMessage[List, String, String, Int](Nil, 123).toString == "ProducerMessage(<empty>, 123)" &&
+        ProducerMessage[List, String, String, Int](Nil, 123).show == "ProducerMessage(<empty>, 123)"
       }
     }
   }


### PR DESCRIPTION
#38 introduced an alternative encoding for `ProducerMessage`. It was a step in the right direction, but due to the `single`, `multiple`, and `passthrough` constructors, users might still be confused as to how messages should be created for their use cases. Additionally, type inference issues still exist, where sometimes the types of multiple `ProducerMessage`s have to be inferred and unified. Simply creating a message with a single record: `ProducerMessage.single(record)` can fail to infer `Id` as the context.

This pull request attempts to improve the situation by:
- removing the `ProducerMessage#single`, `multiple`, and `passthrough` constructors,
- adding `ProducerMessage#one` to always produce a single record (using `Id` as context),
- adding `ProducerMessage#apply` as a renamed version of `multiple`.

Now, there is only two ways to create a `ProducerMessage`:
- produce exactly one record with `ProducerMessage#one` (a very common use case),
- produce zero or more records with `ProducerMessage#apply` (for all other use cases).

`ProducerMessage#one` does not suffer from the type inference issues `single` has, as the context is fixed to `Id`. Additionally, there is now little room to confuse whether to use `multiple` or a combination of `single` + `passthrough`, as there is only `apply` if `one` is not suitable.

Previously, you might have attempted to use `single` + `passthrough` as follows, when actually `multiple` (poorly named) could have been used. This would suffer from both type inference issues and type unification issues, and the following code would not compile without explicit types.

```scala
// maybeRecord: Option[ProducerRecord[K, V]]

maybeRecord match {
  case Some(record) => ProduceMessage.single(record, passthrough)
  case None         => ProducerMessage.passthrough(passthrough)
}
```

With the changes in this pull request, there is no choice between `multiple` and `single` + `passthrough`. Since `one` cannot be used, we have to use `apply` instead.

```scala
ProducerMessage(maybeRecord, passthrough)
```

Another common use case is to produce a `Stream` of records, and only emit a passthrough after all records have been produced. Previously, this could have looked as follows, although it also suffers from both type inference and type unification issues, so would not compile.

```scala
// records: Stream[F, ProducerRecord[K, V]]
// passthrough: P

records
  .map(ProducerMessage.single(_, none[P]))
  ++ Stream(ProducerMessage.passthrough(passthrough.some))
```

Now, since `one` does not fit the use case, we have to use `apply` instead.

```scala
records
  .map(ProducerMessage(record.some, none[P]))
  ++ Stream(ProducerMessage(none, passthrough.some))
```

Note that this still doesn't compile because of invariant type parameters. A follow-up pull request will adress this.

There is also still the option to explicitly specify the context using:
- `ProducerMessage[F].of(records, passthrough)`, or
- `ProducerMessage[F].of(records)`.

---

This pull request also changes `KafkaProducer`:
- the previous `produce` function has been removed,
- the `produceBatched` function is now just called `produce`,
- a `producePassthrough` function has been added to only keep the passthrough.

The reason for removing `produce` is that it yields very poor performance, and might be a default choice for many due to the name. If you're sure you want the old behaviour, then simply use `flatten` on the result from `produce`.
