### PR TITLE
WIP: Bump version of kafka-clients to 2.1.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import ReleaseTransformations._
 
 val fs2Version = "1.0.3"
 
-val kafkaVersion = "2.1.0"
+val kafkaVersion = "2.1.1"
 
 lazy val `fs2-kafka` = project
   .in(file("."))


### PR DESCRIPTION
Bump version of kafka-clients to 2.1.1 to get the fix for https://issues.apache.org/jira/browse/KAFKA-7890 (shop-stopper bug when using kafka-clients in environments where brokers can change their IPs, e.g. Kubernetes).

For some reasons test in `KafkaAdminClientSpec` are red. Maybe we need to wait for `embeddedkafka` to release a build for Kafka 2.1.1?!