### PR TITLE
Change KafkaConsumer#stream to alias of partitionedStream

### DIFF
--- a/src/main/scala/fs2/kafka/ConsumerSettings.scala
+++ b/src/main/scala/fs2/kafka/ConsumerSettings.scala
@@ -256,20 +256,6 @@ sealed abstract class ConsumerSettings[K, V] {
   def withCommitTimeout(commitTimeout: FiniteDuration): ConsumerSettings[K, V]
 
   /**
-    * The time to wait for topic-partition fetches to complete when
-    * using [[KafkaConsumer#stream]]. Once all topic-partition fetches
-    * expire, new fetches for all assigned partitions will be issued.<br>
-    * <br>
-    * The default value is 500 milliseconds.
-    */
-  def fetchTimeout: FiniteDuration
-
-  /**
-    * Creates a new [[ConsumerSettings]] with the specified [[fetchTimeout]].
-    */
-  def withFetchTimeout(fetchTimeout: FiniteDuration): ConsumerSettings[K, V]
-
-  /**
     * How often we should attempt to call `poll` on the Java `KafkaConsumer`.<br>
     * <br>
     * The default value is 50 milliseconds.
@@ -352,7 +338,6 @@ object ConsumerSettings {
     override val properties: Map[String, String],
     override val closeTimeout: FiniteDuration,
     override val commitTimeout: FiniteDuration,
-    override val fetchTimeout: FiniteDuration,
     override val pollInterval: FiniteDuration,
     override val pollTimeout: FiniteDuration,
     override val commitRecovery: CommitRecovery,
@@ -428,9 +413,6 @@ object ConsumerSettings {
     override def withCommitTimeout(commitTimeout: FiniteDuration): ConsumerSettings[K, V] =
       copy(commitTimeout = commitTimeout)
 
-    override def withFetchTimeout(fetchTimeout: FiniteDuration): ConsumerSettings[K, V] =
-      copy(fetchTimeout = fetchTimeout)
-
     override def withPollInterval(pollInterval: FiniteDuration): ConsumerSettings[K, V] =
       copy(pollInterval = pollInterval)
 
@@ -463,7 +445,6 @@ object ConsumerSettings {
     properties = Map(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG -> "false"),
     closeTimeout = 20.seconds,
     commitTimeout = 15.seconds,
-    fetchTimeout = 500.millis,
     pollInterval = 50.millis,
     pollTimeout = 50.millis,
     commitRecovery = CommitRecovery.Default,
@@ -523,6 +504,6 @@ object ConsumerSettings {
 
   implicit def consumerSettingsShow[K, V]: Show[ConsumerSettings[K, V]] =
     Show.show { s =>
-      s"ConsumerSettings(closeTimeout = ${s.closeTimeout}, commitTimeout = ${s.commitTimeout}, fetchTimeout = ${s.fetchTimeout}, pollInterval = ${s.pollInterval}, pollTimeout = ${s.pollTimeout}, commitRecovery = ${s.commitRecovery}, consumerFactory = ${s.consumerFactory})"
+      s"ConsumerSettings(closeTimeout = ${s.closeTimeout}, commitTimeout = ${s.commitTimeout}, pollInterval = ${s.pollInterval}, pollTimeout = ${s.pollTimeout}, commitRecovery = ${s.commitRecovery}, consumerFactory = ${s.consumerFactory})"
     }
 }

--- a/src/test/scala/fs2/kafka/ConsumerSettingsSpec.scala
+++ b/src/test/scala/fs2/kafka/ConsumerSettingsSpec.scala
@@ -165,14 +165,6 @@ final class ConsumerSettingsSpec extends BaseSpec {
       }
     }
 
-    it("should provide withFetchTimeout") {
-      assert {
-        settings
-          .withFetchTimeout(50.millis)
-          .fetchTimeout == 50.millis
-      }
-    }
-
     it("should provide withPollInterval") {
       assert {
         settings
@@ -218,7 +210,7 @@ final class ConsumerSettingsSpec extends BaseSpec {
 
     it("should have a Show instance and matching toString") {
       assert {
-        settings.show == "ConsumerSettings(closeTimeout = 20 seconds, commitTimeout = 15 seconds, fetchTimeout = 500 milliseconds, pollInterval = 50 milliseconds, pollTimeout = 50 milliseconds, commitRecovery = Default, consumerFactory = Default)" &&
+        settings.show == "ConsumerSettings(closeTimeout = 20 seconds, commitTimeout = 15 seconds, pollInterval = 50 milliseconds, pollTimeout = 50 milliseconds, commitRecovery = Default, consumerFactory = Default)" &&
         settings.show == settings.toString
       }
     }

--- a/src/test/scala/fs2/kafka/KafkaConsumerSpec.scala
+++ b/src/test/scala/fs2/kafka/KafkaConsumerSpec.scala
@@ -16,10 +16,6 @@ final class KafkaConsumerSpec extends BaseKafkaSpec {
     tests(_.stream)
   }
 
-  describe("KafkaConsumer#partitionedStream") {
-    tests(_.partitionedStream.parJoinUnbounded)
-  }
-
   type Consumer = KafkaConsumer[IO, String, String]
 
   type ConsumerStream = Stream[IO, CommittableMessage[IO, String, String]]


### PR DESCRIPTION
`partitionedStream.parJoinUnbounded` is essentially a more efficient version of the current `stream`, since it no longer couples fetch requests for different partitions, and enables prefetching of records.