### PR TITLE
Change to use custom ConsumerRecord

### DIFF
--- a/docs/src/main/mdoc/quick-example.md
+++ b/docs/src/main/mdoc/quick-example.md
@@ -13,7 +13,6 @@ Following is an example showing how to:
 import cats.effect.{ExitCode, IO, IOApp}
 import cats.syntax.functor._
 import fs2.kafka._
-import org.apache.kafka.clients.consumer.ConsumerRecord
 import scala.concurrent.duration._
 
 object Main extends IOApp {

--- a/src/main/scala/fs2/kafka/CommittableMessage.scala
+++ b/src/main/scala/fs2/kafka/CommittableMessage.scala
@@ -18,8 +18,6 @@ package fs2.kafka
 
 import cats.Show
 import cats.syntax.show._
-import fs2.kafka.internal.instances._
-import org.apache.kafka.clients.consumer.ConsumerRecord
 
 /**
   * [[CommittableMessage]] is a Kafka record along with an instance of
@@ -33,7 +31,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord
   * While normally not necessary, [[CommittableMessage#apply]] can be
   * used to create a new instance.
   */
-sealed abstract class CommittableMessage[F[_], K, V] {
+sealed abstract class CommittableMessage[F[_], +K, +V] {
 
   /**
     * The Kafka record for the [[CommittableMessage]]. If you are not
@@ -53,7 +51,7 @@ sealed abstract class CommittableMessage[F[_], K, V] {
 }
 
 object CommittableMessage {
-  private[this] final class CommittableMessageImpl[F[_], K, V](
+  private[this] final class CommittableMessageImpl[F[_], +K, +V](
     override val record: ConsumerRecord[K, V],
     override val committableOffset: CommittableOffset[F]
   ) extends CommittableMessage[F, K, V] {

--- a/src/main/scala/fs2/kafka/ConsumerRecord.scala
+++ b/src/main/scala/fs2/kafka/ConsumerRecord.scala
@@ -1,0 +1,225 @@
+/*
+ * Copyright 2018-2019 OVO Energy Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fs2.kafka
+
+import cats.Show
+import cats.syntax.show._
+import fs2.kafka.internal.syntax._
+import org.apache.kafka.clients.consumer.ConsumerRecord.{NULL_SIZE, NO_TIMESTAMP}
+import org.apache.kafka.common.record.TimestampType.{CREATE_TIME, LOG_APPEND_TIME}
+
+/**
+  * [[ConsumerRecord]] represents a record which has been
+  * consumed from Kafka. At the very least, this includes
+  * a key of type `K`, value of type `V`, and the topic,
+  * partition, and offset of the consumed record.<br>
+  * <br>
+  * To create a new instance, use [[ConsumerRecord#apply]]
+  */
+sealed abstract class ConsumerRecord[+K, +V] {
+
+  /** The topic from which the record has been consumed. */
+  def topic: String
+
+  /** The partition from which the record has been consumed. */
+  def partition: Int
+
+  /** The offset from which the record has been consumed. */
+  def offset: Long
+
+  /** The record key. */
+  def key: K
+
+  /** The record value. */
+  def value: V
+
+  /** The record headers. */
+  def headers: Headers
+
+  /** The record timestamp. */
+  def timestamp: Timestamp
+
+  /** The serialized key size if available. */
+  def serializedKeySize: Option[Int]
+
+  /** The serialized value size if available. */
+  def serializedValueSize: Option[Int]
+
+  /** The leader epoch if available. */
+  def leaderEpoch: Option[Int]
+
+  /**
+    * Creates a new [[ConsumerRecord]] instance with the
+    * specified headers as the headers for the record.
+    */
+  def withHeaders(headers: Headers): ConsumerRecord[K, V]
+
+  /**
+    * Creates a new [[ConsumerRecord]] instance with the
+    * specified timestamp as the timestamp for the record.
+    */
+  def withTimestamp(timestamp: Timestamp): ConsumerRecord[K, V]
+
+  /**
+    * Creates a new [[ConsumerRecord]] instance with the
+    * specified key size as the key size for the record.
+    */
+  def withSerializedKeySize(serializedKeySize: Int): ConsumerRecord[K, V]
+
+  /**
+    * Creates a new [[ConsumerRecord]] instance with the
+    * specified value size as the size for the record.
+    */
+  def withSerializedValueSize(serializedValueSize: Int): ConsumerRecord[K, V]
+
+  /**
+    * Creates a new [[ConsumerRecord]] instance with the
+    * specified leader epoch as the epoch for the record.
+    */
+  def withLeaderEpoch(leaderEpoch: Int): ConsumerRecord[K, V]
+}
+
+object ConsumerRecord {
+  private[this] final case class ConsumerRecordImpl[+K, +V](
+    override val topic: String,
+    override val partition: Int,
+    override val offset: Long,
+    override val key: K,
+    override val value: V,
+    override val headers: Headers,
+    override val timestamp: Timestamp,
+    override val serializedKeySize: Option[Int],
+    override val serializedValueSize: Option[Int],
+    override val leaderEpoch: Option[Int]
+  ) extends ConsumerRecord[K, V] {
+    override def withHeaders(headers: Headers): ConsumerRecord[K, V] =
+      copy(headers = headers)
+
+    override def withTimestamp(timestamp: Timestamp): ConsumerRecord[K, V] =
+      copy(timestamp = timestamp)
+
+    override def withSerializedKeySize(serializedKeySize: Int): ConsumerRecord[K, V] =
+      copy(serializedKeySize = Some(serializedKeySize))
+
+    override def withSerializedValueSize(serializedValueSize: Int): ConsumerRecord[K, V] =
+      copy(serializedValueSize = Some(serializedValueSize))
+
+    override def withLeaderEpoch(leaderEpoch: Int): ConsumerRecord[K, V] =
+      copy(leaderEpoch = Some(leaderEpoch))
+
+    override def toString: String = {
+      val b = new java.lang.StringBuilder("ConsumerRecord(")
+      b.append("topic = ").append(topic)
+      b.append(", partition = ").append(partition)
+      b.append(", offset = ").append(offset)
+      b.append(", key = ").append(key)
+      b.append(", value = ").append(value)
+      if (headers.nonEmpty)
+        b.append(", headers = ").append(headers)
+      if (timestamp.nonEmpty)
+        b.append(", timestamp = ").append(timestamp)
+      if (serializedKeySize.nonEmpty)
+        b.append(", serializedKeySize = ").append(serializedKeySize.get)
+      if (serializedValueSize.nonEmpty)
+        b.append(", serializedValueSize = ").append(serializedValueSize.get)
+      if (leaderEpoch.nonEmpty)
+        b.append(", leaderEpoch = ").append(leaderEpoch.get)
+      b.append(")").toString
+    }
+  }
+
+  /**
+    * Creates a new [[ConsumerRecord]] instance using the
+    * specified key and value, and the topic, partition,
+    * and offset of the record.
+    */
+  def apply[K, V](
+    topic: String,
+    partition: Int,
+    offset: Long,
+    key: K,
+    value: V
+  ): ConsumerRecord[K, V] =
+    ConsumerRecordImpl(
+      topic = topic,
+      partition = partition,
+      offset = offset,
+      key = key,
+      value = value,
+      headers = Headers.empty,
+      timestamp = Timestamp.none,
+      serializedKeySize = None,
+      serializedValueSize = None,
+      leaderEpoch = None
+    )
+
+  private[kafka] def fromJava[K, V](
+    record: KafkaConsumerRecord[K, V]
+  ): ConsumerRecord[K, V] =
+    ConsumerRecordImpl(
+      topic = record.topic,
+      partition = record.partition,
+      offset = record.offset,
+      key = record.key,
+      value = record.value,
+      headers = record.headers.asScala,
+      timestamp = record.timestampType match {
+        case CREATE_TIME if record.timestamp != NO_TIMESTAMP =>
+          Timestamp.createTime(record.timestamp)
+        case LOG_APPEND_TIME if record.timestamp != NO_TIMESTAMP =>
+          Timestamp.logAppendTime(record.timestamp)
+        case _ =>
+          Timestamp.none
+      },
+      serializedKeySize =
+        if (record.serializedKeySize != NULL_SIZE)
+          Some(record.serializedKeySize)
+        else None,
+      serializedValueSize =
+        if (record.serializedValueSize != NULL_SIZE)
+          Some(record.serializedValueSize)
+        else None,
+      leaderEpoch =
+        if (record.leaderEpoch.isPresent)
+          Some(record.leaderEpoch.get)
+        else None
+    )
+
+  implicit def consumerRecordShow[K, V](
+    implicit
+    K: Show[K],
+    V: Show[V]
+  ): Show[ConsumerRecord[K, V]] = Show.show { record =>
+    val b = new java.lang.StringBuilder("ConsumerRecord(")
+    b.append("topic = ").append(record.topic)
+    b.append(", partition = ").append(record.partition)
+    b.append(", offset = ").append(record.offset)
+    b.append(", key = ").append(record.key.show)
+    b.append(", value = ").append(record.value.show)
+    if (record.headers.nonEmpty)
+      b.append(", headers = ").append(record.headers)
+    if (record.timestamp.nonEmpty)
+      b.append(", timestamp = ").append(record.timestamp)
+    if (record.serializedKeySize.nonEmpty)
+      b.append(", serializedKeySize = ").append(record.serializedKeySize.get)
+    if (record.serializedValueSize.nonEmpty)
+      b.append(", serializedValueSize = ").append(record.serializedValueSize.get)
+    if (record.leaderEpoch.nonEmpty)
+      b.append(", leaderEpoch = ").append(record.leaderEpoch.get)
+    b.append(")").toString
+  }
+}

--- a/src/main/scala/fs2/kafka/ConsumerSettings.scala
+++ b/src/main/scala/fs2/kafka/ConsumerSettings.scala
@@ -17,7 +17,7 @@
 package fs2.kafka
 
 import cats.Show
-import org.apache.kafka.clients.consumer.{ConsumerConfig, ConsumerRecord}
+import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.common.requests.OffsetFetchResponse
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext

--- a/src/main/scala/fs2/kafka/KafkaProducer.scala
+++ b/src/main/scala/fs2/kafka/KafkaProducer.scala
@@ -129,8 +129,8 @@ private[kafka] object KafkaProducer {
 
         private[this] def asJavaRecord(
           record: ProducerRecord[K, V]
-        ): org.apache.kafka.clients.producer.ProducerRecord[K, V] =
-          new org.apache.kafka.clients.producer.ProducerRecord[K, V](
+        ): KafkaProducerRecord[K, V] =
+          new KafkaProducerRecord[K, V](
             record.topic,
             if (record.partition.isDefined)
               record.partition.get: java.lang.Integer

--- a/src/main/scala/fs2/kafka/Timestamp.scala
+++ b/src/main/scala/fs2/kafka/Timestamp.scala
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2018-2019 OVO Energy Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fs2.kafka
+
+import cats.Show
+
+/**
+  * [[Timestamp]] is an optional timestamp value representing
+  * either the creation time of the record, the time when the
+  * record was appended to the log, or no timestamp at all.
+  */
+sealed abstract class Timestamp {
+
+  /**
+    * Returns the timestamp value, if the timestamp is
+    * representing the time when a record was created.
+    */
+  def createTime: Option[Long]
+
+  /**
+    * Returns the timestamp value, if the timestamp is
+    * representing the time when a record was appended
+    * to the log.
+    */
+  def logAppendTime: Option[Long]
+
+  /**
+    * Returns `true` if there is no timestamp value; otherwise `false`.
+    */
+  def isEmpty: Boolean
+
+  /**
+    * Returns `true` if there is a timestamp value; otherwise `false`.
+    */
+  final def nonEmpty: Boolean =
+    !isEmpty
+}
+
+object Timestamp {
+
+  /**
+    * Creates a new [[Timestamp]] instance from the specified
+    * timestamp value representing the time when the record
+    * was created.
+    */
+  def createTime(value: Long): Timestamp =
+    new Timestamp {
+      override val createTime: Option[Long] = Some(value)
+      override val logAppendTime: Option[Long] = None
+      override val isEmpty: Boolean = false
+      override def toString: String = s"Timestamp(createTime = $value)"
+    }
+
+  /**
+    * Creates a new [[Timestamp]] instance from the specified
+    * timestamp value representing the time when the record
+    * was appended to the log.
+    */
+  def logAppendTime(value: Long): Timestamp =
+    new Timestamp {
+      override val createTime: Option[Long] = None
+      override val logAppendTime: Option[Long] = Some(value)
+      override val isEmpty: Boolean = false
+      override def toString: String = s"Timestamp(logAppendTime = $value)"
+    }
+
+  /**
+    * The [[Timestamp]] instance without any timestamp values.
+    */
+  val none: Timestamp =
+    new Timestamp {
+      override val createTime: Option[Long] = None
+      override val logAppendTime: Option[Long] = None
+      override val isEmpty: Boolean = true
+      override def toString: String = "Timestamp()"
+    }
+
+  implicit val timestampShow: Show[Timestamp] =
+    Show.fromToString
+}

--- a/src/main/scala/fs2/kafka/internal/KafkaConsumerActor.scala
+++ b/src/main/scala/fs2/kafka/internal/KafkaConsumerActor.scala
@@ -36,7 +36,7 @@ import fs2.kafka._
 import fs2.kafka.internal.KafkaConsumerActor._
 import fs2.kafka.internal.instances._
 import fs2.kafka.internal.syntax._
-import org.apache.kafka.clients.consumer._
+import org.apache.kafka.clients.consumer.{ConsumerRecord => _, _}
 import org.apache.kafka.common.TopicPartition
 
 import scala.collection.JavaConverters._
@@ -341,7 +341,10 @@ private[kafka] final class KafkaConsumerActor[F[_], K, V](
         val partitionMessages = new ArrayBuffer[CommittableMessage[F, K, V]](records.size)
 
         val it = records.iterator
-        while (it.hasNext) partitionMessages += message(it.next, partition)
+        while (it.hasNext) {
+          val next = ConsumerRecord.fromJava(it.next)
+          partitionMessages += message(next, partition)
+        }
 
         messages = messages.updated(partition, partitionMessages)
       }

--- a/src/main/scala/fs2/kafka/internal/instances.scala
+++ b/src/main/scala/fs2/kafka/internal/instances.scala
@@ -16,38 +16,19 @@
 
 package fs2.kafka.internal
 
-import java.util
-
 import cats.instances.int._
 import cats.instances.long._
 import cats.instances.string._
 import cats.instances.tuple._
 import cats.syntax.show._
 import cats.{Order, Semigroup, Show}
-import org.apache.kafka.clients.consumer.{ConsumerRecord, OffsetAndMetadata}
+import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import org.apache.kafka.clients.producer.RecordMetadata
 import org.apache.kafka.common.TopicPartition
-import org.apache.kafka.common.header.{Header, Headers}
-import org.apache.kafka.common.record.TimestampType
 
 import scala.collection.mutable.ArrayBuffer
 
 private[kafka] object instances {
-  implicit def consumerRecordShow[K, V](
-    implicit
-    K: Show[K],
-    V: Show[V]
-  ): Show[ConsumerRecord[K, V]] = Show.show { cr =>
-    val leaderEpoch = if (cr.leaderEpoch.isPresent) (cr.leaderEpoch.get: Int).show else "null"
-    show"ConsumerRecord(topic = ${cr.topic}, partition = ${cr.partition}, leaderEpoch = $leaderEpoch, offset = ${cr.offset}, ${cr.timestampType} = ${cr.timestamp}, serialized key size = ${cr.serializedKeySize}, serialized value size = ${cr.serializedValueSize}, headers = ${cr.headers}, key = ${cr.key}, value = ${cr.value})"
-  }
-
-  implicit val headerShow: Show[Header] =
-    Show.show(h => show"${h.key} -> ${util.Arrays.toString(h.value)}")
-
-  implicit val headersShow: Show[Headers] =
-    Show.show(hs => hs.toArray.map(_.show).mkString("Headers(", ", ", ")"))
-
   implicit val offsetAndMetadataOrder: Order[OffsetAndMetadata] =
     Order.by(oam => (oam.offset, oam.metadata))
 
@@ -63,9 +44,6 @@ private[kafka] object instances {
 
   implicit val recordMetadataShow: Show[RecordMetadata] =
     Show.show(rm => show"${rm.topic}-${rm.partition}@${rm.offset}")
-
-  implicit val timestampTypeShow: Show[TimestampType] =
-    Show.show(_.name)
 
   implicit val topicPartitionOrder: Order[TopicPartition] =
     Order.by(tp => (tp.topic, tp.partition))

--- a/src/main/scala/fs2/kafka/package.scala
+++ b/src/main/scala/fs2/kafka/package.scala
@@ -40,6 +40,12 @@ package object kafka {
   private[kafka] type KafkaHeaders =
     org.apache.kafka.common.header.Headers
 
+  private[kafka] type KafkaConsumerRecord[K, V] =
+    org.apache.kafka.clients.consumer.ConsumerRecord[K, V]
+
+  private[kafka] type KafkaProducerRecord[K, V] =
+    org.apache.kafka.clients.producer.ProducerRecord[K, V]
+
   /**
     * Commits offsets in batches determined by the `Chunk`s of the
     * underlying `Stream`. If you want more explicit control over

--- a/src/test/scala/fs2/kafka/CommittableMessageSpec.scala
+++ b/src/test/scala/fs2/kafka/CommittableMessageSpec.scala
@@ -1,7 +1,7 @@
 package fs2.kafka
 
 import cats.implicits._
-import org.apache.kafka.clients.consumer.{ConsumerRecord, OffsetAndMetadata}
+import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import org.apache.kafka.common.TopicPartition
 
 final class CommittableMessageSpec extends BaseSpec {
@@ -9,7 +9,7 @@ final class CommittableMessageSpec extends BaseSpec {
     it("should have a Show instance and matching toString") {
       val message =
         CommittableMessage(
-          new ConsumerRecord("topic", 0, 0L, "key", "value"),
+          ConsumerRecord("topic", 0, 0L, "key", "value"),
           CommittableOffset[Id](
             topicPartition = new TopicPartition("topic", 0),
             offsetAndMetadata = new OffsetAndMetadata(0L),
@@ -18,8 +18,8 @@ final class CommittableMessageSpec extends BaseSpec {
         )
 
       assert {
-        message.toString == "CommittableMessage(ConsumerRecord(topic = topic, partition = 0, leaderEpoch = null, offset = 0, NoTimestampType = -1, serialized key size = -1, serialized value size = -1, headers = RecordHeaders(headers = [], isReadOnly = false), key = key, value = value), CommittableOffset(topic-0 -> 0))" &&
-        message.show == "CommittableMessage(ConsumerRecord(topic = topic, partition = 0, leaderEpoch = null, offset = 0, NoTimestampType = -1, serialized key size = -1, serialized value size = -1, headers = Headers(), key = key, value = value), CommittableOffset(topic-0 -> 0))"
+        message.toString == "CommittableMessage(ConsumerRecord(topic = topic, partition = 0, offset = 0, key = key, value = value), CommittableOffset(topic-0 -> 0))" &&
+        message.show == "CommittableMessage(ConsumerRecord(topic = topic, partition = 0, offset = 0, key = key, value = value), CommittableOffset(topic-0 -> 0))"
       }
     }
   }

--- a/src/test/scala/fs2/kafka/ConsumerRecordSpec.scala
+++ b/src/test/scala/fs2/kafka/ConsumerRecordSpec.scala
@@ -1,0 +1,170 @@
+package fs2.kafka
+
+import cats.implicits._
+import org.apache.kafka.clients.consumer.ConsumerRecord.{NULL_SIZE, NO_TIMESTAMP}
+import org.apache.kafka.common.record.TimestampType
+import org.apache.kafka.common.record.TimestampType._
+import org.scalatest._
+
+final class ConsumerRecordSpec extends BaseSpec {
+  describe("ConsumerRecord#fromJava") {
+    it("should convert timestamps") {
+      def check(timestamp: Long, timestampType: TimestampType)(
+        f: ConsumerRecord[String, String] => Assertion
+      ): Assertion = {
+        val record =
+          new KafkaConsumerRecord("topic", 0, 1, timestamp, timestampType, 2, 3, 4, "key", "value")
+        f(ConsumerRecord.fromJava(record))
+      }
+
+      check(NO_TIMESTAMP, NO_TIMESTAMP_TYPE)(_.timestamp.isEmpty shouldBe true)
+      check(NO_TIMESTAMP, CREATE_TIME)(_.timestamp.isEmpty shouldBe true)
+      check(NO_TIMESTAMP, LOG_APPEND_TIME)(_.timestamp.isEmpty shouldBe true)
+
+      check(0, NO_TIMESTAMP_TYPE)(_.timestamp.isEmpty shouldBe true)
+      check(0, CREATE_TIME)(_.timestamp.createTime shouldBe Some(0))
+      check(0, LOG_APPEND_TIME)(_.timestamp.logAppendTime shouldBe Some(0))
+    }
+
+    it("should convert serialized key size") {
+      def check(serializedKeySize: Int)(
+        f: ConsumerRecord[String, String] => Assertion
+      ): Assertion = {
+        val record =
+          new KafkaConsumerRecord(
+            "topic",
+            0,
+            1,
+            NO_TIMESTAMP,
+            NO_TIMESTAMP_TYPE,
+            2,
+            serializedKeySize,
+            4,
+            "key",
+            "value"
+          )
+
+        f(ConsumerRecord.fromJava(record))
+      }
+
+      check(NULL_SIZE)(_.serializedKeySize shouldBe None)
+      check(0)(_.serializedKeySize shouldBe Some(0))
+    }
+
+    it("should convert serialized value size") {
+      def check(serializedValueSize: Int)(
+        f: ConsumerRecord[String, String] => Assertion
+      ): Assertion = {
+        val record =
+          new KafkaConsumerRecord(
+            "topic",
+            0,
+            1,
+            NO_TIMESTAMP,
+            NO_TIMESTAMP_TYPE,
+            2,
+            3,
+            serializedValueSize,
+            "key",
+            "value"
+          )
+
+        f(ConsumerRecord.fromJava(record))
+      }
+
+      check(NULL_SIZE)(_.serializedValueSize shouldBe None)
+      check(0)(_.serializedValueSize shouldBe Some(0))
+    }
+
+    it("should convert leader epoch") {
+      def check(leaderEpoch: Option[Int])(
+        f: ConsumerRecord[String, String] => Assertion
+      ): Assertion = {
+        val record =
+          new KafkaConsumerRecord(
+            "topic",
+            0,
+            1,
+            NO_TIMESTAMP,
+            NO_TIMESTAMP_TYPE,
+            2,
+            3,
+            4,
+            "key",
+            "value",
+            Headers.empty.asJava,
+            if (leaderEpoch.nonEmpty)
+              java.util.Optional.of[java.lang.Integer](leaderEpoch.get)
+            else java.util.Optional.empty()
+          )
+
+        f(ConsumerRecord.fromJava(record))
+      }
+
+      check(None)(_.leaderEpoch shouldBe None)
+      check(Some(1))(_.leaderEpoch shouldBe Some(1))
+    }
+  }
+
+  describe("ConsumerRecord#toString") {
+    it("should include headers when present") {
+      val record =
+        ConsumerRecord("topic", 0, 1, "key", "value")
+          .withHeaders(Header("key", Array()).headers)
+
+      val expected =
+        "ConsumerRecord(topic = topic, partition = 0, offset = 1, key = key, value = value, headers = Headers(key -> []))"
+
+      record.toString shouldBe expected
+      record.show shouldBe expected
+    }
+
+    it("should include timestamp if present") {
+      val record =
+        ConsumerRecord("topic", 0, 1, "key", "value")
+          .withTimestamp(Timestamp.createTime(0))
+
+      val expected =
+        "ConsumerRecord(topic = topic, partition = 0, offset = 1, key = key, value = value, timestamp = Timestamp(createTime = 0))"
+
+      record.toString shouldBe expected
+      record.show shouldBe expected
+    }
+
+    it("should include serialized key size if present") {
+      val record =
+        ConsumerRecord("topic", 0, 1, "key", "value")
+          .withSerializedKeySize(1)
+
+      val expected =
+        "ConsumerRecord(topic = topic, partition = 0, offset = 1, key = key, value = value, serializedKeySize = 1)"
+
+      record.toString shouldBe expected
+      record.show shouldBe expected
+    }
+
+    it("should include serialized value size if present") {
+      val record =
+        ConsumerRecord("topic", 0, 1, "key", "value")
+          .withSerializedValueSize(1)
+
+      val expected =
+        "ConsumerRecord(topic = topic, partition = 0, offset = 1, key = key, value = value, serializedValueSize = 1)"
+
+      record.toString shouldBe expected
+      record.show shouldBe expected
+    }
+
+    it("should include leader epoch if present") {
+      val record =
+        ConsumerRecord("topic", 0, 1, "key", "value")
+          .withLeaderEpoch(1)
+
+      val expected =
+        "ConsumerRecord(topic = topic, partition = 0, offset = 1, key = key, value = value, leaderEpoch = 1)"
+
+      record.toString shouldBe expected
+      record.show shouldBe expected
+    }
+  }
+}

--- a/src/test/scala/fs2/kafka/ConsumerSettingsSpec.scala
+++ b/src/test/scala/fs2/kafka/ConsumerSettingsSpec.scala
@@ -1,7 +1,7 @@
 package fs2.kafka
 
 import cats.implicits._
-import org.apache.kafka.clients.consumer.{ConsumerConfig, ConsumerRecord}
+import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.common.serialization.StringDeserializer
 
 import scala.concurrent.ExecutionContext
@@ -198,7 +198,7 @@ final class ConsumerSettingsSpec extends BaseSpec {
     }
 
     it("should provide withRecordMetadata") {
-      val record = new ConsumerRecord("topic", 0, 0L, "key", "value")
+      val record = ConsumerRecord("topic", 0, 0L, "key", "value")
 
       assert {
         settings.recordMetadata(record) == "" &&

--- a/src/test/scala/fs2/kafka/ProducerResultSpec.scala
+++ b/src/test/scala/fs2/kafka/ProducerResultSpec.scala
@@ -16,13 +16,16 @@ final class ProducerResultSpec extends BaseSpec {
 
       val one: List[(ProducerRecord[String, String], RecordMetadata)] =
         List(
-          ProducerRecord("topic", "key", "value").withPartition(1).withTimestamp(0L) ->
+          ProducerRecord("topic", "key", "value")
+            .withPartition(1)
+            .withTimestamp(0L)
+            .withHeaders(Header("key", Array()).headers) ->
             new RecordMetadata(new TopicPartition("topic", 0), 0L, 0L, 0L, 0L, 0, 0)
         )
 
       assert {
-        ProducerResult(one, 123).toString == "ProducerResult(topic-0@0 -> ProducerRecord(topic = topic, partition = 1, timestamp = 0, key = key, value = value), 123)" &&
-        ProducerResult(one, 123).show == "ProducerResult(topic-0@0 -> ProducerRecord(topic = topic, partition = 1, timestamp = 0, key = key, value = value), 123)"
+        ProducerResult(one, 123).toString == "ProducerResult(topic-0@0 -> ProducerRecord(topic = topic, partition = 1, timestamp = 0, key = key, value = value, headers = Headers(key -> [])), 123)" &&
+        ProducerResult(one, 123).show == "ProducerResult(topic-0@0 -> ProducerRecord(topic = topic, partition = 1, timestamp = 0, key = key, value = value, headers = Headers(key -> [])), 123)"
       }
 
       val two: List[(ProducerRecord[String, String], RecordMetadata)] =

--- a/src/test/scala/fs2/kafka/TimestampSpec.scala
+++ b/src/test/scala/fs2/kafka/TimestampSpec.scala
@@ -1,0 +1,75 @@
+package fs2.kafka
+
+import cats.syntax.show._
+
+final class TimestampSpec extends BaseSpec {
+  describe("Timeout#createTime") {
+    it("should have a createTime") {
+      forAll { value: Long =>
+        val timestamp = Timestamp.createTime(value)
+        timestamp.createTime shouldBe Some(value)
+        timestamp.nonEmpty shouldBe true
+        timestamp.isEmpty shouldBe false
+      }
+    }
+
+    it("should not have a logAppendTime") {
+      forAll { value: Long =>
+        Timestamp.createTime(value).logAppendTime shouldBe None
+      }
+    }
+
+    it("should include the createTime in toString") {
+      forAll { value: Long =>
+        val timestamp = Timestamp.createTime(value)
+        timestamp.toString should include(s"createTime = $value")
+        timestamp.toString shouldBe timestamp.show
+      }
+    }
+  }
+
+  describe("Timeout#logAppendTime") {
+    it("should have a logAppendTime") {
+      forAll { value: Long =>
+        val timestamp = Timestamp.logAppendTime(value)
+        timestamp.logAppendTime shouldBe Some(value)
+        timestamp.nonEmpty shouldBe true
+        timestamp.isEmpty shouldBe false
+      }
+    }
+
+    it("should not have a createTime") {
+      forAll { value: Long =>
+        Timestamp.logAppendTime(value).createTime shouldBe None
+      }
+    }
+
+    it("should include the logAppendTime in toString") {
+      forAll { value: Long =>
+        val timestamp = Timestamp.logAppendTime(value)
+        timestamp.toString should include(s"logAppendTime = $value")
+        timestamp.toString shouldBe timestamp.show
+      }
+    }
+  }
+
+  describe("Timestamp#none") {
+    it("should not have createTime") {
+      Timestamp.none.createTime shouldBe None
+    }
+
+    it("should not have logAppendTime") {
+      Timestamp.none.logAppendTime shouldBe None
+    }
+
+    it("should be empty") {
+      Timestamp.none.isEmpty shouldBe true
+      Timestamp.none.nonEmpty shouldBe false
+    }
+
+    it("should not include any time in toString") {
+      Timestamp.none.toString shouldBe "Timestamp()"
+      Timestamp.none.show shouldBe Timestamp.none.toString
+    }
+  }
+}


### PR DESCRIPTION
This pull request adds a custom `ConsumerRecord` similar to the existing Java Kafka `ConsumerRecord`. The custom record uses `fs2.kafka.Headers` and should generally be more nice to work with in Scala than the Java version.