### PR TITLE
Change to improve serialization ergonomics

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,6 +36,7 @@ lazy val dependencySettings = Seq(
   ),
   libraryDependencies ++= Seq(
     "org.scalatest" %% "scalatest" % "3.0.5",
+    "org.typelevel" %% "cats-testkit" % "1.6.0",
     "org.scalacheck" %% "scalacheck" % "1.14.0",
     "ch.qos.logback" % "logback-classic" % "1.2.3",
     "io.github.embeddedkafka" %% "embedded-kafka" % "2.1.0"
@@ -143,7 +144,10 @@ lazy val mimaSettings = Seq(
       ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.ConsumerSettings.withMaxPrefetchBatches"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.ConsumerSettings.maxPrefetchBatches"),
       ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.ConsumerSettings#ConsumerSettingsImpl.copy"),
-      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.ConsumerSettings#ConsumerSettingsImpl.this")
+      ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.ConsumerSettings#ConsumerSettingsImpl.this"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.Headers.asJava"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.Headers.withKey"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.Headers.concat")
     )
     // format: on
   }

--- a/docs/src/main/mdoc/quick-example.md
+++ b/docs/src/main/mdoc/quick-example.md
@@ -14,7 +14,6 @@ import cats.effect.{ExitCode, IO, IOApp}
 import cats.syntax.functor._
 import fs2.kafka._
 import org.apache.kafka.clients.consumer.ConsumerRecord
