### PR TITLE
Change to improve working with unkeyed records

### DIFF
--- a/src/test/scala/fs2/kafka/DeserializerSpec.scala
+++ b/src/test/scala/fs2/kafka/DeserializerSpec.scala
@@ -72,6 +72,23 @@ final class DeserializerSpec extends BaseCatsSpec {
     }
   }
 
+  test("Deserializer#option") {
+    val deserializer =
+      Deserializer[Option[String]]
+
+    deserializer.deserialize("topic", null) shouldBe None
+
+    forAll { s: String =>
+      deserializer.deserialize("topic", s.getBytes) shouldBe Some(s)
+    }
+  }
+
+  test("Deserializer#unit") {
+    forAll { bytes: Array[Byte] =>
+      Deserializer[Unit].deserialize("topic", bytes) shouldBe (())
+    }
+  }
+
   test("Deserializer#toString") {
     assert(Deserializer[String].toString startsWith "Deserializer$")
   }

--- a/src/test/scala/fs2/kafka/HeaderDeserializerSpec.scala
+++ b/src/test/scala/fs2/kafka/HeaderDeserializerSpec.scala
@@ -22,6 +22,23 @@ final class HeaderDeserializerSpec extends BaseCatsSpec {
     assert(result.isEmpty)
   }
 
+  test("HeaderDeserializer#option") {
+    val deserializer =
+      HeaderDeserializer[Option[String]]
+
+    deserializer.deserialize(null) shouldBe None
+
+    forAll { s: String =>
+      deserializer.deserialize(s.getBytes) shouldBe Some(s)
+    }
+  }
+
+  test("HeaderDeserializer#unit") {
+    forAll { bytes: Array[Byte] =>
+      HeaderDeserializer[Unit].deserialize(bytes) shouldBe (())
+    }
+  }
+
   test("HeaderDeserializer#toString") {
     assert(HeaderDeserializer[String].toString startsWith "HeaderDeserializer$")
   }

--- a/src/test/scala/fs2/kafka/HeaderSerializerSpec.scala
+++ b/src/test/scala/fs2/kafka/HeaderSerializerSpec.scala
@@ -31,6 +31,41 @@ final class HeaderSerializerSpec extends BaseCatsSpec {
     }
   }
 
+  test("HeaderSerializer#asNull") {
+    val serializer =
+      HeaderSerializer.asNull[Int]
+
+    forAll { i: Int =>
+      val serialized = serializer.serialize(i)
+      serialized shouldBe null
+    }
+  }
+
+  test("HeaderSerializer#empty") {
+    val serializer =
+      HeaderSerializer.empty[Int]
+
+    forAll { i: Int =>
+      val serialized = serializer.serialize(i)
+      serialized shouldBe empty
+    }
+  }
+
+  test("HeaderSerializer#option") {
+    val serializer =
+      HeaderSerializer[Option[String]]
+
+    serializer.serialize(None) shouldBe null
+
+    forAll { s: String =>
+      serializer.serialize(Some(s)) shouldBe s.getBytes
+    }
+  }
+
+  test("HeaderSerializer#unit") {
+    HeaderSerializer[Unit].serialize(()) shouldBe null
+  }
+
   test("HeaderSerializer#toString") {
     assert(HeaderSerializer[Int].toString startsWith "HeaderSerializer$")
   }
@@ -60,7 +95,7 @@ final class HeaderSerializerSpec extends BaseCatsSpec {
     )
   }
 
-  test("Serializer#uuid") {
+  test("HeaderSerializer#uuid") {
     roundtripAttempt(
       HeaderSerializer.uuid(StandardCharsets.UTF_8),
       HeaderDeserializer.uuid(StandardCharsets.UTF_8)

--- a/src/test/scala/fs2/kafka/SerializerSpec.scala
+++ b/src/test/scala/fs2/kafka/SerializerSpec.scala
@@ -78,6 +78,41 @@ final class SerializerSpec extends BaseCatsSpec {
     }
   }
 
+  test("Serializer#asNull") {
+    val serializer =
+      Serializer.asNull[Int]
+
+    forAll { i: Int =>
+      val serialized = serializer.serialize("topic", i)
+      serialized shouldBe null
+    }
+  }
+
+  test("Serializer#empty") {
+    val serializer =
+      Serializer.empty[Int]
+
+    forAll { i: Int =>
+      val serialized = serializer.serialize("topic", i)
+      serialized shouldBe empty
+    }
+  }
+
+  test("Serializer#option") {
+    val serializer =
+      Serializer[Option[String]]
+
+    serializer.serialize("topic", None) shouldBe null
+
+    forAll { s: String =>
+      serializer.serialize("topic", Some(s)) shouldBe s.getBytes
+    }
+  }
+
+  test("Serializer#unit") {
+    Serializer[Unit].serialize("topic", ()) shouldBe null
+  }
+
   test("Serializer#toString") {
     assert(Serializer[Int].toString startsWith "Serializer$")
   }


### PR DESCRIPTION
This pull request aims to make it easier to work with unkeyed records.

If all records are unkeyed, simply use `Unit` serializers and deserializers. These are available implicitly as `Serializer.unit` and `Deserializer.unit`, so you can use `ProducerSettings[Unit, V]` and `ConsumerSettings[Unit, V]`.

If some records are keyed and some are not, use `Serializer#option` and `Deserializer#option`, also available implicitly via `Serializer.option` and `Deserializer.option`. These serializers represent`None` as `null` in serialized form. Similarly, you can use these via `ProducerSettings[Option[K], V]` and `ConsumerSettings[Option[K], V]`.

For more complex types and cases, there is `Serializer.asNull[A]` and `Serializer.empty[A]` which serializes arbitrary values of a given type as `null` or the empty `Array[Byte]`, respectively.

For parity, similar additions have been made to `HeaderSerializer` and `HeaderDeserializer`.

Detailed changes:
- Add `Deserializer#option`, and `Deserializer.option` and `unit`.
- Add `HeaderDeserializer#option` and `HeaderDeserializer.option` and `unit`.
- Add `Serializer#option`, and `Serializer.option`, `asNull`, `empty` and `unit`.
- Add `HeaderSerializer#option`, and `Serializer.option`, `asNull`, `empty` and `unit`.

Fixes #96.