### PR TITLE
Simplify callback code in KafkaProducer#produce

### DIFF
--- a/src/main/scala/fs2/kafka/KafkaProducer.scala
+++ b/src/main/scala/fs2/kafka/KafkaProducer.scala
@@ -67,10 +67,10 @@ private[kafka] object KafkaProducer {
         .create(settings)
     } { producer =>
       F.delay {
-        producer.close(settings.closeTimeout.asJava)
-      }
-      .start
-      .flatMap(_.join)
+          producer.close(settings.closeTimeout.asJava)
+        }
+        .start
+        .flatMap(_.join)
     }
   }
 


### PR DESCRIPTION
Because there's only one place where the promise could be completed, I figured Deferred could be replaced with a simple `async`. Tests pass (locally), so I'm submitting, but if there's a specific reason why Deferred was used feel free to close this ;)