### PR TITLE
Change to only pause/resume when necessary

### DIFF
--- a/src/main/scala/fs2/kafka/internal/KafkaConsumerActor.scala
+++ b/src/main/scala/fs2/kafka/internal/KafkaConsumerActor.scala
@@ -411,8 +411,12 @@ private[kafka] final class KafkaConsumerActor[F[_], K, V](
           val resume = (requested intersect assigned) diff available
           val pause = assigned diff resume
 
-          consumer.pause(pause.asJava)
-          consumer.resume(resume.asJava)
+          if (pause.nonEmpty)
+            consumer.pause(pause.asJava)
+
+          if (resume.nonEmpty)
+            consumer.resume(resume.asJava)
+
           consumer.poll(pollTimeout)
         }
       }


### PR DESCRIPTION
This is mainly to reduce the amount of debug logs when pausing/resuming with an empty set of partitions.