### PR TITLE
Change to improve ProducerMessage type inference

### DIFF
--- a/docs/src/main/mdoc/quick-example.md
+++ b/docs/src/main/mdoc/quick-example.md
@@ -14,7 +14,6 @@ import cats.effect.{ExitCode, IO, IOApp}
 import cats.syntax.functor._
 import fs2.kafka._
 import org.apache.kafka.clients.consumer.ConsumerRecord
-import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.serialization.{StringDeserializer, StringSerializer}
 import scala.concurrent.duration._
 
@@ -50,7 +49,7 @@ object Main extends IOApp {
             .mapAsync(25) { message =>
               processRecord(message.record)
                 .map { case (key, value) =>
-                  val record = new ProducerRecord("topic", key, value)
+                  val record = ProducerRecord("topic", key, value)
                   ProducerMessage.one(record, message.committableOffset)
                 }
             }

--- a/src/main/scala/fs2/kafka/Header.scala
+++ b/src/main/scala/fs2/kafka/Header.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018-2019 OVO Energy Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fs2.kafka
+
+import cats.Show
+
+/**
+  * [[Header]] represents a `String` key and `Array[Byte]` value
+  * which can be included as part of [[Headers]] when creating a
+  * [[ProducerRecord]]. [[Headers]] are included together with a
+  * record once produced, and can be used by consumers.<br>
+  * <br>
+  * To create a new [[Header]], use [[Header#apply]].
+  */
+sealed abstract class Header extends org.apache.kafka.common.header.Header {
+
+  /** The header key. */
+  override def key: String
+
+  /** The serialized header value. */
+  override def value: Array[Byte]
+}
+
+object Header {
+  private[this] final class HeaderImpl(
+    override val key: String,
+    override val value: Array[Byte]
+  ) extends Header {
+    override def toString: String =
+      s"Header($key -> ${java.util.Arrays.toString(value)})"
+  }
+
+  /**
+    * Creates a new [[Header]] instance using the specified
+    * `String` key and serialized `Array[Byte]` header value.
+    */
+  def apply(
+    key: String,
+    value: Array[Byte]
+  ): Header =
+    new HeaderImpl(
+      key = key,
+      value = value
+    )
+
+  implicit val headerShow: Show[Header] =
+    Show.fromToString
+}

--- a/src/main/scala/fs2/kafka/Headers.scala
+++ b/src/main/scala/fs2/kafka/Headers.scala
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2018-2019 OVO Energy Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fs2.kafka
+
+import cats.Show
+import cats.data.{Chain, NonEmptyChain}
+import fs2.kafka.internal.syntax._
+
+/**
+  * [[Headers]] represent an immutable append-only collection
+  * of [[Header]]s. To create a new [[Headers]] instance, you
+  * can use [[Headers#apply]] or [[Headers#empty]] and add an
+  * instance of [[Header]] using `append`.
+  */
+sealed abstract class Headers {
+
+  /**
+    * Creates a new [[Headers]] instance with the specified
+    * [[Header]] included.
+    */
+  def append(header: Header): Headers
+
+  /**
+    * Creates a new [[Headers]] instance including a
+    * [[Header]] with the specified key and value.
+    */
+  def append(key: String, value: Array[Byte]): Headers
+
+  /** The included [[Header]]s as a `Chain`. */
+  def toChain: Chain[Header]
+
+  /** `true` if at least one [[Header]] is included; otherwise `false`. */
+  final def nonEmpty: Boolean = !isEmpty
+
+  /** `true` if no [[Header]]s are included; otherwise `false`. */
+  def isEmpty: Boolean
+
+}
+
+object Headers {
+  private[this] final class HeadersImpl(
+    val headers: NonEmptyChain[Header]
+  ) extends Headers {
+    override def append(header: Header): Headers =
+      new HeadersImpl(headers.append(header))
+
+    override def append(key: String, value: Array[Byte]): Headers =
+      append(Header(key, value))
+
+    override def toChain: Chain[Header] =
+      headers.toChain
+
+    override val isEmpty: Boolean =
+      false
+
+    override def toString: String =
+      headers.mkStringAppend { (append, header) =>
+        append(header.key)
+        append(" -> ")
+        append(java.util.Arrays.toString(header.value))
+      }(
+        start = "Headers(",
+        sep = ", ",
+        end = ")"
+      )
+  }
+
+  /**
+    * Creates a new [[Headers]] instance from the specified
+    * [[Header]]s.
+    */
+  def apply(headers: Header*): Headers =
+    if (headers.isEmpty) empty
+    else new HeadersImpl(NonEmptyChain.fromChainUnsafe(Chain(headers: _*)))
+
+  /**
+    * Creates a new [[Headers]] instance from the specified
+    * `Chain` of [[Header]]s.
+    */
+  def fromChain(headers: Chain[Header]): Headers =
+    if (headers.isEmpty) empty
+    else new HeadersImpl(NonEmptyChain.fromChainUnsafe(headers))
+
+  /** The empty [[Headers]] instance without any [[Header]]s. */
+  val empty: Headers =
+    new Headers {
+      override def append(header: Header): Headers =
+        new HeadersImpl(NonEmptyChain.one(header))
+
+      override def append(key: String, value: Array[Byte]): Headers =
+        append(Header(key, value))
+
+      override val toChain: Chain[Header] =
+        Chain.empty
+
+      override val isEmpty: Boolean =
+        true
+
+      override def toString: String =
+        "Headers()"
+    }
+
+  implicit val headersShow: Show[Headers] =
+    Show.fromToString
+}

--- a/src/main/scala/fs2/kafka/ProducerMessage.scala
+++ b/src/main/scala/fs2/kafka/ProducerMessage.scala
@@ -18,10 +18,8 @@ package fs2.kafka
 
 import cats.syntax.foldable._
 import cats.syntax.show._
-import cats.{Foldable, Id, Show, Traverse}
-import fs2.kafka.internal.instances._
+import cats.{Foldable, Show, Traverse}
 import fs2.kafka.internal.syntax._
-import org.apache.kafka.clients.producer.ProducerRecord
 
 /**
   * [[ProducerMessage]] represents zero or more `ProducerRecord`s,
@@ -43,7 +41,7 @@ import org.apache.kafka.clients.producer.ProducerRecord
   * it needs a `Traverse[F]` instance. This requirement is
   * captured in [[ProducerMessage]] as [[traverse]].
   */
-sealed abstract class ProducerMessage[F[_], K, V, +P] {
+sealed abstract class ProducerMessage[F[+ _], +K, +V, +P] {
 
   /** The records to produce. Can be empty for passthrough-only. */
   def records: F[ProducerRecord[K, V]]
@@ -56,7 +54,7 @@ sealed abstract class ProducerMessage[F[_], K, V, +P] {
 }
 
 object ProducerMessage {
-  private[this] final class ProducerMessageImpl[F[_], K, V, +P](
+  private[this] final class ProducerMessageImpl[F[+ _], +K, +V, +P](
     override val records: F[ProducerRecord[K, V]],
     override val passthrough: P,
     override val traverse: Traverse[F]
@@ -77,7 +75,7 @@ object ProducerMessage {
     * ProducerMessage[F].of(records)
     * }}}
     */
-  final class ApplyBuilders[F[_]] private[kafka] (
+  final class ApplyBuilders[F[+ _]] private[kafka] (
     private val F: Traverse[F]
   ) extends AnyVal {
 
@@ -129,7 +127,7 @@ object ProducerMessage {
     * `ProducerRecords`s, then emitting a [[ProducerResult]] with
     * the results and specified passthrough value.
     */
-  def apply[F[_], K, V, P](
+  def apply[F[+ _], K, V, P](
     records: F[ProducerRecord[K, V]],
     passthrough: P
   )(
@@ -142,7 +140,7 @@ object ProducerMessage {
     * `ProducerRecords`s, then emitting a [[ProducerResult]] with
     * the results and `Unit` passthrough value.
     */
-  def apply[F[_], K, V](
+  def apply[F[+ _], K, V](
     records: F[ProducerRecord[K, V]]
   )(
     implicit F: Traverse[F]
@@ -166,10 +164,10 @@ object ProducerMessage {
     * ProducerMessage[F].of(records)
     * }}}
     */
-  def apply[F[_]](implicit F: Traverse[F]): ApplyBuilders[F] =
+  def apply[F[+ _]](implicit F: Traverse[F]): ApplyBuilders[F] =
     new ApplyBuilders[F](F)
 
-  implicit def producerMessageShow[F[_], K, V, P](
+  implicit def producerMessageShow[F[+ _], K, V, P](
     implicit
     K: Show[K],
     V: Show[V],

--- a/src/main/scala/fs2/kafka/ProducerRecord.scala
+++ b/src/main/scala/fs2/kafka/ProducerRecord.scala
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2018-2019 OVO Energy Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fs2.kafka
+
+import cats.Show
+import cats.syntax.show._
+
+/**
+  * [[ProducerRecord]] represents a record which can be produced
+  * to Kafka. At the very least, this includes a key of type `K`,
+  * a value of type `V`, and to which topic the record should be
+  * produced. The partition, timestamp, and headers can be set
+  * by using the [[withPartition]], [[withTimestamp]], and
+  * [[withHeaders]] functions, respectively.<br>
+  * <br>
+  * To create a new instance, use [[ProducerRecord#apply]].
+  */
+sealed abstract class ProducerRecord[+K, +V] {
+
+  /** The topic to which the record should be produced. */
+  def topic: String
+
+  /** The partition to which the record should be produced. */
+  def partition: Option[Int]
+
+  /** The timestamp for when the record was produced. */
+  def timestamp: Option[Long]
+
+  /** The record key. */
+  def key: K
+
+  /** The record value. */
+  def value: V
+
+  /** The record headers. */
+  def headers: Headers
+
+  /**
+    * Creates a new [[ProducerRecord]] instance with the
+    * specified partition as the partition to which the
+    * record should be produced.
+    */
+  def withPartition(partition: Int): ProducerRecord[K, V]
+
+  /**
+    * Creates a new [[ProducerRecord]] instance with the
+    * specified timestamp as the timestamp for when the
+    * record was produced.
+    */
+  def withTimestamp(timestamp: Long): ProducerRecord[K, V]
+
+  /**
+    * Creates a new [[ProducerRecord]] instance with the
+    * specified headers as the headers for the record.
+    */
+  def withHeaders(headers: Headers): ProducerRecord[K, V]
+}
+
+object ProducerRecord {
+  private[this] final case class ProducerRecordImpl[+K, +V](
+    override val topic: String,
+    override val partition: Option[Int],
+    override val timestamp: Option[Long],
+    override val key: K,
+    override val value: V,
+    override val headers: Headers
+  ) extends ProducerRecord[K, V] {
+    override def withPartition(partition: Int): ProducerRecord[K, V] =
+      copy(partition = Some(partition))
+
+    override def withTimestamp(timestamp: Long): ProducerRecord[K, V] =
+      copy(timestamp = Some(timestamp))
+
+    override def withHeaders(headers: Headers): ProducerRecord[K, V] =
+      copy(headers = headers)
+
+    override def toString: String = {
+      val b = new java.lang.StringBuilder("ProducerRecord(")
+      b.append("topic = ").append(topic)
+      if (partition.nonEmpty) b.append(", partition = ").append(partition.get)
+      if (timestamp.nonEmpty) b.append(", timestamp = ").append(timestamp.get)
+      b.append(", key = ").append(key)
+      b.append(", value = ").append(value)
+      if (headers.nonEmpty) b.append(", headers = ").append(headers)
+      b.append(")").toString
+    }
+  }
+
+  /**
+    * Creates a new [[ProducerRecord]] instance using the
+    * specified key and value, and the topic to which the
+    * record should be produced.
+    */
+  def apply[K, V](
+    topic: String,
+    key: K,
+    value: V
+  ): ProducerRecord[K, V] =
+    ProducerRecordImpl(
+      topic = topic,
+      partition = None,
+      timestamp = None,
+      key = key,
+      value = value,
+      headers = Headers.empty
+    )
+
+  implicit def producerRecordShow[K, V](
+    implicit
+    K: Show[K],
+    V: Show[V]
+  ): Show[ProducerRecord[K, V]] = Show.show { record =>
+    val b = new java.lang.StringBuilder("ProducerRecord(")
+    b.append("topic = ").append(record.topic)
+    if (record.partition.nonEmpty) b.append(", partition = ").append(record.partition.get)
+    if (record.timestamp.nonEmpty) b.append(", timestamp = ").append(record.timestamp.get)
+    b.append(", key = ").append(record.key.show)
+    b.append(", value = ").append(record.value.show)
+    if (record.headers.nonEmpty) b.append(", headers = ").append(record.headers)
+    b.append(")").toString
+  }
+}

--- a/src/main/scala/fs2/kafka/ProducerResult.scala
+++ b/src/main/scala/fs2/kafka/ProducerResult.scala
@@ -21,7 +21,7 @@ import cats.syntax.show._
 import cats.{Foldable, Show}
 import fs2.kafka.internal.instances._
 import fs2.kafka.internal.syntax._
-import org.apache.kafka.clients.producer.{ProducerRecord, RecordMetadata}
+import org.apache.kafka.clients.producer.RecordMetadata
 
 /**
   * [[ProducerResult]] represents the result of having produced zero
@@ -34,7 +34,7 @@ import org.apache.kafka.clients.producer.{ProducerRecord, RecordMetadata}
   * <br>
   * Use [[ProducerResult#apply]] to create a new [[ProducerResult]].
   */
-sealed abstract class ProducerResult[F[_], K, V, +P] {
+sealed abstract class ProducerResult[F[+ _], +K, +V, +P] {
 
   /**
     * The records produced along with respective metadata.
@@ -47,7 +47,7 @@ sealed abstract class ProducerResult[F[_], K, V, +P] {
 }
 
 object ProducerResult {
-  private[this] final class ProducerResultImpl[F[_], K, V, +P](
+  private[this] final class ProducerResultImpl[F[+ _], +K, +V, +P](
     override val records: F[(ProducerRecord[K, V], RecordMetadata)],
     override val passthrough: P
   )(implicit F: Foldable[F])
@@ -75,7 +75,7 @@ object ProducerResult {
     * or more `ProducerRecord`s, finally emitting a passthrough
     * value and the `ProducerRecord`s with `RecordMetadata`.
     */
-  def apply[F[_], K, V, P](
+  def apply[F[+ _], K, V, P](
     records: F[(ProducerRecord[K, V], RecordMetadata)],
     passthrough: P
   )(
@@ -83,7 +83,7 @@ object ProducerResult {
   ): ProducerResult[F, K, V, P] =
     new ProducerResultImpl(records, passthrough)
 
-  implicit def producerResultShow[F[_], K, V, P](
+  implicit def producerResultShow[F[+ _], K, V, P](
     implicit
     F: Foldable[F],
     K: Show[K],

--- a/src/main/scala/fs2/kafka/internal/instances.scala
+++ b/src/main/scala/fs2/kafka/internal/instances.scala
@@ -25,7 +25,7 @@ import cats.instances.tuple._
 import cats.syntax.show._
 import cats.{Order, Semigroup, Show}
 import org.apache.kafka.clients.consumer.{ConsumerRecord, OffsetAndMetadata}
-import org.apache.kafka.clients.producer.{ProducerRecord, RecordMetadata}
+import org.apache.kafka.clients.producer.RecordMetadata
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.header.{Header, Headers}
 import org.apache.kafka.common.record.TimestampType
@@ -45,18 +45,8 @@ private[kafka] object instances {
   implicit val headerShow: Show[Header] =
     Show.show(h => show"${h.key} -> ${util.Arrays.toString(h.value)}")
 
-  implicit val headerOrder: Order[Header] =
-    Order.by(_.key)
-
-  implicit val headerOrdering: Ordering[Header] =
-    Order[Header].toOrdering
-
   implicit val headersShow: Show[Headers] =
-    Show.show { hs =>
-      val headers = hs.toArray
-      if (headers.isEmpty) "Headers(<empty>)"
-      else headers.sorted.map(_.show).mkString("Headers(", ", ", ")")
-    }
+    Show.show(hs => hs.toArray.map(_.show).mkString("Headers(", ", ", ")"))
 
   implicit val offsetAndMetadataOrder: Order[OffsetAndMetadata] =
     Order.by(oam => (oam.offset, oam.metadata))
@@ -70,19 +60,6 @@ private[kafka] object instances {
         show"(${oam.offset}, ${oam.metadata})"
       else oam.offset.show
     }
-
-  implicit def producerRecordShow[K, V](
-    implicit
-    K: Show[K],
-    V: Show[V]
-  ): Show[ProducerRecord[K, V]] = Show.show { r =>
-    val headers = if (r.headers != null) r.headers.show else "null"
-    val key = if (r.key != null) r.key.show else "null"
-    val value = if (r.value != null) r.value.show else "null"
-    val timestamp = if (r.timestamp != null) (r.timestamp: Long).show else "null"
-    val partition = if (r.partition != null) (r.partition: Int).show else "null"
-    show"ProducerRecord(topic = ${r.topic}, partition = $partition, headers = $headers, key = $key, value = $value, timestamp = $timestamp)"
-  }
 
   implicit val recordMetadataShow: Show[RecordMetadata] =
     Show.show(rm => show"${rm.topic}-${rm.partition}@${rm.offset}")

--- a/src/main/scala/fs2/kafka/package.scala
+++ b/src/main/scala/fs2/kafka/package.scala
@@ -27,6 +27,7 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.FiniteDuration
 
 package object kafka {
+  private[kafka] type Id[+A] = A
 
   /**
     * Commits offsets in batches determined by the `Chunk`s of the

--- a/src/test/scala/fs2/kafka/CommittableMessageSpec.scala
+++ b/src/test/scala/fs2/kafka/CommittableMessageSpec.scala
@@ -1,6 +1,5 @@
 package fs2.kafka
 
-import cats.Id
 import cats.implicits._
 import org.apache.kafka.clients.consumer.{ConsumerRecord, OffsetAndMetadata}
 import org.apache.kafka.common.TopicPartition
@@ -20,7 +19,7 @@ final class CommittableMessageSpec extends BaseSpec {
 
       assert {
         message.toString == "CommittableMessage(ConsumerRecord(topic = topic, partition = 0, leaderEpoch = null, offset = 0, NoTimestampType = -1, serialized key size = -1, serialized value size = -1, headers = RecordHeaders(headers = [], isReadOnly = false), key = key, value = value), CommittableOffset(topic-0 -> 0))" &&
-        message.show == "CommittableMessage(ConsumerRecord(topic = topic, partition = 0, leaderEpoch = null, offset = 0, NoTimestampType = -1, serialized key size = -1, serialized value size = -1, headers = Headers(<empty>), key = key, value = value), CommittableOffset(topic-0 -> 0))"
+        message.show == "CommittableMessage(ConsumerRecord(topic = topic, partition = 0, leaderEpoch = null, offset = 0, NoTimestampType = -1, serialized key size = -1, serialized value size = -1, headers = Headers(), key = key, value = value), CommittableOffset(topic-0 -> 0))"
       }
     }
   }

--- a/src/test/scala/fs2/kafka/CommittableOffsetBatchSpec.scala
+++ b/src/test/scala/fs2/kafka/CommittableOffsetBatchSpec.scala
@@ -1,6 +1,5 @@
 package fs2.kafka
 
-import cats.Id
 import cats.implicits._
 import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import org.apache.kafka.common.TopicPartition

--- a/src/test/scala/fs2/kafka/CommittableOffsetSpec.scala
+++ b/src/test/scala/fs2/kafka/CommittableOffsetSpec.scala
@@ -1,6 +1,5 @@
 package fs2.kafka
 
-import cats.Id
 import cats.implicits._
 import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import org.apache.kafka.common.TopicPartition

--- a/src/test/scala/fs2/kafka/HeaderSpec.scala
+++ b/src/test/scala/fs2/kafka/HeaderSpec.scala
@@ -1,0 +1,29 @@
+package fs2.kafka
+
+import cats.syntax.show._
+
+final class HeaderSpec extends BaseSpec {
+  describe("Header") {
+    it("toString should be Header(key -> value)") {
+      assert {
+        Header("key", Array(1.toByte, 2.toByte)).toString == "Header(key -> [1, 2])"
+      }
+    }
+
+    it("should have consistent toString and Show") {
+      assert {
+        val header = Header("key", Array(1.toByte, 2.toByte))
+        header.show == header.toString
+      }
+    }
+
+    it("should return the key with key") {
+      assert(Header("key", Array()).key == "key")
+    }
+
+    it("should return the value with value") {
+      val value = Array[Byte]()
+      assert(Header("key", value).value == value)
+    }
+  }
+}

--- a/src/test/scala/fs2/kafka/HeadersSpec.scala
+++ b/src/test/scala/fs2/kafka/HeadersSpec.scala
@@ -1,0 +1,75 @@
+package fs2.kafka
+import cats.data.Chain
+
+final class HeadersSpec extends BaseSpec {
+  describe("Headers#empty") {
+    it("should have toString as Headers()") {
+      assert(Headers.empty.toString == "Headers()")
+    }
+
+    it("should return true for isEmpty") {
+      assert(Headers.empty.isEmpty)
+    }
+
+    it("should return empty Chain from toChain") {
+      assert(Headers.empty.toChain.isEmpty)
+    }
+
+    it("should create a new Headers from append(Header)") {
+      assert {
+        val header = Header("key", Array())
+        Headers.empty.append(header).toChain == Chain.one(header)
+      }
+    }
+
+    it("should create a new Headers from append(key, value)") {
+      assert {
+        Headers.empty.append("key", Array()).toChain.size == 1
+      }
+    }
+  }
+
+  describe("Headers (non-empty)") {
+    it("should not be empty") {
+      assert(!Headers(Header("key", Array())).isEmpty)
+    }
+
+    it("should include the headers in toString") {
+      val headers = Chain(Header("key1", Array()), Header("key2", Array()))
+      assert(Headers.fromChain(headers).toString == "Headers(key1 -> [], key2 -> [])")
+    }
+
+    it("should append one more header with append(Header)") {
+      val header1 = Header("key1", Array())
+      val header2 = Header("key2", Array())
+
+      Headers(header1).append(header2).toChain == Chain(header1, header2)
+    }
+
+    it("should append one more header with append(key, value)") {
+      Headers(Header("key1", Array())).append("key2", Array()).toChain.size == 2
+    }
+  }
+
+  describe("Headers#apply") {
+    it("returns empty for no headers") {
+      assert(Headers() == Headers.empty)
+    }
+
+    it("returns non-empty for at least one header") {
+      val header = Header("key", Array())
+      Headers(header).toChain == Chain.one(header)
+    }
+  }
+
+  describe("Headers#fromChain") {
+    it("returns empty for empty chain") {
+      assert(Headers.fromChain(Chain.empty) == Headers.empty)
+    }
+
+    it("returns non-empty for non-empty chain") {
+      val headers = Chain(Header("key1", Array()), Header("key2", Array()))
+      assert(Headers.fromChain(headers).toChain == headers)
+    }
+  }
+}

--- a/src/test/scala/fs2/kafka/JitterSpec.scala
+++ b/src/test/scala/fs2/kafka/JitterSpec.scala
@@ -1,6 +1,5 @@
 package fs2.kafka
 
-import cats.Id
 import cats.effect.IO
 
 final class JitterSpec extends BaseSpec {

--- a/src/test/scala/fs2/kafka/KafkaProducerSpec.scala
+++ b/src/test/scala/fs2/kafka/KafkaProducerSpec.scala
@@ -3,7 +3,6 @@ package fs2.kafka
 import cats.effect.IO
 import cats.implicits._
 import fs2.{Chunk, Stream}
-import org.apache.kafka.clients.producer.ProducerRecord
 
 final class KafkaProducerSpec extends BaseKafkaSpec {
   it("should be able to produce records with single") {
@@ -17,7 +16,7 @@ final class KafkaProducerSpec extends BaseKafkaSpec {
           _ <- Stream.eval(IO(producer.toString should startWith("KafkaProducer$")))
           message <- Stream.chunk(Chunk.seq(toProduce).map {
             case passthrough @ (key, value) =>
-              ProducerMessage.one(new ProducerRecord(topic, key, value), passthrough)
+              ProducerMessage.one(ProducerRecord(topic, key, value), passthrough)
           })
           batched <- Stream.eval(producer.producePassthrough(message)).buffer(toProduce.size)
           passthrough <- Stream.eval(batched)
@@ -43,7 +42,7 @@ final class KafkaProducerSpec extends BaseKafkaSpec {
           producer <- producerStream[IO].using(producerSettings(config))
           records = toProduce.map {
             case (key, value) =>
-              new ProducerRecord(topic, key, value)
+              ProducerRecord(topic, key, value)
           }
           message = ProducerMessage(records, toPassthrough)
           result <- Stream.eval(producer.produce(message).flatten)

--- a/src/test/scala/fs2/kafka/ProducerMessageSpec.scala
+++ b/src/test/scala/fs2/kafka/ProducerMessageSpec.scala
@@ -1,48 +1,47 @@
 package fs2.kafka
 
 import cats.implicits._
-import org.apache.kafka.clients.producer.ProducerRecord
 
 final class ProducerMessageSpec extends BaseSpec {
   describe("ProducerMessage") {
     it("should be able to create with one record") {
-      val record = new ProducerRecord("topic", "key", "value")
+      val record = ProducerRecord("topic", "key", "value")
 
       assert {
         ProducerMessage
           .one[String, String, Int](record, 123)
-          .toString == "ProducerMessage(ProducerRecord(topic=topic, partition=null, headers=RecordHeaders(headers = [], isReadOnly = false), key=key, value=value, timestamp=null), 123)" &&
+          .toString == "ProducerMessage(ProducerRecord(topic = topic, key = key, value = value), 123)" &&
         ProducerMessage
           .one[String, String, Int](record, 123)
-          .show == "ProducerMessage(ProducerRecord(topic = topic, partition = null, headers = Headers(<empty>), key = key, value = value, timestamp = null), 123)" &&
+          .show == "ProducerMessage(ProducerRecord(topic = topic, key = key, value = value), 123)" &&
         ProducerMessage
           .one[String, String](record)
-          .toString == "ProducerMessage(ProducerRecord(topic=topic, partition=null, headers=RecordHeaders(headers = [], isReadOnly = false), key=key, value=value, timestamp=null), ())" &&
+          .toString == "ProducerMessage(ProducerRecord(topic = topic, key = key, value = value), ())" &&
         ProducerMessage
           .one[String, String](record)
-          .show == "ProducerMessage(ProducerRecord(topic = topic, partition = null, headers = Headers(<empty>), key = key, value = value, timestamp = null), ())"
+          .show == "ProducerMessage(ProducerRecord(topic = topic, key = key, value = value), ())"
       }
     }
 
     it("should be able to create with multiple records") {
-      val records = List(new ProducerRecord("topic", "key", "value"))
+      val records = List(ProducerRecord("topic", "key", "value"))
       assert {
-        ProducerMessage[List, String, String, Int](records, 123).toString == "ProducerMessage(ProducerRecord(topic=topic, partition=null, headers=RecordHeaders(headers = [], isReadOnly = false), key=key, value=value, timestamp=null), 123)" &&
-        ProducerMessage[List, String, String, Int](records, 123).show == "ProducerMessage(ProducerRecord(topic = topic, partition = null, headers = Headers(<empty>), key = key, value = value, timestamp = null), 123)" &&
-        ProducerMessage[List, String, String](records).toString == "ProducerMessage(ProducerRecord(topic=topic, partition=null, headers=RecordHeaders(headers = [], isReadOnly = false), key=key, value=value, timestamp=null), ())" &&
-        ProducerMessage[List, String, String](records).show == "ProducerMessage(ProducerRecord(topic = topic, partition = null, headers = Headers(<empty>), key = key, value = value, timestamp = null), ())" &&
+        ProducerMessage[List, String, String, Int](records, 123).toString == "ProducerMessage(ProducerRecord(topic = topic, key = key, value = value), 123)" &&
+        ProducerMessage[List, String, String, Int](records, 123).show == "ProducerMessage(ProducerRecord(topic = topic, key = key, value = value), 123)" &&
+        ProducerMessage[List, String, String](records).toString == "ProducerMessage(ProducerRecord(topic = topic, key = key, value = value), ())" &&
+        ProducerMessage[List, String, String](records).show == "ProducerMessage(ProducerRecord(topic = topic, key = key, value = value), ())" &&
         ProducerMessage[List]
           .of(records, 123)
-          .toString == "ProducerMessage(ProducerRecord(topic=topic, partition=null, headers=RecordHeaders(headers = [], isReadOnly = false), key=key, value=value, timestamp=null), 123)" &&
+          .toString == "ProducerMessage(ProducerRecord(topic = topic, key = key, value = value), 123)" &&
         ProducerMessage[List]
           .of(records, 123)
-          .show == "ProducerMessage(ProducerRecord(topic = topic, partition = null, headers = Headers(<empty>), key = key, value = value, timestamp = null), 123)" &&
+          .show == "ProducerMessage(ProducerRecord(topic = topic, key = key, value = value), 123)" &&
         ProducerMessage[List]
           .of(records)
-          .toString == "ProducerMessage(ProducerRecord(topic=topic, partition=null, headers=RecordHeaders(headers = [], isReadOnly = false), key=key, value=value, timestamp=null), ())" &&
+          .toString == "ProducerMessage(ProducerRecord(topic = topic, key = key, value = value), ())" &&
         ProducerMessage[List]
           .of(records)
-          .show == "ProducerMessage(ProducerRecord(topic = topic, partition = null, headers = Headers(<empty>), key = key, value = value, timestamp = null), ())"
+          .show == "ProducerMessage(ProducerRecord(topic = topic, key = key, value = value), ())"
       }
     }
 

--- a/src/test/scala/fs2/kafka/ProducerResultSpec.scala
+++ b/src/test/scala/fs2/kafka/ProducerResultSpec.scala
@@ -1,7 +1,7 @@
 package fs2.kafka
 
 import cats.implicits._
-import org.apache.kafka.clients.producer.{ProducerRecord, RecordMetadata}
+import org.apache.kafka.clients.producer.RecordMetadata
 import org.apache.kafka.common.TopicPartition
 
 final class ProducerResultSpec extends BaseSpec {
@@ -16,26 +16,26 @@ final class ProducerResultSpec extends BaseSpec {
 
       val one: List[(ProducerRecord[String, String], RecordMetadata)] =
         List(
-          new ProducerRecord("topic", 0, 0L, "key", "value") ->
+          ProducerRecord("topic", "key", "value").withPartition(1).withTimestamp(0L) ->
             new RecordMetadata(new TopicPartition("topic", 0), 0L, 0L, 0L, 0L, 0, 0)
         )
 
       assert {
-        ProducerResult(one, 123).toString == "ProducerResult(topic-0@0 -> ProducerRecord(topic=topic, partition=0, headers=RecordHeaders(headers = [], isReadOnly = false), key=key, value=value, timestamp=0), 123)" &&
-        ProducerResult(one, 123).show == "ProducerResult(topic-0@0 -> ProducerRecord(topic = topic, partition = 0, headers = Headers(<empty>), key = key, value = value, timestamp = 0), 123)"
+        ProducerResult(one, 123).toString == "ProducerResult(topic-0@0 -> ProducerRecord(topic = topic, partition = 1, timestamp = 0, key = key, value = value), 123)" &&
+        ProducerResult(one, 123).show == "ProducerResult(topic-0@0 -> ProducerRecord(topic = topic, partition = 1, timestamp = 0, key = key, value = value), 123)"
       }
 
       val two: List[(ProducerRecord[String, String], RecordMetadata)] =
         List(
-          new ProducerRecord("topic", 0, 0L, "key", "value") ->
+          ProducerRecord("topic", "key", "value").withPartition(0).withTimestamp(0L) ->
             new RecordMetadata(new TopicPartition("topic", 0), 0L, 0L, 0L, 0L, 0, 0),
-          new ProducerRecord("topic", 1, 0L, "key", "value") ->
+          ProducerRecord("topic", "key", "value").withPartition(1).withTimestamp(0L) ->
             new RecordMetadata(new TopicPartition("topic", 1), 0L, 0L, 0L, 0L, 0, 0)
         )
 
       assert {
-        ProducerResult(two, 123).toString == "ProducerResult(topic-0@0 -> ProducerRecord(topic=topic, partition=0, headers=RecordHeaders(headers = [], isReadOnly = false), key=key, value=value, timestamp=0), topic-1@0 -> ProducerRecord(topic=topic, partition=1, headers=RecordHeaders(headers = [], isReadOnly = false), key=key, value=value, timestamp=0), 123)" &&
-        ProducerResult(two, 123).show == "ProducerResult(topic-0@0 -> ProducerRecord(topic = topic, partition = 0, headers = Headers(<empty>), key = key, value = value, timestamp = 0), topic-1@0 -> ProducerRecord(topic = topic, partition = 1, headers = Headers(<empty>), key = key, value = value, timestamp = 0), 123)"
+        ProducerResult(two, 123).toString == "ProducerResult(topic-0@0 -> ProducerRecord(topic = topic, partition = 0, timestamp = 0, key = key, value = value), topic-1@0 -> ProducerRecord(topic = topic, partition = 1, timestamp = 0, key = key, value = value), 123)" &&
+        ProducerResult(two, 123).show == "ProducerResult(topic-0@0 -> ProducerRecord(topic = topic, partition = 0, timestamp = 0, key = key, value = value), topic-1@0 -> ProducerRecord(topic = topic, partition = 1, timestamp = 0, key = key, value = value), 123)"
       }
     }
   }


### PR DESCRIPTION
#74 helped clarify how `ProducerMessage`s should be created and helped avoid some type inference and type unification issues. However, there are still some type inference issues present, mainly due to `ProducerMessage`'s type parameters being invariant. The reason for this is that `ProducerRecord`'s type parameters are invariant. 

For example, the following example still fails to compile.

```scala
// records: Stream[F, ProducerRecord[K, V]]
// passthrough: P

records
  .map(ProducerMessage(record.some, none))
  ++ Stream(ProducerMessage(none, passthrough.some))
```

The changes in this pull request makes the above example compile. The changes introduce a custom implementation of `ProducerRecord` (and `Headers` and `Header`), which has covariant type parameters. We in turn change the `ProducerMessage` definition to:

```scala
ProducerMessage[F[+_], +K, +V, +P]
```

and make similar changes to `ProducerResult` and `KafkaProducer`. While the custom classes are immutable and nicer to work with than the Java versions, we do pay a cost of ultimately having to convert to the Java classes behind the scenes.