### PR TITLE
Add 'describeCluster' and 'createTopic' operations to KafkaAdminClient.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -147,7 +147,10 @@ lazy val mimaSettings = Seq(
       ProblemFilters.exclude[DirectMissingMethodProblem]("fs2.kafka.ConsumerSettings#ConsumerSettingsImpl.this"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.Headers.asJava"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.Headers.withKey"),
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.Headers.concat")
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.Headers.concat"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.KafkaAdminClient.createTopic"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.KafkaAdminClient.createTopics"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.KafkaAdminClient.describeCluster")
     )
     // format: on
   }

--- a/src/main/scala/fs2/kafka/internal/syntax.scala
+++ b/src/main/scala/fs2/kafka/internal/syntax.scala
@@ -172,6 +172,9 @@ private[kafka] object syntax {
     def map[B](f: A => B): KafkaFuture[B] =
       future.thenApply(baseFunction(f))
 
+    def void: KafkaFuture[Unit] =
+      map(_ => ())
+
     def cancelToken[F[_]](implicit F: Sync[F]): CancelToken[F] =
       F.delay { future.cancel(true); () }
 

--- a/src/test/scala/fs2/kafka/KafkaAdminClientSpec.scala
+++ b/src/test/scala/fs2/kafka/KafkaAdminClientSpec.scala
@@ -93,11 +93,9 @@ final class KafkaAdminClientSpec extends BaseKafkaSpec {
                 .toString shouldBe "ListConsumerGroupOffsetsForPartitions(groupId = group, partitions = List(topic-0))"
             }
             newTopic = new NewTopic("new-test-topic", 1, 1)
-            createRequest = adminClient.createTopic(newTopic)
-            _ <- IO(assert(createRequest.topicName == newTopic.name))
             preCreateNames <- adminClient.listTopics.names
             _ <- IO(assert(!preCreateNames.contains(newTopic.name)))
-            _ <- createRequest.value
+            _ <- adminClient.createTopic(newTopic)
             postCreateNames <- adminClient.listTopics.names
             _ <- IO(assert(postCreateNames.contains(newTopic.name)))
           } yield ()

--- a/src/test/scala/fs2/kafka/KafkaAdminClientSpec.scala
+++ b/src/test/scala/fs2/kafka/KafkaAdminClientSpec.scala
@@ -68,6 +68,9 @@ final class KafkaAdminClientSpec extends BaseKafkaSpec {
             describedTopics <- adminClient.describeTopics(topicNames.toList)
             _ <- IO(assert(describedTopics.size == 1))
             _ <- IO {
+              adminClient.describeCluster.toString should startWith("DescribeCluster$")
+            }
+            _ <- IO {
               adminClient.toString should startWith("KafkaAdminClient$")
             }
             _ <- IO {
@@ -97,6 +100,8 @@ final class KafkaAdminClientSpec extends BaseKafkaSpec {
             _ <- IO(assert(!preCreateNames.contains(newTopic.name)))
             _ <- adminClient.createTopic(newTopic)
             postCreateNames <- adminClient.listTopics.names
+            createAgain <- adminClient.createTopics(List(newTopic)).attempt
+            _ <- IO(assert(createAgain.isLeft))
             _ <- IO(assert(postCreateNames.contains(newTopic.name)))
           } yield ()
         }.unsafeRunSync


### PR DESCRIPTION
I'm hoping to use `fs2-kafka` in a new project at work, but I need these two operations. I tried to follow the existing patterns in the `KafkaAdminClient`, but please let me know if I should change anything!