### PR TITLE
Change to run rebalance callbacks during poll

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -155,7 +155,11 @@ lazy val mimaSettings = Seq(
       ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.KafkaConsumer.assignment"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.KafkaConsumer.position"),
       ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.KafkaConsumer.seekToBeginning"),
-      ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.KafkaConsumer.seekToEnd")
+      ProblemFilters.exclude[ReversedMissingMethodProblem]("fs2.kafka.KafkaConsumer.seekToEnd"),
+      ProblemFilters.exclude[MissingClassProblem]("fs2.kafka.internal.KafkaConsumerActor$Request$Revoked"),
+      ProblemFilters.exclude[MissingClassProblem]("fs2.kafka.internal.KafkaConsumerActor$Request$Assigned$"),
+      ProblemFilters.exclude[MissingClassProblem]("fs2.kafka.internal.KafkaConsumerActor$Request$Assigned"),
+      ProblemFilters.exclude[MissingClassProblem]("fs2.kafka.internal.KafkaConsumerActor$Request$Revoked$")
     )
     // format: on
   }

--- a/src/main/scala/fs2/kafka/KafkaConsumer.scala
+++ b/src/main/scala/fs2/kafka/KafkaConsumer.scala
@@ -423,7 +423,7 @@ private[kafka] object KafkaConsumer {
         def onRebalance(
           partitions: Queue[F, Stream[F, CommittableMessage[F, K, V]]]
         ): OnRebalance[F, K, V] = OnRebalance(
-          onAssigned = assigned => enqueueStreams(assigned.partitions, partitions),
+          onAssigned = assigned => enqueueStreams(assigned, partitions),
           onRevoked = _ => F.unit
         )
 


### PR DESCRIPTION
Issue #105 describes a situation where the following happens.

1. Assignment of `x` happens, an `Assigned(x)` message is put on the Actor's queue.
2. An `Assignment` request is processed and returns `x` as current assignment.
    This also registers a rebalance listener for assignments.
3. Streams are enqueued for the current assignment `x`.
4. The rebalance listener enqueues streams for assignment `x`.

Steps 3 and 4 can happen in reverse order, and there can be more assignments happening at the same time, but this covers the issue. The reason this happens is due to the fact that rebalance listeners simply queue messages onto the Actor's queue, rather than running the rebalance callbacks. This pull request changes to synchronously run the rebalance callbacks in the rebalance listener.

This also fixes another issue: we currently break the `ConsumerRebalanceListener` guarantee that `onPartitionsRevoked` is called before `onPartitionsAssigned` by asyncronously enqueuing the `Assigned` and `Revoked` messages (`Assigned` can potentially happen before `Revoked`).

Fixes #105.