### PR TITLE
Add ConsumerSettings#withMaxPrefetchBatches

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -45,7 +45,7 @@ lazy val dependencySettings = Seq(
 lazy val mdocSettings = Seq(
   mdoc := run.in(Compile).evaluated,
   scalacOptions -= "-Xfatal-warnings",
-  crossScalaVersions := Seq(scalaVersion.value),
+  crossScalaVersions := Seq(scalaVersion.value)
 )
 
 lazy val buildInfoSettings = Seq(
@@ -138,7 +138,12 @@ lazy val mimaSettings = Seq(
     import com.typesafe.tools.mima.core._
     // format: off
     Seq(
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.ProducerSettings.withDeliveryTimeout")
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.ProducerSettings.withDeliveryTimeout"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.ConsumerSettings#ConsumerSettingsImpl.apply"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.ConsumerSettings.withMaxPrefetchBatches"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.ConsumerSettings.maxPrefetchBatches"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.ConsumerSettings#ConsumerSettingsImpl.copy"),
+      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.ConsumerSettings#ConsumerSettingsImpl.this")
     )
     // format: on
   }
@@ -237,7 +242,8 @@ ensureReleaseNotesExists in ThisBuild := {
   val notes = releaseNotesFile.value
   if (!notes.isFile) {
     throw new IllegalStateException(
-      s"no release notes found for version [$currentVersion] at [$notes].")
+      s"no release notes found for version [$currentVersion] at [$notes]."
+    )
   }
 }
 

--- a/src/main/scala/fs2/kafka/internal/KafkaConsumerActor.scala
+++ b/src/main/scala/fs2/kafka/internal/KafkaConsumerActor.scala
@@ -45,6 +45,21 @@ import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.FiniteDuration
 
+/**
+  * [[KafkaConsumerActor]] wraps a Java `KafkaConsumer` and works similar to
+  * a traditional actor, in the sense that it receives requests one at-a-time
+  * via a queue, which are received as calls to the `handle` function. `Poll`
+  * requests are scheduled at a fixed interval and, when handled, calls the
+  * `KafkaConsumer#poll` function, allowing the Java consumer to perform
+  * necessary background functions, and to return fetched records.<br>
+  * <br>
+  * The actor receives `Fetch` requests for topic-partitions for which there
+  * is demand. The actor then attempts to fetch records for topic-partitions
+  * where there is a `Fetch` request. For topic-partitions where there is no
+  * request, no attempt to fetch records is made. This effectively enables
+  * backpressure, as long as `Fetch` requests are only issued when there
+  * is more demand.
+  */
 private[kafka] final class KafkaConsumerActor[F[_], K, V](
   settings: ConsumerSettings[K, V],
   executionContext: ExecutionContext,

--- a/src/test/scala/fs2/kafka/ConsumerSettingsSpec.scala
+++ b/src/test/scala/fs2/kafka/ConsumerSettingsSpec.scala
@@ -208,6 +208,26 @@ final class ConsumerSettingsSpec extends BaseSpec {
       }
     }
 
+    it("should provide withMaxPrefetchBatches") {
+      assert {
+        settings
+          .withMaxPrefetchBatches(3)
+          .maxPrefetchBatches == 3
+      }
+
+      assert {
+        settings
+          .withMaxPrefetchBatches(2)
+          .maxPrefetchBatches == 2
+      }
+
+      assert {
+        settings
+          .withMaxPrefetchBatches(1)
+          .maxPrefetchBatches == 2
+      }
+    }
+
     it("should have a Show instance and matching toString") {
       assert {
         settings.show == "ConsumerSettings(closeTimeout = 20 seconds, commitTimeout = 15 seconds, pollInterval = 50 milliseconds, pollTimeout = 50 milliseconds, commitRecovery = Default, consumerFactory = Default)" &&


### PR DESCRIPTION
This is an attempt to better document the backpressure in consumer streams. We add a new setting `maxPrefetchBatches` and corresponding setter `withMaxPrefetchBatches` to `ConsumerSettings`. An explanation of the backpressure and how this setting controls it is provided in the scaladoc.

Fixes #82.