### PR TITLE
Add internal WithConsumer construct

### DIFF
--- a/src/main/scala/fs2/kafka/internal/WithConsumer.scala
+++ b/src/main/scala/fs2/kafka/internal/WithConsumer.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018-2019 OVO Energy Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fs2.kafka.internal
+
+import cats.effect._
+import cats.implicits._
+import fs2.kafka._
+import fs2.kafka.internal.syntax._
+import scala.concurrent.ExecutionContext
+
+private[kafka] sealed abstract class WithConsumer[F[_]] {
+  def apply[A](f: ByteConsumer => F[A]): F[A]
+}
+
+private[kafka] object WithConsumer {
+  def of[F[_], K, V](
+    settings: ConsumerSettings[F, K, V]
+  )(
+    implicit F: Concurrent[F],
+    context: ContextShift[F]
+  ): Resource[F, WithConsumer[F]] = {
+    val executionContextResource =
+      settings.executionContext
+        .map(Resource.pure[F, ExecutionContext])
+        .getOrElse(consumerExecutionContextResource)
+
+    executionContextResource.flatMap { executionContext =>
+      Resource.make[F, WithConsumer[F]] {
+        settings.createConsumer
+          .flatMap(Synchronized[F].of)
+          .map { synchronizedConsumer =>
+            new WithConsumer[F] {
+              override def apply[A](f: ByteConsumer => F[A]): F[A] =
+                synchronizedConsumer.use { consumer =>
+                  context.evalOn(executionContext) {
+                    f(consumer)
+                  }
+                }
+            }
+          }
+      } { withConsumer =>
+        withConsumer { consumer =>
+          F.delay(consumer.close(settings.closeTimeout.asJava))
+        }
+      }
+    }
+  }
+}

--- a/src/main/scala/fs2/kafka/package.scala
+++ b/src/main/scala/fs2/kafka/package.scala
@@ -28,6 +28,9 @@ import scala.concurrent.duration.FiniteDuration
 package object kafka {
   type Id[+A] = A
 
+  private[kafka] type ByteConsumer =
+    org.apache.kafka.clients.consumer.Consumer[Array[Byte], Array[Byte]]
+
   private[kafka] type KafkaDeserializer[A] =
     org.apache.kafka.common.serialization.Deserializer[A]
 


### PR DESCRIPTION
- Add internal `WithConsumer` for using a Java Kafka `Consumer` in a thread-safe manner (using `Synchronized`)  and on a blocking `ExecutionContext`. This is effectively the same function as `KafkaConsumerActor#withConsumer`.
- Change to move all Java Kafka `Consumer` calls not requiring the actor's shared state from `KafkaConsumerActor` to `KafkaConsumer`, making use of `WithConsumer`.