### PR TITLE
Change to not store records internally in the actor

### DIFF
--- a/src/main/scala/fs2/kafka/internal/LogEntry.scala
+++ b/src/main/scala/fs2/kafka/internal/LogEntry.scala
@@ -99,15 +99,6 @@ private[kafka] object LogEntry {
       s"Completed fetches with records for partitions [${recordsString(records)}]. Current state [$state]."
   }
 
-  final case class RevokedFetchesWithRecords[F[_], K, V](
-    records: Records[F, K, V],
-    state: State[F, K, V]
-  ) extends LogEntry {
-    override def level: LogLevel = Debug
-    override def message: String =
-      s"Revoked fetches with records for partitions [${recordsString(records)}]. Current state [$state]."
-  }
-
   final case class RevokedFetchesWithoutRecords[F[_], K, V](
     partitions: Set[TopicPartition],
     state: State[F, K, V]


### PR DESCRIPTION
This pull request changes `KafkaConsumerActor` to not store records internally when records are received for partitions for which there are no requests. Instead, we change to `poll(Duration.Zero)` when there are no requests. This avoids assignment and records to be returned in one `poll`, which is the cause for 'records for partitions without requests'. This is also similar to what Alpakka Kafka does, which seems to have worked there. We add checks to make sure nothing unexpected is received.