-import org.apache.kafka.common.serialization.{StringDeserializer, StringSerializer}
 import scala.concurrent.duration._
 
 object Main extends IOApp {
@@ -23,20 +22,14 @@ object Main extends IOApp {
       IO.pure(record.key -> record.value)
 
     val consumerSettings =
-      ConsumerSettings(
-        keyDeserializer = new StringDeserializer,
-        valueDeserializer = new StringDeserializer
-      )
-      .withAutoOffsetReset(AutoOffsetReset.Earliest)
-      .withBootstrapServers("localhost")
-      .withGroupId("group")
+      ConsumerSettings[String, String]
+        .withAutoOffsetReset(AutoOffsetReset.Earliest)
+        .withBootstrapServers("localhost")
+        .withGroupId("group")
 
     val producerSettings =
-      ProducerSettings(
-        keySerializer = new StringSerializer,
-        valueSerializer = new StringSerializer
-      )
-      .withBootstrapServers("localhost")
+      ProducerSettings[String, String]
+        .withBootstrapServers("localhost")
 
     val stream =
       producerStream[IO]

--- a/src/main/scala/fs2/kafka/Deserializer.scala
+++ b/src/main/scala/fs2/kafka/Deserializer.scala
@@ -1,0 +1,269 @@
+/*
+ * Copyright 2018-2019 OVO Energy Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fs2.kafka
+
+import cats.{Eval, Monad}
+import cats.syntax.either._
+import fs2.kafka.internal.syntax._
+import java.nio.charset.{Charset, StandardCharsets}
+import java.util.UUID
+import org.apache.kafka.common.utils.Bytes
+import scala.annotation.tailrec
+
+/**
+  * [[Deserializer]] is a functional Kafka deserializer which directly
+  * extends the Kafka `Deserializer` interface, but doesn't make use
+  * of `close` or `configure`. There is only a single function for
+  * deserialization, which provides access to the record headers.
+  */
+sealed abstract class Deserializer[A] extends KafkaDeserializer[A] {
+
+  /**
+    * Deserializes the specified bytes into a value of type `A`. The
+    * Kafka topic name, from which the serialized bytes came, and
+    * record headers are available.
+    */
+  def deserialize(topic: String, headers: Headers, bytes: Array[Byte]): A
+
+  /**
+    * Creates a new [[Deserializer]] which applies the specified
+    * function `f` to the result of this [[Deserializer]].
+    */
+  final def map[B](f: A => B): Deserializer[B] =
+    Deserializer.instance { (topic, headers, bytes) =>
+      f(deserialize(topic, headers, bytes))
+    }
+
+  /**
+    * Creates a new [[Deserializer]] using the result of
+    * this [[Deserializer]] and the specified function.
+    */
+  final def flatMap[B](f: A => Deserializer[B]): Deserializer[B] =
+    Deserializer.instance { (topic, headers, bytes) =>
+      f(deserialize(topic, headers, bytes))
+        .deserialize(topic, headers, bytes)
+    }
+
+  /**
+    * Creates a new [[Deserializer]] which deserializes both using
+    * this [[Deserializer]] and that [[Deserializer]], and returns
+    * both results in a tuple.
+    */
+  final def product[B](that: Deserializer[B]): Deserializer[(A, B)] =
+    Deserializer.instance { (topic, headers, bytes) =>
+      val a = deserialize(topic, headers, bytes)
+      val b = that.deserialize(topic, headers, bytes)
+      (a, b)
+    }
+
+  /**
+    * Creates a new [[Deserializer]] which does deserialization
+    * lazily by wrapping this [[Deserializer]] in `Eval.always`.
+    */
+  final def delay: Deserializer[Eval[A]] =
+    Deserializer.instance { (topic, headers, bytes) =>
+      Eval.always(deserialize(topic, headers, bytes))
+    }
+
+  /**
+    * Creates a new [[Deserializer]] which catches any non-fatal
+    * exceptions during deserialization with this [[Deserializer]].
+    */
+  final def attempt: Deserializer[Either[Throwable, A]] =
+    Deserializer.instance { (topic, headers, bytes) =>
+      Either.catchNonFatal(deserialize(topic, headers, bytes))
+    }
+
+  /** For interoperability with Kafka deserialization. */
+  final override def deserialize(topic: String, bytes: Array[Byte]): A =
+    deserialize(topic, Headers.empty, bytes)
+
+  /** For interoperability with Kafka deserialization. */
+  final override def deserialize(topic: String, headers: KafkaHeaders, bytes: Array[Byte]): A =
+    deserialize(topic, headers.asScala, bytes)
+
+  /** Always only returns `Unit`. For interoperability with Kafka deserialization. */
+  final override def configure(configs: java.util.Map[String, _], isKey: Boolean): Unit = ()
+
+  /** Always only returns `Unit`. For interoperability with Kafka deserialization. */
+  final override def close(): Unit = ()
+}
+
+object Deserializer {
+  def apply[A](
+    implicit deserializer: Deserializer[A]
+  ): Deserializer[A] = deserializer
+
+  def attempt[A](
+    implicit deserializer: Deserializer[Either[Throwable, A]]
+  ): Deserializer[Either[Throwable, A]] = deserializer
+
+  /**
+    * Creates a new [[Deserializer]] which deserializes
+    * all bytes to the specified value of type `A`.
+    */
+  def const[A](a: A): Deserializer[A] =
+    Deserializer.lift(_ => a)
+
+  /**
+    * Creates a new [[Deserializer]] which delegates deserialization
+    * to the specified Kafka `Deserializer`. Note that the `close`
+    * and `configure` functions won't be called for the delegate.
+    */
+  def delegate[A](deserializer: KafkaDeserializer[A]): Deserializer[A] =
+    Deserializer.instance { (topic, headers, bytes) =>
+      deserializer.deserialize(topic, headers.asJava, bytes)
+    }
+
+  /**
+    * Creates a new [[Deserializer]] which can use different
+    * [[Deserializer]]s depending on the record headers.
+    */
+  def headers[A](f: Headers => Deserializer[A]): Deserializer[A] =
+    Deserializer.instance { (topic, headers, bytes) =>
+      f(headers).deserialize(topic, headers, bytes)
+    }
+
+  /**
+    * Creates a new [[Deserializer]] from the specified function.
+    * Use [[lift]] instead if the deserializer doesn't need
+    * access to the Kafka topic name or record headers.
+    */
+  def instance[A](f: (String, Headers, Array[Byte]) => A): Deserializer[A] =
+    new Deserializer[A] {
+      override def deserialize(topic: String, headers: Headers, bytes: Array[Byte]): A =
+        f(topic, headers, bytes)
+
+      override def toString: String =
+        "Deserializer$" + System.identityHashCode(this)
+    }
+
+  /**
+    * Creates a new [[Deserializer]] from the specified function,
+    * ignoring from which Kafka topic the bytes came and any
+    * record headers. Use [[instance]] instead if the
+    * deserializer needs access to the Kafka topic
+    * name or the record headers.
+    */
+  def lift[A](f: Array[Byte] => A): Deserializer[A] =
+    Deserializer.instance((_, _, bytes) => f(bytes))
+
+  /**
+    * Creates a new [[Deserializer]] which can use different
+    * [[Deserializer]]s depending on the Kafka topic name
+    * from which the serialized bytes came.
+    */
+  def topic[A](f: String => Deserializer[A]): Deserializer[A] =
+    Deserializer.instance { (topic, headers, bytes) =>
+      f(topic).deserialize(topic, headers, bytes)
+    }
+
+  /**
+    * Creates a new [[Deserializer]] which deserializes `String`
+    * values using the specified `Charset`. Note that the
+    * default `String` deserializer uses `UTF-8`.
+    */
+  def string(charset: Charset): Deserializer[String] =
+    Deserializer.lift(bytes => new String(bytes, charset))
+
+  /**
+    * Creates a new [[Deserializer]] which deserializes `String`
+    * values using the specified `Charset` as `UUID`s. Note that
+    * the default `UUID` deserializer uses `UTF-8`.
+    */
+  def uuid(charset: Charset): Deserializer[Either[Throwable, UUID]] =
+    Deserializer.string(charset).map(UUID.fromString).attempt
+
+  /**
+    * The identity [[Deserializer]], which does not perform any kind
+    * of deserialization, simply using the input bytes as the output.
+    */
+  implicit val identity: Deserializer[Array[Byte]] =
+    Deserializer.lift(bytes => bytes)
+
+  implicit val monad: Monad[Deserializer] =
+    new Monad[Deserializer] {
+      override def pure[A](a: A): Deserializer[A] =
+        Deserializer.const(a)
+
+      override def map[A, B](
+        deserializer: Deserializer[A]
+      )(f: A => B): Deserializer[B] =
+        deserializer.map(f)
+
+      override def flatMap[A, B](
+        deserializer: Deserializer[A]
+      )(f: A => Deserializer[B]): Deserializer[B] =
+        deserializer.flatMap(f)
+
+      override def product[A, B](
+        first: Deserializer[A],
+        second: Deserializer[B]
+      ): Deserializer[(A, B)] =
+        first.product(second)
+
+      override def tailRecM[A, B](a: A)(f: A => Deserializer[Either[A, B]]): Deserializer[B] =
+        Deserializer.instance { (topic, headers, bytes) =>
+          @tailrec def go(deserializer: Deserializer[Either[A, B]]): B =
+            deserializer.deserialize(topic, headers, bytes) match {
+              case Right(b) => b
+              case Left(a)  => go(f(a))
+            }
+
+          go(f(a))
+        }
+    }
+
+  implicit val bytes: Deserializer[Bytes] =
+    Deserializer.identity.map(bytes => new Bytes(bytes))
+
+  implicit val double: Deserializer[Either[Throwable, Double]] =
+    Deserializer.delegate {
+      (new org.apache.kafka.common.serialization.DoubleDeserializer)
+        .asInstanceOf[org.apache.kafka.common.serialization.Deserializer[Double]]
+    }.attempt
+
+  implicit val float: Deserializer[Either[Throwable, Float]] =
+    Deserializer.delegate {
+      (new org.apache.kafka.common.serialization.FloatDeserializer)
+        .asInstanceOf[org.apache.kafka.common.serialization.Deserializer[Float]]
+    }.attempt
+
+  implicit val int: Deserializer[Either[Throwable, Int]] =
+    Deserializer.delegate {
+      (new org.apache.kafka.common.serialization.IntegerDeserializer)
+        .asInstanceOf[org.apache.kafka.common.serialization.Deserializer[Int]]
+    }.attempt
+
+  implicit val long: Deserializer[Either[Throwable, Long]] =
+    Deserializer.delegate {
+      (new org.apache.kafka.common.serialization.LongDeserializer)
+        .asInstanceOf[org.apache.kafka.common.serialization.Deserializer[Long]]
+    }.attempt
+
+  implicit val short: Deserializer[Either[Throwable, Short]] =
+    Deserializer.delegate {
+      (new org.apache.kafka.common.serialization.ShortDeserializer)
+        .asInstanceOf[org.apache.kafka.common.serialization.Deserializer[Short]]
+    }.attempt
+
+  implicit val string: Deserializer[String] =
+    Deserializer.string(StandardCharsets.UTF_8)
+
+  implicit val uuid: Deserializer[Either[Throwable, UUID]] =
+    Deserializer.string.map(UUID.fromString).attempt
+}

--- a/src/main/scala/fs2/kafka/HeaderDeserializer.scala
+++ b/src/main/scala/fs2/kafka/HeaderDeserializer.scala
@@ -1,0 +1,225 @@
+/*
+ * Copyright 2018-2019 OVO Energy Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fs2.kafka
+
+import cats.{Eval, Monad}
+import cats.syntax.either._
+import java.nio.charset.{Charset, StandardCharsets}
+import java.util.UUID
+import org.apache.kafka.common.utils.Bytes
+import scala.annotation.tailrec
+
+/**
+  * [[HeaderDeserializer]] is a functional deserializer for Kafka record
+  * header values. It's similar to [[Deserializer]], except it only has
+  * access to the header bytes, and it does not interoperate with the
+  * Kafka `Deserializer` interface.
+  */
+sealed abstract class HeaderDeserializer[A] {
+
+  /**
+    * Deserializes the header value bytes into a value of type `A`.
+    */
+  def deserialize(bytes: Array[Byte]): A
+
+  /**
+    * Creates a new [[HeaderDeserializer]] which applies the specified
+    * function `f` to the result of this [[HeaderDeserializer]].
+    */
+  final def map[B](f: A => B): HeaderDeserializer[B] =
+    HeaderDeserializer.instance { bytes =>
+      f(deserialize(bytes))
+    }
+
+  /**
+    * Creates a new [[HeaderDeserializer]] using the result of
+    * this [[HeaderDeserializer]] and the specified function.
+    */
+  final def flatMap[B](f: A => HeaderDeserializer[B]): HeaderDeserializer[B] =
+    HeaderDeserializer.instance { bytes =>
+      f(deserialize(bytes)).deserialize(bytes)
+    }
+
+  /**
+    * Creates a new [[HeaderDeserializer]] which deserializes both using
+    * this [[HeaderDeserializer]] and that [[HeaderDeserializer]], and
+    * returns both results in a tuple.
+    */
+  final def product[B](that: HeaderDeserializer[B]): HeaderDeserializer[(A, B)] =
+    HeaderDeserializer.instance { bytes =>
+      val a = deserialize(bytes)
+      val b = that.deserialize(bytes)
+      (a, b)
+    }
+
+  /**
+    * Creates a new [[HeaderDeserializer]] which does deserialization
+    * lazily by wrapping this [[HeaderDeserializer]] in `Eval.always`.
+    */
+  final def delay: HeaderDeserializer[Eval[A]] =
+    HeaderDeserializer.instance { bytes =>
+      Eval.always(deserialize(bytes))
+    }
+
+  /**
+    * Creates a new [[HeaderDeserializer]] which catches any non-fatal
+    * exceptions during deserialization with this [[HeaderDeserializer]].
+    */
+  final def attempt: HeaderDeserializer[Either[Throwable, A]] =
+    HeaderDeserializer.instance { bytes =>
+      Either.catchNonFatal(deserialize(bytes))
+    }
+}
+
+object HeaderDeserializer {
+  def apply[A](
+    implicit deserializer: HeaderDeserializer[A]
+  ): HeaderDeserializer[A] =
+    deserializer
+
+  def attempt[A](
+    implicit deserializer: HeaderDeserializer[Either[Throwable, A]]
+  ): HeaderDeserializer[Either[Throwable, A]] =
+    deserializer
+
+  /**
+    * Creates a new [[HeaderDeserializer]] which deserializes
+    * all bytes to the specified value of type `A`.
+    */
+  def const[A](a: A): HeaderDeserializer[A] =
+    HeaderDeserializer.instance(_ => a)
+
+  /**
+    * Creates a new [[HeaderDeserializer]] which delegates deserialization
+    * to the specified Kafka `Deserializer`. Please note that the `close`
+    * and `configure` functions won't be called for the delegate. Also,
+    * the topic is an empty `String` and no headers are provided.
+    */
+  def delegate[A](deserializer: KafkaDeserializer[A]): HeaderDeserializer[A] =
+    HeaderDeserializer.instance { bytes =>
+      deserializer.deserialize("", bytes)
+    }
+
+  /**
+    * Creates a new [[HeaderDeserializer]] from the specified function.
+    */
+  def instance[A](f: Array[Byte] => A): HeaderDeserializer[A] =
+    new HeaderDeserializer[A] {
+      override def deserialize(bytes: Array[Byte]): A =
+        f(bytes)
+
+      override def toString: String =
+        "HeaderDeserializer$" + System.identityHashCode(this)
+    }
+
+  /**
+    * Creates a new [[HeaderDeserializer]] which deserializes `String`
+    * values using the specified `Charset`. Note that the default
+    * `String` deserializer uses `UTF-8`.
+    */
+  def string(charset: Charset): HeaderDeserializer[String] =
+    HeaderDeserializer.instance(bytes => new String(bytes, charset))
+
+  /**
+    * Creates a new [[HeaderDeserializer]] which deserializes `String`
+    * values using the specified `Charset` as `UUID`s. Note that the
+    * default `UUID` deserializer uses `UTF-8`.
+    */
+  def uuid(charset: Charset): HeaderDeserializer[Either[Throwable, UUID]] =
+    HeaderDeserializer.string(charset).map(UUID.fromString).attempt
+
+  /**
+    * The identity [[HeaderDeserializer]], which does not perform any kind
+    * of deserialization, simply using the input bytes as the output.
+    */
+  implicit val identity: HeaderDeserializer[Array[Byte]] =
+    HeaderDeserializer.instance(bytes => bytes)
+
+  implicit val monad: Monad[HeaderDeserializer] =
+    new Monad[HeaderDeserializer] {
+      override def pure[A](a: A): HeaderDeserializer[A] =
+        HeaderDeserializer.const(a)
+
+      override def map[A, B](
+        deserializer: HeaderDeserializer[A]
+      )(f: A => B): HeaderDeserializer[B] =
+        deserializer.map(f)
+
+      override def flatMap[A, B](
+        deserializer: HeaderDeserializer[A]
+      )(f: A => HeaderDeserializer[B]): HeaderDeserializer[B] =
+        deserializer.flatMap(f)
+
+      override def product[A, B](
+        first: HeaderDeserializer[A],
+        second: HeaderDeserializer[B]
+      ): HeaderDeserializer[(A, B)] =
+        first.product(second)
+
+      override def tailRecM[A, B](a: A)(
+        f: A => HeaderDeserializer[Either[A, B]]
+      ): HeaderDeserializer[B] =
+        HeaderDeserializer.instance { bytes =>
+          @tailrec def go(deserializer: HeaderDeserializer[Either[A, B]]): B =
+            deserializer.deserialize(bytes) match {
+              case Right(b) => b
+              case Left(a)  => go(f(a))
+            }
+
+          go(f(a))
+        }
+    }
+
+  implicit val bytes: HeaderDeserializer[Bytes] =
+    HeaderDeserializer.identity.map(bytes => new Bytes(bytes))
+
+  implicit val double: HeaderDeserializer[Either[Throwable, Double]] =
+    HeaderDeserializer.delegate {
+      (new org.apache.kafka.common.serialization.DoubleDeserializer)
+        .asInstanceOf[org.apache.kafka.common.serialization.Deserializer[Double]]
+    }.attempt
+
+  implicit val float: HeaderDeserializer[Either[Throwable, Float]] =
+    HeaderDeserializer.delegate {
+      (new org.apache.kafka.common.serialization.FloatDeserializer)
+        .asInstanceOf[org.apache.kafka.common.serialization.Deserializer[Float]]
+    }.attempt
+
+  implicit val int: HeaderDeserializer[Either[Throwable, Int]] =
+    HeaderDeserializer.delegate {
+      (new org.apache.kafka.common.serialization.IntegerDeserializer)
+        .asInstanceOf[org.apache.kafka.common.serialization.Deserializer[Int]]
+    }.attempt
+
+  implicit val long: HeaderDeserializer[Either[Throwable, Long]] =
+    HeaderDeserializer.delegate {
+      (new org.apache.kafka.common.serialization.LongDeserializer)
+        .asInstanceOf[org.apache.kafka.common.serialization.Deserializer[Long]]
+    }.attempt
+
+  implicit val short: HeaderDeserializer[Either[Throwable, Short]] =
+    HeaderDeserializer.delegate {
+      (new org.apache.kafka.common.serialization.ShortDeserializer)
+        .asInstanceOf[org.apache.kafka.common.serialization.Deserializer[Short]]
+    }.attempt
+
+  implicit val string: HeaderDeserializer[String] =
+    HeaderDeserializer.string(StandardCharsets.UTF_8)
+
+  implicit val uuid: HeaderDeserializer[Either[Throwable, UUID]] =
+    HeaderDeserializer.string.map(UUID.fromString).attempt
+}

--- a/src/main/scala/fs2/kafka/HeaderSerializer.scala
+++ b/src/main/scala/fs2/kafka/HeaderSerializer.scala
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2018-2019 OVO Energy Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fs2.kafka
+
+import cats.Contravariant
+import java.nio.charset.{Charset, StandardCharsets}
+import java.util.UUID
+import org.apache.kafka.common.utils.Bytes
+
+/**
+  * [[HeaderSerializer]] is a functional serializer for Kafka record
+  * header values. It's similar to [[Serializer]], except it only
+  * has access to the value, and it does not interoperate with
+  * the Kafka `Serializer` interface.
+  */
+sealed abstract class HeaderSerializer[A] {
+
+  /**
+    * Serializes the specified value of type `A` into bytes.
+    */
+  def serialize(a: A): Array[Byte]
+
+  /**
+    * Creates a new [[HeaderSerializer]] which applies the specified
+    * function `f` on a value of type `B`, and then serializes the
+    * result with this [[HeaderSerializer]].
+    */
+  final def contramap[B](f: B => A): HeaderSerializer[B] =
+    HeaderSerializer.instance { b =>
+      serialize(f(b))
+    }
+
+  /**
+    * Creates a new [[HeaderSerializer]] which applies the specified
+    * function `f` on the output bytes of this [[HeaderSerializer]].
+    */
+  final def mapBytes(f: Array[Byte] => Array[Byte]): HeaderSerializer[A] =
+    HeaderSerializer.instance { bytes =>
+      f(serialize(bytes))
+    }
+}
+
+object HeaderSerializer {
+  def apply[A](implicit serializer: HeaderSerializer[A]): HeaderSerializer[A] = serializer
+
+  /**
+    * Creates a new [[HeaderSerializer]] which serializes
+    * all values of type `A` to the specified `bytes`.
+    */
+  def const[A](bytes: Array[Byte]): HeaderSerializer[A] =
+    HeaderSerializer.instance(_ => bytes)
+
+  /**
+    * Creates a new [[HeaderSerializer]] which delegates serialization
+    * to the specified Kafka `Serializer`. Note that the `close` and
+    * `configure` functions won't be called for the delegate. Also,
+    * the topic is an empty `String` and no headers are provided.
+    */
+  def delegate[A](serializer: KafkaSerializer[A]): HeaderSerializer[A] =
+    HeaderSerializer.instance { a =>
+      serializer.serialize("", a)
+    }
+
+  /**
+    * Creates a new [[HeaderSerializer]] from the specified function.
+    */
+  def instance[A](f: A => Array[Byte]): HeaderSerializer[A] =
+    new HeaderSerializer[A] {
+      override def serialize(a: A): Array[Byte] =
+        f(a)
+
+      override def toString: String =
+        "HeaderSerializer$" + System.identityHashCode(this)
+    }
+
+  /**
+    * Creates a new [[HeaderSerializer]] which serializes `String`
+    * values using the specified `Charset`. Note that the default
+    * `String` serializer uses `UTF-8`.
+    */
+  def string(charset: Charset): HeaderSerializer[String] =
+    HeaderSerializer.instance(_.getBytes(charset))
+
+  /**
+    * Creates a new [[HeaderSerializer]] which serializes `UUID` values
+    * as `String`s with the specified `Charset`. Note that the default
+    * `UUID` serializer uses `UTF-8.`
+    */
+  def uuid(charset: Charset): HeaderSerializer[UUID] =
+    HeaderSerializer.string(charset).contramap(_.toString)
+
+  /**
+    * The identity [[HeaderSerializer]], which does not perform
+    * serialization, simply using the input bytes as the output.
+    */
+  implicit val identity: HeaderSerializer[Array[Byte]] =
+    HeaderSerializer.instance(bytes => bytes)
+
+  implicit val contravariant: Contravariant[HeaderSerializer] =
+    new Contravariant[HeaderSerializer] {
+      override def contramap[A, B](
+        serializer: HeaderSerializer[A]
+      )(f: B => A): HeaderSerializer[B] =
+        serializer.contramap(f)
+    }
+
+  implicit val bytes: HeaderSerializer[Bytes] =
+    HeaderSerializer.identity.contramap(_.get)
+
+  implicit val double: HeaderSerializer[Double] =
+    HeaderSerializer.delegate {
+      (new org.apache.kafka.common.serialization.DoubleSerializer)
+        .asInstanceOf[org.apache.kafka.common.serialization.Serializer[Double]]
+    }
+
+  implicit val float: HeaderSerializer[Float] =
+    HeaderSerializer.delegate {
+      (new org.apache.kafka.common.serialization.FloatSerializer)
+        .asInstanceOf[org.apache.kafka.common.serialization.Serializer[Float]]
+    }
+
+  implicit val int: HeaderSerializer[Int] =
+    HeaderSerializer.delegate {
+      (new org.apache.kafka.common.serialization.IntegerSerializer)
+        .asInstanceOf[org.apache.kafka.common.serialization.Serializer[Int]]
+    }
+
+  implicit val long: HeaderSerializer[Long] =
+    HeaderSerializer.delegate {
+      (new org.apache.kafka.common.serialization.LongSerializer)
+        .asInstanceOf[org.apache.kafka.common.serialization.Serializer[Long]]
+    }
+
+  implicit val short: HeaderSerializer[Short] =
+    HeaderSerializer.delegate {
+      (new org.apache.kafka.common.serialization.ShortSerializer)
+        .asInstanceOf[org.apache.kafka.common.serialization.Serializer[Short]]
+    }
+
+  implicit val string: HeaderSerializer[String] =
+    HeaderSerializer.string(StandardCharsets.UTF_8)
+
+  implicit val uuid: HeaderSerializer[UUID] =
+    HeaderSerializer.string.contramap(_.toString)
+}

--- a/src/main/scala/fs2/kafka/Headers.scala
+++ b/src/main/scala/fs2/kafka/Headers.scala
@@ -16,9 +16,10 @@
 
 package fs2.kafka
 
-import cats.Show
 import cats.data.{Chain, NonEmptyChain}
+import cats.Show
 import fs2.kafka.internal.syntax._
+import org.apache.kafka.common.header.internals.RecordHeaders
 
 /**
   * [[Headers]] represent an immutable append-only collection
@@ -27,6 +28,21 @@ import fs2.kafka.internal.syntax._
   * instance of [[Header]] using `append`.
   */
 sealed abstract class Headers {
+
+  /**
+    * Returns the first header with the specified key,
+    * wrapped in `Some`, or `None` if no such header
+    * exists. Alias for [[withKey]].
+    */
+  final def apply(key: String): Option[Header] =
+    withKey(key)
+
+  /**
+    * Returns the first header with the specified key,
+    * wrapped in `Some`, or `None` if no such header
+    * exists. The [[apply]] function is an alias.
+    */
+  def withKey(key: String): Option[Header]
 
   /**
     * Creates a new [[Headers]] instance with the specified
@@ -40,6 +56,11 @@ sealed abstract class Headers {
     */
   def append(key: String, value: Array[Byte]): Headers
 
+  /**
+    * Appends the specified [[Headers]] after these headers.
+    */
+  def concat(that: Headers): Headers
+
   /** The included [[Header]]s as a `Chain`. */
   def toChain: Chain[Header]
 
@@ -49,23 +70,42 @@ sealed abstract class Headers {
   /** `true` if no [[Header]]s are included; otherwise `false`. */
   def isEmpty: Boolean
 
+  /** The [[Headers]] as an immutable Java Kafka `Headers` instance. */
+  def asJava: KafkaHeaders
 }
 
 object Headers {
   private[this] final class HeadersImpl(
     val headers: NonEmptyChain[Header]
   ) extends Headers {
+    override def withKey(key: String): Option[Header] =
+      headers.find(_.key == key)
+
     override def append(header: Header): Headers =
       new HeadersImpl(headers.append(header))
 
     override def append(key: String, value: Array[Byte]): Headers =
       append(Header(key, value))
 
+    override def concat(that: Headers): Headers = {
+      if (that.isEmpty) this
+      else new HeadersImpl(headers.appendChain(that.toChain))
+    }
+
     override def toChain: Chain[Header] =
       headers.toChain
 
     override val isEmpty: Boolean =
       false
+
+    override def asJava: KafkaHeaders = {
+      val headers: Array[KafkaHeader] =
+        toChain.iterator.toArray
+
+      val recordHeaders = new RecordHeaders(headers)
+      recordHeaders.setReadOnly()
+      recordHeaders
+    }
 
     override def toString: String =
       headers.mkStringAppend { (append, header) =>
@@ -95,20 +135,46 @@ object Headers {
     if (headers.isEmpty) empty
     else new HeadersImpl(NonEmptyChain.fromChainUnsafe(headers))
 
+  /**
+    * Creates a new [[Headers]] instance from the specified
+    * `Seq` of [[Header]]s.
+    */
+  def fromSeq(headers: Seq[Header]): Headers =
+    fromChain(Chain.fromSeq(headers))
+
+  /**
+    * Creates a new [[Headers]] instance from the specified
+    * `Iterable` of [[Header]]s.
+    */
+  def fromIterable(headers: Iterable[Header]): Headers =
+    fromSeq(headers.toSeq)
+
   /** The empty [[Headers]] instance without any [[Header]]s. */
   val empty: Headers =
     new Headers {
+      override def withKey(key: String): Option[Header] =
+        None
+
       override def append(header: Header): Headers =
         new HeadersImpl(NonEmptyChain.one(header))
 
       override def append(key: String, value: Array[Byte]): Headers =
         append(Header(key, value))
 
+      override def concat(that: Headers): Headers =
+        that
+
       override val toChain: Chain[Header] =
         Chain.empty
 
       override val isEmpty: Boolean =
         true
+
+      override val asJava: KafkaHeaders = {
+        val headers = new RecordHeaders()
+        headers.setReadOnly()
+        headers
+      }
 
       override def toString: String =
         "Headers()"

--- a/src/main/scala/fs2/kafka/KafkaProducer.scala
+++ b/src/main/scala/fs2/kafka/KafkaProducer.scala
@@ -140,17 +140,8 @@ private[kafka] object KafkaProducer {
             else null,
             record.key,
             record.value,
-            asJavaHeaders(record.headers)
+            record.headers.asJava
           )
-
-        private[this] def asJavaHeaders(
-          headers: Headers
-        ): org.apache.kafka.common.header.Headers = {
-          val empty: org.apache.kafka.common.header.Headers =
-            new org.apache.kafka.common.header.internals.RecordHeaders()
-
-          headers.toChain.foldLeft(empty)(_ add _)
-        }
 
         private[this] def callback(f: (RecordMetadata, Throwable) => Unit): Callback =
           new Callback {

--- a/src/main/scala/fs2/kafka/Serializer.scala
+++ b/src/main/scala/fs2/kafka/Serializer.scala
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2018-2019 OVO Energy Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fs2.kafka
+
+import cats.Contravariant
+import fs2.kafka.internal.syntax._
+import java.nio.charset.{Charset, StandardCharsets}
+import java.util.UUID
+import org.apache.kafka.common.utils.Bytes
+
+/**
+  * [[Serializer]] is a functional Kafka serializer which directly
+  * extends the Kafka `Serializer` interface, but doesn't make use
+  * of `close` or `configure`. There is only a single function for
+  * serialization, which provides access to the record headers.
+  */
+sealed abstract class Serializer[A] extends KafkaSerializer[A] {
+
+  /**
+    * Serializes the specified value of type `A` into bytes. The
+    * Kafka topic name, to which the serialized bytes are going
+    * to be sent, and record headers are available.
+    */
+  def serialize(topic: String, headers: Headers, a: A): Array[Byte]
+
+  /**
+    * Creates a new [[Serializer]] which applies the specified
+    * function `f` on a value of type `B`, and then serializes
+    * the result with this [[Serializer]].
+    */
+  final def contramap[B](f: B => A): Serializer[B] =
+    Serializer.instance { (topic, headers, b) =>
+      serialize(topic, headers, f(b))
+    }
+
+  /**
+    * Creates a new [[Serializer]] which applies the specified
+    * function `f` on the output bytes of this [[Serializer]].
+    */
+  final def mapBytes(f: Array[Byte] => Array[Byte]): Serializer[A] =
+    Serializer.instance { (topic, headers, a) =>
+      f(serialize(topic, headers, a))
+    }
+
+  /** For interoperability with Kafka serialization. */
+  final override def serialize(topic: String, a: A): Array[Byte] =
+    serialize(topic, Headers.empty, a)
+
+  /** For interoperability with Kafka serialization. */
+  final override def serialize(topic: String, headers: KafkaHeaders, a: A): Array[Byte] =
+    serialize(topic, headers.asScala, a)
+
+  /** Always only returns `Unit`. For interoperability with Kafka serialization. */
+  final override def configure(configs: java.util.Map[String, _], isKey: Boolean): Unit = ()
+
+  /** Always only returns `Unit`. For interoperability with Kafka serialization. */
+  final override def close(): Unit = ()
+}
+
+object Serializer {
+  def apply[A](implicit serializer: Serializer[A]): Serializer[A] = serializer
+
+  /**
+    * Creates a new [[Serializer]] which serializes
+    * all values of type `A` to the specified `bytes`.
+    */
+  def const[A](bytes: Array[Byte]): Serializer[A] =
+    Serializer.lift(_ => bytes)
+
+  /**
+    * Creates a new [[Serializer]] which delegates serialization
+    * to the specified Kafka `Serializer`. Note the `close` and
+    * `configure` functions won't be called for the delegate.
+    */
+  def delegate[A](serializer: KafkaSerializer[A]): Serializer[A] =
+    Serializer.instance { (topic, headers, a) =>
+      serializer.serialize(topic, headers.asJava, a)
+    }
+
+  /**
+    * Creates a new [[Serializer]] which can use different
+    * [[Serializer]]s depending on the record headers.
+    */
+  def headers[A](f: Headers => Serializer[A]): Serializer[A] =
+    Serializer.instance { (topic, headers, a) =>
+      f(headers).serialize(topic, headers, a)
+    }
+
+  /**
+    * Creates a new [[Serializer]] from the specified function.
+    * Use [[lift]] instead if the serializer doesn't need
+    * access to the Kafka topic name or record headers.
+    */
+  def instance[A](f: (String, Headers, A) => Array[Byte]): Serializer[A] =
+    new Serializer[A] {
+      override def serialize(topic: String, headers: Headers, a: A): Array[Byte] =
+        f(topic, headers, a)
+
+      override def toString: String =
+        "Serializer$" + System.identityHashCode(this)
+    }
+
+  /**
+    * Creates a new [[Serializer]] from the specified function,
+    * ignoring to which Kafka topic the bytes are going to be
+    * sent and any record headers. Use [[instance]] instead
+    * if the serializer needs access to the Kafka topic
+    * name or the record headers.
+    */
+  def lift[A](f: A => Array[Byte]): Serializer[A] =
+    Serializer.instance((_, _, a) => f(a))
+
+  /**
+    * Creates a new [[Serializer]] which can use different
+    * [[Serializer]]s depending on the Kafka topic name to
+    * which the bytes are going to be sent.
+    */
+  def topic[A](f: String => Serializer[A]): Serializer[A] =
+    Serializer.instance { (topic, headers, a) =>
+      f(topic).serialize(topic, headers, a)
+    }
+
+  /**
+    * Creates a new [[Serializer]] which serializes `String`
+    * values using the specified `Charset`. Note that the
+    * default `String` serializer uses `UTF-8`.
+    */
+  def string(charset: Charset): Serializer[String] =
+    Serializer.lift(_.getBytes(charset))
+
+  /**
+    * Creates a new [[Serializer]] which serializes `UUID` values
+    * as `String`s with the specified `Charset`. Note that the
+    * default `UUID` serializer uses `UTF-8.`
+    */
+  def uuid(charset: Charset): Serializer[UUID] =
+    Serializer.string(charset).contramap(_.toString)
+
+  /**
+    * The identity [[Serializer]], which does not perform any kind
+    * of serialization, simply using the input bytes as the output.
+    */
+  implicit val identity: Serializer[Array[Byte]] =
+    Serializer.lift(bytes => bytes)
+
+  implicit val contravariant: Contravariant[Serializer] =
+    new Contravariant[Serializer] {
+      override def contramap[A, B](serializer: Serializer[A])(f: B => A): Serializer[B] =
+        serializer.contramap(f)
+    }
+
+  implicit val bytes: Serializer[Bytes] =
+    Serializer.identity.contramap(_.get)
+
+  implicit val double: Serializer[Double] =
+    Serializer.delegate {
+      (new org.apache.kafka.common.serialization.DoubleSerializer)
+        .asInstanceOf[org.apache.kafka.common.serialization.Serializer[Double]]
+    }
+
+  implicit val float: Serializer[Float] =
+    Serializer.delegate {
+      (new org.apache.kafka.common.serialization.FloatSerializer)
+        .asInstanceOf[org.apache.kafka.common.serialization.Serializer[Float]]
+    }
+
+  implicit val int: Serializer[Int] =
+    Serializer.delegate {
+      (new org.apache.kafka.common.serialization.IntegerSerializer)
+        .asInstanceOf[org.apache.kafka.common.serialization.Serializer[Int]]
+    }
+
+  implicit val long: Serializer[Long] =
+    Serializer.delegate {
+      (new org.apache.kafka.common.serialization.LongSerializer)
+        .asInstanceOf[org.apache.kafka.common.serialization.Serializer[Long]]
+    }
+
+  implicit val short: Serializer[Short] =
+    Serializer.delegate {
+      (new org.apache.kafka.common.serialization.ShortSerializer)
+        .asInstanceOf[org.apache.kafka.common.serialization.Serializer[Short]]
+    }
+
+  implicit val string: Serializer[String] =
+    Serializer.string(StandardCharsets.UTF_8)
+
+  implicit val uuid: Serializer[UUID] =
+    Serializer.string.contramap(_.toString)
+}

--- a/src/main/scala/fs2/kafka/internal/syntax.scala
+++ b/src/main/scala/fs2/kafka/internal/syntax.scala
@@ -16,18 +16,17 @@
 
 package fs2.kafka.internal
 
+import cats.{Foldable, Show}
+import cats.effect.{CancelToken, Concurrent, Sync}
+import cats.syntax.foldable._
+import cats.syntax.show._
+import fs2.kafka.{Header, Headers, KafkaHeaders}
 import java.time.Duration
 import java.time.temporal.ChronoUnit
 import java.util
 import java.util.concurrent.{CancellationException, CompletionException, TimeUnit}
-
-import cats.effect.{CancelToken, Concurrent, Sync}
-import cats.syntax.foldable._
-import cats.syntax.show._
-import cats.{Foldable, Show}
 import org.apache.kafka.common.KafkaFuture
 import org.apache.kafka.common.KafkaFuture.{BaseFunction, BiConsumer}
-
 import scala.collection.immutable.SortedSet
 import scala.concurrent.duration.FiniteDuration
 
@@ -189,6 +188,17 @@ private[kafka] object syntax {
             }
           })
           .cancelToken
+      }
+  }
+
+  implicit final class KafkaHeadersSyntax(
+    private val headers: KafkaHeaders
+  ) extends AnyVal {
+    def asScala: Headers =
+      Headers.fromSeq {
+        headers.toArray.map { header =>
+          Header(header.key, header.value)
+        }
       }
   }
 }

--- a/src/main/scala/fs2/kafka/package.scala
+++ b/src/main/scala/fs2/kafka/package.scala
@@ -28,6 +28,18 @@ import scala.concurrent.duration.FiniteDuration
 package object kafka {
   private[kafka] type Id[+A] = A
 
+  private[kafka] type KafkaDeserializer[A] =
+    org.apache.kafka.common.serialization.Deserializer[A]
+
+  private[kafka] type KafkaSerializer[A] =
+    org.apache.kafka.common.serialization.Serializer[A]
+
+  private[kafka] type KafkaHeader =
+    org.apache.kafka.common.header.Header
+
+  private[kafka] type KafkaHeaders =
+    org.apache.kafka.common.header.Headers
+
   /**
     * Commits offsets in batches determined by the `Chunk`s of the
     * underlying `Stream`. If you want more explicit control over

--- a/src/test/scala/fs2/kafka/BaseCatsSpec.scala
+++ b/src/test/scala/fs2/kafka/BaseCatsSpec.scala
@@ -1,0 +1,52 @@
+package fs2.kafka
+
+import cats._
+import cats.tests._
+import org.scalacheck._
+import scala.util.Try
+
+trait BaseCatsSpec extends CatsSuite with BaseGenerators {
+  implicit def deserializerEq[A](implicit A: Eq[A]): Eq[Deserializer[A]] =
+    Eq.instance { (d1, d2) =>
+      Try {
+        forAll { (topic: String, headers: Headers, bytes: Array[Byte]) =>
+          val r1 = d1.deserialize(topic, headers, bytes)
+          val r2 = d2.deserialize(topic, headers, bytes)
+          (r1 === r2) shouldBe true
+        }
+      }.isSuccess
+    }
+
+  implicit def serializerEq[A](implicit A: Arbitrary[A]): Eq[Serializer[A]] =
+    Eq.instance { (s1, s2) =>
+      Try {
+        forAll { (topic: String, headers: Headers, a: A) =>
+          val r1 = s1.serialize(topic, headers, a)
+          val r2 = s2.serialize(topic, headers, a)
+          r1 should contain theSameElementsInOrderAs (r2)
+        }
+      }.isSuccess
+    }
+
+  implicit def headerSerializerEq[A](implicit A: Arbitrary[A]): Eq[HeaderSerializer[A]] =
+    Eq.instance { (s1, s2) =>
+      Try {
+        forAll { a: A =>
+          val r1 = s1.serialize(a)
+          val r2 = s2.serialize(a)
+          r1 should contain theSameElementsInOrderAs (r2)
+        }
+      }.isSuccess
+    }
+
+  implicit def headerDeserializerEq[A](implicit A: Eq[A]): Eq[HeaderDeserializer[A]] =
+    Eq.instance { (d1, d2) =>
+      Try {
+        forAll { bytes: Array[Byte] =>
+          val r1 = d1.deserialize(bytes)
+          val r2 = d2.deserialize(bytes)
+          (r1 === r2) shouldBe true
+        }
+      }.isSuccess
+    }
+}

--- a/src/test/scala/fs2/kafka/BaseSpec.scala
+++ b/src/test/scala/fs2/kafka/BaseSpec.scala
@@ -1,6 +1,11 @@
 package fs2.kafka
 
-import org.scalatest.prop.PropertyChecks
-import org.scalatest.{Assertions, FunSpec}
+import org.scalatest._
+import org.scalatest.prop._
 
-abstract class BaseSpec extends FunSpec with Assertions with PropertyChecks with BaseGenerators
+abstract class BaseSpec
+    extends FunSpec
+    with Assertions
+    with Matchers
+    with PropertyChecks
+    with BaseGenerators

--- a/src/test/scala/fs2/kafka/DeserializerSpec.scala
+++ b/src/test/scala/fs2/kafka/DeserializerSpec.scala
@@ -1,0 +1,78 @@
+package fs2.kafka
+
+import cats.laws.discipline._
+import scala.collection.JavaConverters._
+
+final class DeserializerSpec extends BaseCatsSpec {
+  checkAll("Deserializer", MonadTests[Deserializer].monad[String, String, String])
+
+  // Always only returns `Unit`. Invoked to include in coverage.
+  test("Deserializer#configure") { Deserializer[String].configure(Map.empty.asJava, true) }
+  test("Deserializer#close") { Deserializer[String].close() }
+
+  test("Deserializer#delay") {
+    var deserialized = false
+
+    val deserializer =
+      Deserializer.lift { bytes =>
+        deserialized = true
+        bytes
+      }.delay
+
+    val eval = deserializer.deserialize("", Array())
+    assert(!deserialized)
+
+    val result = eval.value
+    assert(deserialized)
+    assert(result.isEmpty)
+  }
+
+  test("Deserializer#headers") {
+    val deserializer =
+      Deserializer.headers { headers =>
+        headers("format").map(_.as[String]) match {
+          case Some("int") => Deserializer.attempt[Int]
+          case _           => Deserializer[String].map(_.toInt).attempt
+        }
+      }
+
+    forAll { (topic: String, i: Int) =>
+      val headers = Header.serialize("format", "int").headers
+      val serialized = Serializer[Int].serialize(topic, i)
+      val deserialized = deserializer.deserialize(topic, headers, serialized)
+      deserialized shouldBe Right(i)
+    }
+
+    forAll { (topic: String, i: Int) =>
+      val serialized = Serializer[String].contramap[Int](_.toString).serialize(topic, i)
+      val deserialized = Deserializer[String].map(_.toInt).attempt.deserialize(topic, serialized)
+      deserialized shouldBe Right(i)
+    }
+  }
+
+  test("Deserializer#topic") {
+    val deserializer =
+      Deserializer.topic {
+        case "topic" => Deserializer.attempt[Int]
+        case _       => Deserializer[String].map(_.toInt).attempt
+      }
+
+    forAll { i: Int =>
+      val serialized = Serializer[Int].serialize("topic", i)
+      val deserialized = deserializer.deserialize("topic", serialized)
+      deserialized shouldBe Right(i)
+    }
+
+    forAll { (topic: String, i: Int) =>
+      whenever(topic != "topic") {
+        val serialized = Serializer[String].contramap[Int](_.toString).serialize(topic, i)
+        val deserialized = Deserializer[String].map(_.toInt).attempt.deserialize(topic, serialized)
+        deserialized shouldBe Right(i)
+      }
+    }
+  }
+
+  test("Deserializer#toString") {
+    assert(Deserializer[String].toString startsWith "Deserializer$")
+  }
+}

--- a/src/test/scala/fs2/kafka/HeaderDeserializerSpec.scala
+++ b/src/test/scala/fs2/kafka/HeaderDeserializerSpec.scala
@@ -1,0 +1,28 @@
+package fs2.kafka
+
+import cats.laws.discipline._
+
+final class HeaderDeserializerSpec extends BaseCatsSpec {
+  checkAll("HeaderDeserializer", MonadTests[HeaderDeserializer].monad[String, String, String])
+
+  test("HeaderDeserializer#delay") {
+    var deserialized = false
+
+    val deserializer =
+      HeaderDeserializer.instance { bytes =>
+        deserialized = true
+        bytes
+      }.delay
+
+    val eval = deserializer.deserialize(Array())
+    assert(!deserialized)
+
+    val result = eval.value
+    assert(deserialized)
+    assert(result.isEmpty)
+  }
+
+  test("HeaderDeserializer#toString") {
+    assert(HeaderDeserializer[String].toString startsWith "HeaderDeserializer$")
+  }
+}

--- a/src/test/scala/fs2/kafka/HeaderSerializerSpec.scala
+++ b/src/test/scala/fs2/kafka/HeaderSerializerSpec.scala
@@ -1,0 +1,104 @@
+package fs2.kafka
+
+import cats._
+import cats.laws.discipline._
+import java.nio.charset._
+import org.scalacheck._
+import org.scalatest._
+
+final class HeaderSerializerSpec extends BaseCatsSpec {
+  checkAll(
+    "HeaderSerializer",
+    ContravariantTests[HeaderSerializer].contravariant[String, String, String]
+  )
+
+  test("HeaderSerializer#mapBytes") {
+    val serializer =
+      HeaderSerializer.identity
+        .mapBytes(Array(0.toByte) ++ _)
+
+    forAll { bytes: Array[Byte] =>
+      serializer.serialize(bytes) shouldBe (Array(0.toByte) ++ bytes)
+    }
+  }
+
+  test("HeaderSerializer#const") {
+    val serializer =
+      HeaderSerializer.const[Int](Array())
+
+    forAll { i: Int =>
+      serializer.serialize(i).isEmpty shouldBe true
+    }
+  }
+
+  test("HeaderSerializer#toString") {
+    assert(HeaderSerializer[Int].toString startsWith "HeaderSerializer$")
+  }
+
+  def roundtrip[A: Arbitrary: Eq](
+    serializer: HeaderSerializer[A],
+    deserializer: HeaderDeserializer[A]
+  ): Assertion = forAll { a: A =>
+    val serialized = serializer.serialize(a)
+    val deserialized = deserializer.deserialize(serialized)
+    assert(deserialized === a)
+  }
+
+  def roundtripAttempt[A: Arbitrary: Eq](
+    serializer: HeaderSerializer[A],
+    deserializer: HeaderDeserializer[Either[Throwable, A]]
+  ): Assertion = forAll { a: A =>
+    val serialized = serializer.serialize(a)
+    val deserialized = deserializer.deserialize(serialized)
+    assert(deserialized.toOption === Option(a))
+  }
+
+  test("HeaderSerializer#string") {
+    roundtrip(
+      HeaderSerializer.string(StandardCharsets.UTF_8),
+      HeaderDeserializer.string(StandardCharsets.UTF_8)
+    )
+  }
+
+  test("Serializer#uuid") {
+    roundtripAttempt(
+      HeaderSerializer.uuid(StandardCharsets.UTF_8),
+      HeaderDeserializer.uuid(StandardCharsets.UTF_8)
+    )
+  }
+
+  test("HeaderSerializer#double") {
+    roundtripAttempt(
+      HeaderSerializer.double,
+      HeaderDeserializer.double
+    )
+  }
+
+  test("HeaderSerializer#float") {
+    roundtripAttempt(
+      HeaderSerializer.float,
+      HeaderDeserializer.float
+    )
+  }
+
+  test("HeaderSerializer#int") {
+    roundtripAttempt(
+      HeaderSerializer.int,
+      HeaderDeserializer.int
+    )
+  }
+
+  test("HeaderSerializer#long") {
+    roundtripAttempt(
+      HeaderSerializer.long,
+      HeaderDeserializer.long
+    )
+  }
+
+  test("HeaderSerializer#short") {
+    roundtripAttempt(
+      HeaderSerializer.short,
+      HeaderDeserializer.short
+    )
+  }
+}

--- a/src/test/scala/fs2/kafka/HeaderSpec.scala
+++ b/src/test/scala/fs2/kafka/HeaderSpec.scala
@@ -25,5 +25,19 @@ final class HeaderSpec extends BaseSpec {
       val value = Array[Byte]()
       assert(Header("key", value).value == value)
     }
+
+    it("should deserialize with as") {
+      forAll { s: String =>
+        val header = Header("key", s.getBytes)
+        assert(header.as[String] == s)
+      }
+    }
+
+    it("should deserialize with attemptAs") {
+      forAll { i: Int =>
+        val header = Header.serialize("key", i)
+        assert(header.attemptAs[Int] == Right(i))
+      }
+    }
   }
 }

--- a/src/test/scala/fs2/kafka/HeadersSpec.scala
+++ b/src/test/scala/fs2/kafka/HeadersSpec.scala
@@ -11,8 +11,29 @@ final class HeadersSpec extends BaseSpec {
       assert(Headers.empty.isEmpty)
     }
 
+    it("should return false for nonEmpty") {
+      assert(!Headers.empty.nonEmpty)
+    }
+
+    it("should not find any key") {
+      assert(Headers.empty("key").isEmpty)
+    }
+
+    it("should concat empty") {
+      assert(Headers.empty.concat(Headers.empty).isEmpty)
+    }
+
+    it("should concat non-empty") {
+      val headers = Header("key", Array()).headers
+      assert(Headers.empty.concat(headers).toChain.size == 1)
+    }
+
     it("should return empty Chain from toChain") {
       assert(Headers.empty.toChain.isEmpty)
+    }
+
+    it("should return empty from asJava") {
+      assert(Headers.empty.asJava.toArray.isEmpty)
     }
 
     it("should create a new Headers from append(Header)") {
@@ -34,6 +55,38 @@ final class HeadersSpec extends BaseSpec {
       assert(!Headers(Header("key", Array())).isEmpty)
     }
 
+    it("should be non empty") {
+      assert(Headers(Header("key", Array())).nonEmpty)
+    }
+
+    it("should find an existing key") {
+      assert(Headers(Header("key", Array()))("key").isDefined)
+    }
+
+    it("should find the first key") {
+      val headers =
+        Headers(
+          Header("key", Array(1)),
+          Header("key", Array(2))
+        )
+
+      assert(headers("key").map(_.value.head) == Some(1.toByte))
+    }
+
+    it("should return non-empty from asJava") {
+      assert(Headers(Header("key", Array())).asJava.toArray.size == 1)
+    }
+
+    it("should concat empty") {
+      val headers = Header("key", Array()).headers
+      assert(headers.concat(Headers.empty).toChain.size == 1)
+    }
+
+    it("should concat non-empty") {
+      val headers = Header("key", Array()).headers
+      assert(headers.concat(headers).toChain.size == 2)
+    }
+
     it("should include the headers in toString") {
       val headers = Chain(Header("key1", Array()), Header("key2", Array()))
       assert(Headers.fromChain(headers).toString == "Headers(key1 -> [], key2 -> [])")
@@ -43,11 +96,11 @@ final class HeadersSpec extends BaseSpec {
       val header1 = Header("key1", Array())
       val header2 = Header("key2", Array())
 
-      Headers(header1).append(header2).toChain == Chain(header1, header2)
+      assert(Headers(header1).append(header2).toChain.size == 2)
     }
 
     it("should append one more header with append(key, value)") {
-      Headers(Header("key1", Array())).append("key2", Array()).toChain.size == 2
+      assert(Headers(Header("key1", Array())).append("key2", Array()).toChain.size == 2)
     }
   }
 
@@ -58,7 +111,7 @@ final class HeadersSpec extends BaseSpec {
 
     it("returns non-empty for at least one header") {
       val header = Header("key", Array())
-      Headers(header).toChain == Chain.one(header)
+      assert(Headers(header).toChain == Chain.one(header))
     }
   }
 
@@ -70,6 +123,28 @@ final class HeadersSpec extends BaseSpec {
     it("returns non-empty for non-empty chain") {
       val headers = Chain(Header("key1", Array()), Header("key2", Array()))
       assert(Headers.fromChain(headers).toChain == headers)
+    }
+  }
+
+  describe("Headers#fromSeq") {
+    it("returns empty for empty seq") {
+      assert(Headers.fromSeq(Seq.empty) == Headers.empty)
+    }
+
+    it("returns non-empty for non-empty seq") {
+      val headers = Seq(Header("key1", Array()), Header("key2", Array()))
+      assert(Headers.fromSeq(headers).toChain == Chain.fromSeq(headers))
+    }
+  }
+
+  describe("Headers#fromIterable") {
+    it("returns empty for empty iterable") {
+      assert(Headers.fromIterable(List.empty) == Headers.empty)
+    }
+
+    it("returns non-empty for non-empty iterable") {
+      val headers = List(Header("key1", Array()), Header("key2", Array()))
+      assert(Headers.fromIterable(headers).toChain == Chain.fromSeq(headers))
     }
   }
 }

--- a/src/test/scala/fs2/kafka/SerializerSpec.scala
+++ b/src/test/scala/fs2/kafka/SerializerSpec.scala
@@ -1,0 +1,151 @@
+package fs2.kafka
+
+import cats.Eq
+import cats.laws.discipline._
+import java.nio.charset.StandardCharsets
+import org.scalacheck.Arbitrary
+import org.scalatest._
+import scala.collection.JavaConverters._
+
+final class SerializerSpec extends BaseCatsSpec {
+  checkAll("Serializer", ContravariantTests[Serializer].contravariant[String, String, String])
+
+  // Always only returns `Unit`. Invoked to include in coverage.
+  test("Serializer#configure") { Serializer[Int].configure(Map.empty.asJava, true) }
+  test("Serializer#close") { Serializer[Int].close() }
+
+  test("Serializer#mapBytes") {
+    val serializer =
+      Serializer.identity
+        .mapBytes(Array(0.toByte) ++ _)
+
+    forAll { (topic: String, bytes: Array[Byte]) =>
+      serializer.serialize(topic, bytes) shouldBe (Array(0.toByte) ++ bytes)
+    }
+  }
+
+  test("Serializer#const") {
+    val serializer =
+      Serializer.const[Int](Array())
+
+    forAll { (topic: String, i: Int) =>
+      serializer.serialize(topic, i).isEmpty shouldBe true
+    }
+  }
+
+  test("Serializer#headers") {
+    val serializer =
+      Serializer.headers { headers =>
+        headers("format").map(_.as[String]) match {
+          case Some("int") => Serializer[Int]
+          case _           => Serializer[String].contramap[Int](_.toString)
+        }
+      }
+
+    forAll { (topic: String, i: Int) =>
+      val headers = Header.serialize("format", "int").headers
+      val serialized = serializer.serialize(topic, headers, i)
+      val expected = Serializer[Int].serialize(topic, i)
+      serialized shouldBe expected
+    }
+
+    forAll { (topic: String, i: Int) =>
+      val serialized = serializer.serialize(topic, i)
+      val expected = Serializer[String].contramap[Int](_.toString).serialize(topic, i)
+      serialized shouldBe expected
+    }
+  }
+
+  test("Serializer#topic") {
+    val serializer =
+      Serializer.topic {
+        case "topic" => Serializer[Int]
+        case _       => Serializer[String].contramap[Int](_.toString)
+      }
+
+    forAll { i: Int =>
+      val serialized = serializer.serialize("topic", i)
+      val expected = Serializer[Int].serialize("topic", i)
+      serialized shouldBe expected
+    }
+
+    forAll { (topic: String, i: Int) =>
+      whenever(topic != "topic") {
+        val serialized = serializer.serialize(topic, i)
+        val expected = Serializer[String].contramap[Int](_.toString).serialize(topic, i)
+        serialized shouldBe expected
+      }
+    }
+  }
+
+  test("Serializer#toString") {
+    assert(Serializer[Int].toString startsWith "Serializer$")
+  }
+
+  def roundtrip[A: Arbitrary: Eq](
+    serializer: Serializer[A],
+    deserializer: Deserializer[A]
+  ): Assertion = forAll { (topic: String, headers: Headers, a: A) =>
+    val serialized = serializer.serialize(topic, headers, a)
+    val deserialized = deserializer.deserialize(topic, headers, serialized)
+    assert(deserialized === a)
+  }
+
+  def roundtripAttempt[A: Arbitrary: Eq](
+    serializer: Serializer[A],
+    deserializer: Deserializer[Either[Throwable, A]]
+  ): Assertion = forAll { (topic: String, headers: Headers, a: A) =>
+    val serialized = serializer.serialize(topic, headers, a)
+    val deserialized = deserializer.deserialize(topic, headers, serialized)
+    assert(deserialized.toOption === Option(a))
+  }
+
+  test("Serializer#string") {
+    roundtrip(
+      Serializer.string(StandardCharsets.UTF_8),
+      Deserializer.string(StandardCharsets.UTF_8)
+    )
+  }
+
+  test("Serializer#uuid") {
+    roundtripAttempt(
+      Serializer.uuid(StandardCharsets.UTF_8),
+      Deserializer.uuid(StandardCharsets.UTF_8)
+    )
+  }
+
+  test("Serializer#double") {
+    roundtripAttempt(
+      Serializer.double,
+      Deserializer.double
+    )
+  }
+
+  test("Serializer#float") {
+    roundtripAttempt(
+      Serializer.float,
+      Deserializer.float
+    )
+  }
+
+  test("Serializer#int") {
+    roundtripAttempt(
+      Serializer.int,
+      Deserializer.int
+    )
+  }
+
+  test("Serializer#long") {
+    roundtripAttempt(
+      Serializer.long,
+      Deserializer.long
+    )
+  }
+
+  test("Serializer#short") {
+    roundtripAttempt(
+      Serializer.short,
+      Deserializer.short
+    )
+  }
+}

--- a/src/test/scala/fs2/kafka/internal/SyntaxSpec.scala
+++ b/src/test/scala/fs2/kafka/internal/SyntaxSpec.scala
@@ -1,10 +1,10 @@
 package fs2.kafka.internal
 
-import java.time.temporal.ChronoUnit.MICROS
-
+import fs2.kafka._
 import fs2.kafka.BaseSpec
 import fs2.kafka.internal.syntax._
-
+import java.time.temporal.ChronoUnit.MICROS
+import org.apache.kafka.common.header.internals.RecordHeaders
 import scala.concurrent.duration._
 
 final class SyntaxSpec extends BaseSpec {
@@ -24,6 +24,29 @@ final class SyntaxSpec extends BaseSpec {
         assert {
           m.filterKeysStrictValuesList(p) == m.filterKeys(p).values.toList
         }
+      }
+    }
+  }
+
+  describe("KafkaHeaders#asScala") {
+    it("should convert empty") {
+      val kafkaHeaders: KafkaHeaders =
+        new RecordHeaders()
+
+      assert(kafkaHeaders.asScala == Headers.empty)
+    }
+
+    it("should convert non-empty") {
+      val kafkaHeaders: KafkaHeaders = {
+        val recordHeaders = new RecordHeaders()
+        recordHeaders.add("key", Array())
+        recordHeaders
+      }
+
+      assert {
+        val headers = kafkaHeaders.asScala
+        headers.toChain.size == 1 &&
+        headers("key").map(_.value.size) == Some(0)
       }
     }
   }


### PR DESCRIPTION
For working with record headers, the following changes have been made.
- Add `HeaderDeserializer` for deserialization of record header values.
- Add `HeaderSerializer` for serializing values to use as header values.
- Add `Header.serialize` for serializing a value and creating a `Header`.
- Add `Header#headers` for creating a `Headers` with a single `Header`.
- Add `Header#as` and `attemptAs` for deserializing header values.
- Add `Headers#withKey` and alias `apply` for extracting a single `Header`.
- Add `Headers#concat` for concatenating another `Headers` instance.
- Add `Headers#asJava` for converting to Java Kafka-compatible headers.
- Add `Headers.fromIterable` to create `Headers` from `Iterable[Header]`.
- Add `Headers.fromSeq` to create `Headers` from `Seq[Header]`.

For record serialization, the following changes have been made. 
- Add a custom `Serializer` to make it easier to create and compose serializers.
- Add a custom `Deserializer` to make it easier to create and compose deserializers.
- Add `ProducerSettings.apply` for using implicit `Serializer`s for the key and value.
- Add `ConsumerSettings.apply` for using implicit `Deserializer`s for the key and value.