### PR TITLE
Add new transactional producer

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,6 +32,7 @@ lazy val docs = project
 lazy val dependencySettings = Seq(
   libraryDependencies ++= Seq(
     "co.fs2" %% "fs2-core" % fs2Version,
+    "org.typelevel" %% "cats-effect" % "1.3.0",
     "org.apache.kafka" % "kafka-clients" % kafkaVersion
   ),
   libraryDependencies ++= Seq(

--- a/src/main/scala/fs2/kafka/CommittableOffset.scala
+++ b/src/main/scala/fs2/kafka/CommittableOffset.scala
@@ -120,7 +120,7 @@ object CommittableOffset {
         Map(_topicPartition -> _offsetAndMetadata)
 
       override def batch: CommittableOffsetBatch[F] =
-        CommittableOffsetBatch(offsets, consumerGroupId.toSet[String], _commit)
+        CommittableOffsetBatch(offsets, _commit)
 
       override def commit: F[Unit] =
         _commit(offsets)

--- a/src/main/scala/fs2/kafka/CommittableOffset.scala
+++ b/src/main/scala/fs2/kafka/CommittableOffset.scala
@@ -120,7 +120,7 @@ object CommittableOffset {
         Map(_topicPartition -> _offsetAndMetadata)
 
       override def batch: CommittableOffsetBatch[F] =
-        CommittableOffsetBatch(offsets, _commit)
+        CommittableOffsetBatch(offsets, consumerGroupId.toSet[String], _commit)
 
       override def commit: F[Unit] =
         _commit(offsets)

--- a/src/main/scala/fs2/kafka/CommittableProducerRecords.scala
+++ b/src/main/scala/fs2/kafka/CommittableProducerRecords.scala
@@ -16,9 +16,24 @@
 
 package fs2.kafka
 
+/**
+  * [[CommittableProducerRecords]] represents zero or more [[ProducerRecord]]s
+  * and a [[CommittableOffset]] which can be used by [[TransactionalKafkaProducer]]
+  * to produce the records and commit the offset atomically.
+  * [[CommittableProducerRecords]]s can be created using one of the following options.<br>
+  * <br>
+  * - `CommittableProducerRecords#apply` to produce zero or more records
+  * within the same transaction that an offset is committed.<br>
+  * - `CommittableProducerRecords#one` to produce exactly one record within
+  * the same transaction that an offset is committed.<br>
+  * <br>
+  */
 sealed abstract class CommittableProducerRecords[F[_], G[+ _], +K, +V] {
+
+  /** The records to produce. Can be empty to simply commit the offset. */
   def records: G[ProducerRecord[K, V]]
 
+  /** The offset to commit. */
   def committableOffset: CommittableOffset[F]
 }
 
@@ -31,12 +46,22 @@ object CommittableProducerRecords {
       s"CommittableProducerRecords($records, $committableOffset)"
   }
 
+  /**
+    * Creates a new [[CommittableProducerRecords]] for producing zero or
+    * more [[ProducerRecord]]s and committing an offset atomically within
+    * a transaction.
+    */
   def apply[F[_], G[+ _], K, V](
     records: G[ProducerRecord[K, V]],
     committableOffset: CommittableOffset[F]
   ): CommittableProducerRecords[F, G, K, V] =
     new CommittableProducerRecordsImpl(records, committableOffset)
 
+  /**
+    * Creates a new [[CommittableProducerRecords]] for producing exactly
+    * one [[ProducerRecord]] and committing an offset atomically within
+    * a transaction.
+    */
   def one[F[_], K, V](
     record: ProducerRecord[K, V],
     committableOffset: CommittableOffset[F]

--- a/src/main/scala/fs2/kafka/CommittableProducerRecords.scala
+++ b/src/main/scala/fs2/kafka/CommittableProducerRecords.scala
@@ -16,6 +16,8 @@
 
 package fs2.kafka
 
+import cats.data.Chain
+
 /**
   * [[CommittableProducerRecords]] represents zero or more [[ProducerRecord]]s
   * and a [[CommittableOffset]] which can be used by [[TransactionalKafkaProducer]]
@@ -65,6 +67,6 @@ object CommittableProducerRecords {
   def one[F[_], K, V](
     record: ProducerRecord[K, V],
     committableOffset: CommittableOffset[F]
-  ): CommittableProducerRecords[F, Id, K, V] =
-    apply[F, Id, K, V](record, committableOffset)
+  ): CommittableProducerRecords[F, Chain, K, V] =
+    apply(Chain.one(record), committableOffset)
 }

--- a/src/main/scala/fs2/kafka/CommittableProducerRecords.scala
+++ b/src/main/scala/fs2/kafka/CommittableProducerRecords.scala
@@ -20,15 +20,15 @@ import cats.data.Chain
 
 /**
   * [[CommittableProducerRecords]] represents zero or more [[ProducerRecord]]s
-  * and a [[CommittableOffset]] which can be used by [[TransactionalKafkaProducer]]
-  * to produce the records and commit the offset atomically.
+  * and a [[CommittableOffset]], used by [[TransactionalKafkaProducer]] to
+  * produce the records and commit the offset atomically.<br>
+  * <br>
   * [[CommittableProducerRecords]]s can be created using one of the following options.<br>
   * <br>
   * - `CommittableProducerRecords#apply` to produce zero or more records
-  * within the same transaction that an offset is committed.<br>
+  * within the same transaction as the offset is committed.<br>
   * - `CommittableProducerRecords#one` to produce exactly one record within
-  * the same transaction that an offset is committed.<br>
-  * <br>
+  * the same transaction as the offset is committed.
   */
 sealed abstract class CommittableProducerRecords[F[_], G[+ _], +K, +V] {
 

--- a/src/main/scala/fs2/kafka/CommittableProducerRecords.scala
+++ b/src/main/scala/fs2/kafka/CommittableProducerRecords.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018-2019 OVO Energy Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fs2.kafka
+
+sealed abstract class CommittableProducerRecords[F[_], G[+ _], +K, +V] {
+  def records: G[ProducerRecord[K, V]]
+
+  def committableOffset: CommittableOffset[F]
+}
+
+object CommittableProducerRecords {
+  private[this] final class CommittableProducerRecordsImpl[F[_], G[+ _], +K, +V](
+    override val records: G[ProducerRecord[K, V]],
+    override val committableOffset: CommittableOffset[F]
+  ) extends CommittableProducerRecords[F, G, K, V] {
+    override def toString: String =
+      s"CommittableProducerRecords($records, $committableOffset)"
+  }
+
+  def apply[F[_], G[+ _], K, V](
+    records: G[ProducerRecord[K, V]],
+    committableOffset: CommittableOffset[F]
+  ): CommittableProducerRecords[F, G, K, V] =
+    new CommittableProducerRecordsImpl(records, committableOffset)
+
+  def one[F[_], K, V](
+    record: ProducerRecord[K, V],
+    committableOffset: CommittableOffset[F]
+  ): CommittableProducerRecords[F, Id, K, V] =
+    apply[F, Id, K, V](record, committableOffset)
+}

--- a/src/main/scala/fs2/kafka/ConsumerGroupException.scala
+++ b/src/main/scala/fs2/kafka/ConsumerGroupException.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018-2019 OVO Energy Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fs2.kafka
+
+import org.apache.kafka.common.KafkaException
+
+/**
+  * [[ConsumerGroupException]] indicates that one of the two following
+  * conditions occurred before records were produced transactionally
+  * with the [[TransactionalKafkaProducer]].<br>
+  * <br>
+  * - There were [[CommittableOffset]]s without a consumer group ID.<br>
+  * - There were [[CommittableOffset]]s for multiple consumer group IDs.
+  */
+sealed abstract class ConsumerGroupException(groupIds: Set[String])
+    extends KafkaException({
+      val groupIdsString = groupIds.toList.sorted.mkString(", ")
+      s"multiple or missing consumer group ids in transaction [$groupIdsString]"
+    })
+
+private[kafka] object ConsumerGroupException {
+  def apply(groupIds: Set[String]): ConsumerGroupException =
+    new ConsumerGroupException(groupIds) {
+      override def toString: String =
+        s"fs2.kafka.ConsumerGroupException: $getMessage"
+    }
+}

--- a/src/main/scala/fs2/kafka/ConsumerSettings.scala
+++ b/src/main/scala/fs2/kafka/ConsumerSettings.scala
@@ -16,14 +16,15 @@
 
 package fs2.kafka
 
-import cats.effect.Sync
 import cats.Show
+import cats.effect.Sync
 import org.apache.kafka.clients.consumer.{Consumer, ConsumerConfig}
-import org.apache.kafka.common.requests.OffsetFetchResponse
+import org.apache.kafka.common.requests.{IsolationLevel, OffsetFetchResponse}
 import org.apache.kafka.common.serialization.ByteArrayDeserializer
+
 import scala.collection.JavaConverters._
-import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
 
 /**
   * [[ConsumerSettings]] contain settings necessary to create a
@@ -222,6 +223,18 @@ sealed abstract class ConsumerSettings[F[_], K, V] {
     * }}}
     */
   def withDefaultApiTimeout(defaultApiTimeout: FiniteDuration): ConsumerSettings[F, K, V]
+
+  /**
+    * Returns a new [[ConsumerSettings]] instance with the specified
+    * isolation level. This is equivalent to setting the following property
+    * using the [[withProperty]] function, except you can specify it
+    * with an `IsolationLevel` instead of a `String`.
+    *
+    * {{{
+    * ConsumerConfig.ISOLATION_LEVEL_CONFIG
+    * }}}
+    */
+  def withIsolationLevel(isolationLevel: IsolationLevel): ConsumerSettings[F, K, V]
 
   /**
     * Includes a property with the specified `key` and `value`.
@@ -462,6 +475,15 @@ object ConsumerSettings {
       withProperty(
         ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG,
         defaultApiTimeout.toMillis.toString
+      )
+
+    override def withIsolationLevel(isolationLevel: IsolationLevel): ConsumerSettings[F, K, V] =
+      withProperty(
+        ConsumerConfig.ISOLATION_LEVEL_CONFIG,
+        isolationLevel match {
+          case IsolationLevel.READ_COMMITTED   => "read_committed"
+          case IsolationLevel.READ_UNCOMMITTED => "read_uncommitted"
+        }
       )
 
     override def withProperty(key: String, value: String): ConsumerSettings[F, K, V] =

--- a/src/main/scala/fs2/kafka/ConsumerSettings.scala
+++ b/src/main/scala/fs2/kafka/ConsumerSettings.scala
@@ -16,15 +16,14 @@
 
 package fs2.kafka
 
-import cats.Show
 import cats.effect.Sync
+import cats.Show
 import org.apache.kafka.clients.consumer.{Consumer, ConsumerConfig}
-import org.apache.kafka.common.requests.{IsolationLevel, OffsetFetchResponse}
+import org.apache.kafka.common.requests.OffsetFetchResponse
 import org.apache.kafka.common.serialization.ByteArrayDeserializer
-
 import scala.collection.JavaConverters._
-import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext
 
 /**
   * [[ConsumerSettings]] contain settings necessary to create a
@@ -231,9 +230,9 @@ sealed abstract class ConsumerSettings[F[_], K, V] {
 
   /**
     * Returns a new [[ConsumerSettings]] instance with the specified
-    * isolation level. This is equivalent to setting the following property
-    * using the [[withProperty]] function, except you can specify it
-    * with an `IsolationLevel` instead of a `String`.
+    * isolation level. This is equivalent to setting the following
+    * property using the [[withProperty]] function, except you can
+    * specify it with an [[IsolationLevel]] instead of a `String`.
     *
     * {{{
     * ConsumerConfig.ISOLATION_LEVEL_CONFIG
@@ -488,8 +487,8 @@ object ConsumerSettings {
       withProperty(
         ConsumerConfig.ISOLATION_LEVEL_CONFIG,
         isolationLevel match {
-          case IsolationLevel.READ_COMMITTED   => "read_committed"
-          case IsolationLevel.READ_UNCOMMITTED => "read_uncommitted"
+          case IsolationLevel.ReadCommittedIsolationLevel   => "read_committed"
+          case IsolationLevel.ReadUncommittedIsolationLevel => "read_uncommitted"
         }
       )
 
@@ -568,7 +567,7 @@ object ConsumerSettings {
             byteArrayDeserializer,
             byteArrayDeserializer
           )
-      }
+        }
     )
 
   /**

--- a/src/main/scala/fs2/kafka/ConsumerSettings.scala
+++ b/src/main/scala/fs2/kafka/ConsumerSettings.scala
@@ -560,7 +560,7 @@ object ConsumerSettings {
             byteArrayDeserializer,
             byteArrayDeserializer
           )
-        }
+      }
     )
 
   /**

--- a/src/main/scala/fs2/kafka/ConsumerSettings.scala
+++ b/src/main/scala/fs2/kafka/ConsumerSettings.scala
@@ -568,7 +568,7 @@ object ConsumerSettings {
             byteArrayDeserializer,
             byteArrayDeserializer
           )
-        }
+      }
     )
 
   /**

--- a/src/main/scala/fs2/kafka/ConsumerSettings.scala
+++ b/src/main/scala/fs2/kafka/ConsumerSettings.scala
@@ -127,6 +127,11 @@ sealed abstract class ConsumerSettings[F[_], K, V] {
   def withGroupId(groupId: String): ConsumerSettings[F, K, V]
 
   /**
+    * The group ID consumers created with these settings will report.
+    */
+  def groupId: Option[String]
+
+  /**
     * Returns a new [[ConsumerSettings]] instance with the specified
     * max poll records. This is equivalent to setting the following
     * property using the [[withProperty]] function, except you can
@@ -438,6 +443,8 @@ object ConsumerSettings {
     override def withGroupId(groupId: String): ConsumerSettings[F, K, V] =
       withProperty(ConsumerConfig.GROUP_ID_CONFIG, groupId)
 
+    override def groupId: Option[String] = properties.get(ConsumerConfig.GROUP_ID_CONFIG)
+
     override def withMaxPollRecords(maxPollRecords: Int): ConsumerSettings[F, K, V] =
       withProperty(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, maxPollRecords.toString)
 
@@ -561,7 +568,7 @@ object ConsumerSettings {
             byteArrayDeserializer,
             byteArrayDeserializer
           )
-      }
+        }
     )
 
   /**

--- a/src/main/scala/fs2/kafka/ConsumerSettings.scala
+++ b/src/main/scala/fs2/kafka/ConsumerSettings.scala
@@ -126,11 +126,6 @@ sealed abstract class ConsumerSettings[F[_], K, V] {
   def withGroupId(groupId: String): ConsumerSettings[F, K, V]
 
   /**
-    * The group ID consumers created with these settings will report.
-    */
-  def groupId: Option[String]
-
-  /**
     * Returns a new [[ConsumerSettings]] instance with the specified
     * max poll records. This is equivalent to setting the following
     * property using the [[withProperty]] function, except you can
@@ -441,8 +436,6 @@ object ConsumerSettings {
 
     override def withGroupId(groupId: String): ConsumerSettings[F, K, V] =
       withProperty(ConsumerConfig.GROUP_ID_CONFIG, groupId)
-
-    override def groupId: Option[String] = properties.get(ConsumerConfig.GROUP_ID_CONFIG)
 
     override def withMaxPollRecords(maxPollRecords: Int): ConsumerSettings[F, K, V] =
       withProperty(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, maxPollRecords.toString)

--- a/src/main/scala/fs2/kafka/IsolationLevel.scala
+++ b/src/main/scala/fs2/kafka/IsolationLevel.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018-2019 OVO Energy Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fs2.kafka
+
+/**
+  * The available options for [[ConsumerSettings#withIsolationLevel]].<br>
+  * <br>
+  * Available options include:<br>
+  * - [[IsolationLevel#ReadCommitted]] to only read committed records,<br>
+  * - [[IsolationLevel#ReadUncommitted]] to also read uncommitted records.
+  */
+sealed abstract class IsolationLevel
+
+object IsolationLevel {
+  private[kafka] case object ReadCommittedIsolationLevel extends IsolationLevel {
+    override def toString: String = "ReadCommitted"
+  }
+
+  private[kafka] case object ReadUncommittedIsolationLevel extends IsolationLevel {
+    override def toString: String = "ReadUncommitted"
+  }
+
+  /**
+    * Option to only read committed records.
+    */
+  val ReadCommitted: IsolationLevel = ReadCommittedIsolationLevel
+
+  /**
+    * Option to read both committed and uncommitted records.
+    */
+  val ReadUncommitted: IsolationLevel = ReadUncommittedIsolationLevel
+}

--- a/src/main/scala/fs2/kafka/KafkaConsumer.scala
+++ b/src/main/scala/fs2/kafka/KafkaConsumer.scala
@@ -609,7 +609,7 @@ private[kafka] object KafkaConsumer {
       polls <- Resource.liftF(Queue.bounded[F, Request[F, K, V]](1))
       ref <- Resource.liftF(Ref.of[F, State[F, K, V]](State.empty))
       streamId <- Resource.liftF(Ref.of[F, Int](0))
-      withConsumer <- WithConsumer.of(settings)
+      withConsumer <- WithConsumer(settings)
       actor = new KafkaConsumerActor(settings, ref, requests, withConsumer)
       actor <- startConsumerActor(requests, polls, actor)
       polls <- startPollScheduler(polls, settings.pollInterval)

--- a/src/main/scala/fs2/kafka/KafkaProducer.scala
+++ b/src/main/scala/fs2/kafka/KafkaProducer.scala
@@ -123,7 +123,7 @@ private[kafka] object KafkaProducer {
             }
             .as(deferred.get.rethrow)
         }
-      }
+    }
 
   private[this] def serializeToBytes[F[_], K, V](
     settings: ProducerSettings[F, K, V],

--- a/src/main/scala/fs2/kafka/KafkaProducer.scala
+++ b/src/main/scala/fs2/kafka/KafkaProducer.scala
@@ -59,7 +59,7 @@ sealed abstract class KafkaProducer[F[_], K, V] {
 }
 
 private[kafka] object KafkaProducer {
-  def producerResource[F[_], K, V](
+  def resource[F[_], K, V](
     settings: ProducerSettings[F, K, V]
   )(
     implicit F: ConcurrentEffect[F],

--- a/src/main/scala/fs2/kafka/ProducerSettings.scala
+++ b/src/main/scala/fs2/kafka/ProducerSettings.scala
@@ -368,7 +368,7 @@ object ProducerSettings {
             byteArraySerializer,
             byteArraySerializer
           )
-        }
+      }
     )
 
   /**

--- a/src/main/scala/fs2/kafka/ProducerSettings.scala
+++ b/src/main/scala/fs2/kafka/ProducerSettings.scala
@@ -271,7 +271,7 @@ object ProducerSettings {
     override val valueSerializer: Serializer[F, V],
     override val executionContext: Option[ExecutionContext],
     override val properties: Map[String, String],
-    override val closeTimeout: FiniteDuration
+    override val closeTimeout: FiniteDuration,
     val createProducerWith: Map[String, String] => F[Producer[Array[Byte], Array[Byte]]]
   ) extends ProducerSettings[F, K, V] {
     override def withExecutionContext(

--- a/src/main/scala/fs2/kafka/ProducerSettings.scala
+++ b/src/main/scala/fs2/kafka/ProducerSettings.scala
@@ -341,7 +341,8 @@ object ProducerSettings {
     override def withTransactionalId(transactionalId: String): ProducerSettings[F, K, V] =
       withProperty(ProducerConfig.TRANSACTIONAL_ID_CONFIG, transactionalId)
 
-    override def withTransactionTimeout(transactionTimeout: FiniteDuration): ProducerSettings[F, K, V] =
+    override def withTransactionTimeout(
+      transactionTimeout: FiniteDuration): ProducerSettings[F, K, V] =
       withProperty(ProducerConfig.TRANSACTION_TIMEOUT_CONFIG, transactionTimeout.toMillis.toString)
 
     override def withProperty(key: String, value: String): ProducerSettings[F, K, V] =

--- a/src/main/scala/fs2/kafka/ProducerSettings.scala
+++ b/src/main/scala/fs2/kafka/ProducerSettings.scala
@@ -193,6 +193,29 @@ sealed abstract class ProducerSettings[F[_], K, V] {
   def withDeliveryTimeout(deliveryTimeout: FiniteDuration): ProducerSettings[F, K, V]
 
   /**
+    * Returns a new [[ProducerSettings]] instance with the specified
+    * transactional ID. This is equivalent to setting the following
+    * property using the [[withProperty]] function.
+    *
+    * {{{
+    * ProducerConfig.TRANSACTIONAL_ID_CONFIG
+    * }}}
+    */
+  def withTransactionalId(transactionalId: String): ProducerSettings[F, K, V]
+
+  /**
+    * Returns a new [[ProducerSettings]] instance with the specified
+    * transactional ID. This is equivalent to setting the following
+    * property using the [[withProperty]] function, except you can specify
+    * it with a `FiniteDuration` instead of a `String`
+    *
+    * {{{
+    * ProducerConfig.TRANSACTION_TIMEOUT_CONFIG
+    * }}}
+    */
+  def withTransactionTimeout(transactionTimeout: FiniteDuration): ProducerSettings[F, K, V]
+
+  /**
     * Includes a property with the specified `key` and `value`.
     * The key should be one of the keys in `ProducerConfig`,
     * and the value should be a valid choice for the key.
@@ -314,6 +337,12 @@ object ProducerSettings {
 
     override def withDeliveryTimeout(deliveryTimeout: FiniteDuration): ProducerSettings[F, K, V] =
       withProperty(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, deliveryTimeout.toMillis.toString)
+
+    override def withTransactionalId(transactionalId: String): ProducerSettings[F, K, V] =
+      withProperty(ProducerConfig.TRANSACTIONAL_ID_CONFIG, transactionalId)
+
+    override def withTransactionTimeout(transactionTimeout: FiniteDuration): ProducerSettings[F, K, V] =
+      withProperty(ProducerConfig.TRANSACTION_TIMEOUT_CONFIG, transactionTimeout.toMillis.toString)
 
     override def withProperty(key: String, value: String): ProducerSettings[F, K, V] =
       copy(properties = properties.updated(key, value))

--- a/src/main/scala/fs2/kafka/ProducerSettings.scala
+++ b/src/main/scala/fs2/kafka/ProducerSettings.scala
@@ -205,9 +205,9 @@ sealed abstract class ProducerSettings[F[_], K, V] {
 
   /**
     * Returns a new [[ProducerSettings]] instance with the specified
-    * transactional ID. This is equivalent to setting the following
-    * property using the [[withProperty]] function, except you can specify
-    * it with a `FiniteDuration` instead of a `String`
+    * transaction timeout. This is equivalent to setting the following
+    * property using the [[withProperty]] function, except you can
+    * specify it with a `FiniteDuration` instead of a `String`.
     *
     * {{{
     * ProducerConfig.TRANSACTION_TIMEOUT_CONFIG
@@ -342,7 +342,8 @@ object ProducerSettings {
       withProperty(ProducerConfig.TRANSACTIONAL_ID_CONFIG, transactionalId)
 
     override def withTransactionTimeout(
-      transactionTimeout: FiniteDuration): ProducerSettings[F, K, V] =
+      transactionTimeout: FiniteDuration
+    ): ProducerSettings[F, K, V] =
       withProperty(ProducerConfig.TRANSACTION_TIMEOUT_CONFIG, transactionTimeout.toMillis.toString)
 
     override def withProperty(key: String, value: String): ProducerSettings[F, K, V] =

--- a/src/main/scala/fs2/kafka/TransactionalKafkaProducer.scala
+++ b/src/main/scala/fs2/kafka/TransactionalKafkaProducer.scala
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2018-2019 OVO Energy Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fs2.kafka
+
+import cats.Traverse
+import cats.effect.concurrent.Deferred
+import cats.effect.{ConcurrentEffect, ContextShift, ExitCase, IO, Resource, Sync}
+import cats.implicits._
+import fs2.kafka.internal.syntax._
+import org.apache.kafka.clients.producer.{Callback, Producer, RecordMetadata}
+
+import scala.concurrent.ExecutionContext
+
+/**
+  * [[TransactionalKafkaProducer]] represents a producer of Kafka messages specialized
+  * for "read-process-write" streams, with the ability to simultaneously produce
+  * `ProducerRecord`s and commit corresponding `CommittableOffset`s using [[produce]].
+  * Records are wrapped in [[TransactionalProducerMessage]] which allow an arbitrary value, that
+  * is a passthrough, to be included in the result.
+  */
+sealed abstract class TransactionalKafkaProducer[F[_], K, V] {
+
+  /**
+    * Produces the `ProducerRecord`s in the specified [[TransactionalProducerMessage]]
+    * in four steps: first a transaction is initialized, then the records are
+    * placed in the buffer of the producer, then the offsets of the records are
+    * sent to the trancation, and lastly the transaction is completed. The
+    * returned effect completes when the transaction is successfully completed.<br>
+    * <br>
+    * If you're only interested in the passthrough value, and not the whole
+    * [[ProducerResult]], you can instead use [[producePassthrough]] which
+    * only keeps the passthrough value in the output.
+    */
+  def produce[G[+ _], P](
+    message: TransactionalProducerMessage[F, G, K, V, P]
+  ): F[ProducerResult[G, K, V, P]]
+
+  /**
+    * Like [[produce]] but only keeps the passthrough value of the
+    * [[ProducerResult]] rather than the whole [[ProducerResult]].
+    */
+  def producePassthrough[G[+ _], P](
+    message: TransactionalProducerMessage[F, G, K, V, P]
+  ): F[P]
+}
+
+private[kafka] object TransactionalKafkaProducer {
+  private[this] def executionContextResource[F[_], K, V](
+    settings: ProducerSettings[F, K, V]
+  )(implicit F: Sync[F]): Resource[F, ExecutionContext] =
+    settings.executionContext match {
+      case Some(executionContext) => Resource.pure(executionContext)
+      case None                   => producerExecutionContextResource
+    }
+
+  private[this] def createProducer[F[_], K, V](
+    settings: ProducerSettings[F, K, V],
+    executionContext: ExecutionContext
+  )(
+    implicit F: Sync[F],
+    context: ContextShift[F]
+  ): Resource[F, Producer[Array[Byte], Array[Byte]]] = {
+    Resource
+      .make[F, Producer[Array[Byte], Array[Byte]]] {
+        settings.createProducer
+      } { producer =>
+        context.evalOn(executionContext) {
+          F.delay(producer.close(settings.closeTimeout.asJava))
+        }
+      }
+      .evalMap { producer =>
+        context.evalOn(executionContext)(F.delay(producer.initTransactions())).as(producer)
+      }
+  }
+
+  def producerResource[F[_], K, V](settings: ProducerSettings[F, K, V])(
+    implicit F: ConcurrentEffect[F],
+    context: ContextShift[F]
+  ): Resource[F, TransactionalKafkaProducer[F, K, V]] =
+    executionContextResource(settings).flatMap { executionContext =>
+      createProducer(settings, executionContext).map { producer =>
+        new TransactionalKafkaProducer[F, K, V] {
+          override def produce[G[+ _], P](
+            message: TransactionalProducerMessage[F, G, K, V, P]
+          ): F[ProducerResult[G, K, V, P]] =
+            produceTransaction(message).map(
+              ProducerResult(_, message.passthrough)(message.traverse)
+            )
+
+          override def producePassthrough[G[+ _], P](
+            message: TransactionalProducerMessage[F, G, K, V, P]
+          ): F[P] = produceTransaction(message).as(message.passthrough)
+
+          private[this] def produceTransaction[G[+ _], P](
+            message: TransactionalProducerMessage[F, G, K, V, P]
+          ): F[G[(ProducerRecord[K, V], RecordMetadata)]] = {
+            implicit val G: Traverse[G] = message.traverse
+
+            F.bracketCase(context.evalOn(executionContext)(F.delay(producer.beginTransaction()))) {
+              _ =>
+                import scala.collection.JavaConverters._
+
+                for {
+                  waitForMetadata <- message.records
+                    .traverse(record => produceRecord(record).map(_.map(record -> _)))
+                    .map(_.sequence)
+                  _ <- context.evalOn(executionContext)(F.delay {
+                    producer.sendOffsetsToTransaction(
+                      message.offsetBatch.offsets.asJava,
+                      message.consumerGroupId
+                    )
+                  })
+                  _ <- context.evalOn(executionContext)(F.delay(producer.commitTransaction()))
+                  recordsWithMetadata <- waitForMetadata
+                } yield {
+                  recordsWithMetadata
+                }
+            } { (_, exitCase) =>
+              exitCase match {
+                case ExitCase.Completed => F.unit
+                case _                  => context.evalOn(executionContext)(F.delay(producer.abortTransaction()))
+              }
+            }
+          }
+
+          private[this] def produceRecord(
+            record: ProducerRecord[K, V]
+          ): F[F[RecordMetadata]] =
+            asJavaRecord(record, settings.shiftSerialization).flatMap { javaRecord =>
+              Deferred[F, Either[Throwable, RecordMetadata]].flatMap { deferred =>
+                F.delay {
+                    producer.send(
+                      javaRecord,
+                      callback { (metadata, throwable) =>
+                        val complete =
+                          deferred.complete {
+                            if (throwable == null)
+                              Right(metadata)
+                            else Left(throwable)
+                          }
+
+                        F.runAsync(complete)(_ => IO.unit).unsafeRunSync()
+                      }
+                    )
+                  }
+                  .as(deferred.get.rethrow)
+              }
+            }
+
+          private[this] def serializeToBytes(
+            record: ProducerRecord[K, V],
+            shiftSerialization: Boolean
+          ): F[(Array[Byte], Array[Byte])] = {
+            def serialize = {
+              val keyBytes =
+                settings.keySerializer
+                  .serialize(record.topic, record.headers, record.key)
+
+              val valueBytes =
+                settings.valueSerializer
+                  .serialize(record.topic, record.headers, record.value)
+
+              keyBytes.product(valueBytes)
+            }
+
+            if (shiftSerialization)
+              context.evalOn(executionContext)(serialize)
+            else serialize
+          }
+
+          private[this] def asJavaRecord(
+            record: ProducerRecord[K, V],
+            shiftSerialization: Boolean
+          ): F[KafkaProducerRecord] =
+            serializeToBytes(record, shiftSerialization).map {
+              case (keyBytes, valueBytes) =>
+                new KafkaProducerRecord(
+                  record.topic,
+                  if (record.partition.isDefined)
+                    record.partition.get: java.lang.Integer
+                  else null,
+                  if (record.timestamp.isDefined)
+                    record.timestamp.get: java.lang.Long
+                  else null,
+                  keyBytes,
+                  valueBytes,
+                  record.headers.asJava
+                )
+            }
+
+          private[this] def callback(f: (RecordMetadata, Throwable) => Unit): Callback =
+            new Callback {
+              override def onCompletion(metadata: RecordMetadata, exception: Exception): Unit =
+                f(metadata, exception)
+            }
+
+          override def toString: String =
+            "TransactionalKafkaProducer$" + System.identityHashCode(this)
+        }
+      }
+    }
+}

--- a/src/main/scala/fs2/kafka/TransactionalKafkaProducer.scala
+++ b/src/main/scala/fs2/kafka/TransactionalKafkaProducer.scala
@@ -58,7 +58,7 @@ sealed abstract class TransactionalKafkaProducer[F[_], K, V] {
 }
 
 private[kafka] object TransactionalKafkaProducer {
-  def producerResource[F[_], K, V](
+  def resource[F[_], K, V](
     settings: ProducerSettings[F, K, V]
   )(
     implicit F: ConcurrentEffect[F],

--- a/src/main/scala/fs2/kafka/TransactionalKafkaProducer.scala
+++ b/src/main/scala/fs2/kafka/TransactionalKafkaProducer.scala
@@ -117,6 +117,7 @@ private[kafka] object TransactionalKafkaProducer {
                       committable.foldable.foldLeft(committable.records, ()) {
                         case (_, record) =>
                           records += record
+                          ()
                       }
                     }
 

--- a/src/main/scala/fs2/kafka/TransactionalProducerMessage.scala
+++ b/src/main/scala/fs2/kafka/TransactionalProducerMessage.scala
@@ -16,237 +16,61 @@
 
 package fs2.kafka
 
-import cats._
-import cats.implicits._
-import fs2.kafka.internal.instances._
-import fs2.kafka.internal.syntax._
-import org.apache.kafka.clients.consumer.OffsetAndMetadata
-import org.apache.kafka.common.TopicPartition
+import cats.{FlatMap, Monad, Traverse}
+import cats.syntax.applicative._
 
-/**
-  * [[TransactionalProducerMessage]] represents zero or more `ProducerRecord`s
-  * paired with corresponding `CommittableOffset`s, together with an arbitrary
-  * passthrough value, all of which can be used with [[TransactionalKafkaProducer]].
-  * [[TransactionalProducerMessage]]s can be created using one of the following options.<br>
-  * <br>
-  * - `TransactionalMessage#apply` to produce zero or more records
-  * and then emit a [[ProducerResult]] with the results and
-  * specified passthrough value.<br>
-  * - `TransactionalMessage#one` to produce exactly one record and
-  * then emit a [[ProducerResult]] with the result and specified
-  * passthrough value.<br>
-  * <br>
-  * The [[passthrough]] and [[records]] can be retrieved from an
-  * existing [[TransactionalProducerMessage]] instance.<br>
-  * <br>
-  * For a [[TransactionalProducerMessage]] to be usable by [[TransactionalKafkaProducer]],
-  * it needs a `Traverse[F]` instance. This requirement is
-  * captured in [[TransactionalProducerMessage]] as [[traverse]].
-  */
-sealed abstract class TransactionalProducerMessage[G[+ _], +K, +V, +P] {
+sealed abstract class TransactionalProducerMessage[F[_], G[+ _], +K, +V, +P] {
+  def records: G[CommittableProducerRecords[F, G, K, V]]
 
-  /**
-    * The records to produce within the transaction. If these records are
-    * produced, but [[offsets]] fail to be committed, consumers configured
-    * to have isolation level "read_committed" will not see the records.
-    */
-  def records: G[ProducerRecord[K, V]]
-
-  /** Offsets to commit within the transaction where [[records]] are produced. */
-  def offsets: Map[TopicPartition, OffsetAndMetadata]
-
-  /** Group ID of the consumer which pulled `offsets` from Kafka. */
-  def consumerGroupId: String
-
-  /**
-    * The passthrough to emit once all [[records]] have been produced,
-    * [[offsets]] have been committed, and the wrapping transaction has
-    * been completed.
-    */
   def passthrough: P
 
-  /** The traverse instance for `F[_]`. Required by [[TransactionalKafkaProducer]]. */
+  def flatMap: FlatMap[G]
+
   def traverse: Traverse[G]
 }
 
 object TransactionalProducerMessage {
-  private[this] final class TransactionalProducerMessageImpl[G[+ _], +K, +V, +P](
-    override val records: G[ProducerRecord[K, V]],
-    override val offsets: Map[TopicPartition, OffsetAndMetadata],
-    override val consumerGroupId: String,
+  private[this] final class TransactionalProducerMessageImpl[F[_], G[+ _], +K, +V, +P](
+    override val records: G[CommittableProducerRecords[F, G, K, V]],
     override val passthrough: P,
-    override val traverse: NonEmptyTraverse[G]
-  ) extends TransactionalProducerMessage[G, K, V, P] {
-    override def toString: String = {
-      implicit val G: Foldable[G] = traverse
-      val offsetStr =
-        if (offsets.isEmpty) {
-          "<empty>"
-        } else {
-          offsets.toList.sorted.map {
-            case (tp, oam) => s"${tp.show} -> ${oam.show}"
-          }.mkString("[", ", ", "]")
-        }
-
-      records.mkString(
-        "TransactionalProducerMessage(",
-        ", ",
-        s", $offsetStr, $consumerGroupId, $passthrough)"
-      )
-    }
+    override val flatMap: FlatMap[G],
+    override val traverse: Traverse[G]
+  ) extends TransactionalProducerMessage[F, G, K, V, P] {
+    override def toString: String =
+      s"TransactionalProducerMessage($records, $passthrough)"
   }
 
-  /**
-    * Enables creating [[TransactionalProducerMessage]]s with the following syntax.
-    *
-    * {{{
-    * TransactionalMessage[G].of(records, passthrough)
-    *
-    * TransactionalMessage[G].of(records)
-    * }}}
-    */
-  final class ApplyBuilders[G[+ _]] private[kafka] (
-    private val G: NonEmptyTraverse[G]
-  ) extends AnyVal {
-
-    /**
-      * Creates a new [[TransactionalProducerMessage]] for producing zero or more
-      * `ProducerRecord`s within a Kafka transaction, then emitting a
-      * [[ProducerResult]] with the results and specified passthrough value.
-      */
-    def of[F[_], K, V, P](
-      records: G[ProducerRecord[K, V]],
-      offsetBatch: CommittableOffsetBatch[F],
-      passthrough: P
-    )(implicit F: MonadError[F, Throwable]): F[TransactionalProducerMessage[G, K, V, P]] =
-      TransactionalProducerMessage(records, offsetBatch, passthrough)(F, G)
-
-    /**
-      * Creates a new [[TransactionalProducerMessage]] for producing zero or more
-      * `ProducerRecord`s within a Kafka transaction, then emitting a
-      * [[ProducerResult]] with the results and `Unit` passthrough value.
-      */
-    def of[F[_], K, V](
-      records: G[ProducerRecord[K, V]],
-      offsetBatch: CommittableOffsetBatch[F]
-    )(implicit F: MonadError[F, Throwable]): F[TransactionalProducerMessage[G, K, V, Unit]] =
-      TransactionalProducerMessage(records, offsetBatch)(F, G)
-  }
-
-  /**
-    * Creates a new [[TransactionalProducerMessage]] for producing exactly one
-    * `ProducerRecord` within a Kafka transaction, then emitting a
-    * [[ProducerResult]] with the results and specified passthrough value.
-    */
-  def one[F[_], K, V, P](
-    record: ProducerRecord[K, V],
-    offsetBatch: CommittableOffsetBatch[F],
-    passthrough: P
-  )(implicit F: MonadError[F, Throwable]): F[TransactionalProducerMessage[Id, K, V, P]] =
-    apply[F, Id, K, V, P](record, offsetBatch, passthrough)
-
-  /**
-    * Creates a new [[TransactionalProducerMessage]] for producing exactly one
-    * `ProducerRecord` within a Kafka transaction, then emitting a
-    * [[ProducerResult]] with the results and `Unit` passthrough value.
-    */
-  def one[F[_], K, V](
-    record: ProducerRecord[K, V],
-    offsetBatch: CommittableOffsetBatch[F]
-  )(implicit F: MonadError[F, Throwable]): F[TransactionalProducerMessage[Id, K, V, Unit]] =
-    one(record, offsetBatch, ())
-
-  /**
-    * Creates a new [[TransactionalProducerMessage]] for producing zero or more
-    * `ProducerRecord`s within a Kafka transaction, then emitting a
-    * [[ProducerResult]] with the results and specified passthrough value.
-    */
-  def apply[F[_], G[+ _], K, V, P](
-    records: G[ProducerRecord[K, V]],
-    offsetBatch: CommittableOffsetBatch[F],
-    passthrough: P
-  )(
-    implicit F: MonadError[F, Throwable],
-    G: NonEmptyTraverse[G]
-  ): F[TransactionalProducerMessage[G, K, V, P]] =
-    F.whenA(offsetBatch.consumerGroupIds.size != 1) {
-        F.raiseError(
-          new RuntimeException(
-            "Transactional messages must contain messages from exactly one consuer group"
-          )
-        )
-      }
-      .map { _ =>
-        new TransactionalProducerMessageImpl(
-          records,
-          offsetBatch.offsets,
-          offsetBatch.consumerGroupIds.head,
-          passthrough,
-          G
-        )
-      }
-
-  /**
-    * Creates a new [[TransactionalProducerMessage]] for producing zero or more
-    * `ProducerRecord`s within a Kafka transaction, then emitting a
-    * [[ProducerResult]] with the results and `Unit` passthrough value.
-    */
   def apply[F[_], G[+ _], K, V](
-    records: G[ProducerRecord[K, V]],
-    offsetBatch: CommittableOffsetBatch[F]
+    records: G[CommittableProducerRecords[F, G, K, V]]
   )(
-    implicit F: MonadError[F, Throwable],
-    G: NonEmptyTraverse[G]
-  ): F[TransactionalProducerMessage[G, K, V, Unit]] =
-    apply(records, offsetBatch, ())
+    implicit flatMap: FlatMap[G],
+    traverse: Traverse[G]
+  ): TransactionalProducerMessage[F, G, K, V, Unit] =
+    apply(records, ())
 
-  /**
-    * Creates a new [[TransactionalProducerMessage]] for producing zero or more
-    * `ProducerRecord`s within a Kafka transaction, then emitting a
-    * [[ProducerResult]] with the results and a specified or `Unit`
-    * passthrough value.<br>
-    * <br>
-    * This version allows you to explicitly specify the context `G[_]`.
-    * This is useful when the context cannot otherwise be inferred correctly.<br>
-    * <br>
-    * This function enables the following syntax.
-    *
-    * {{{
-    * TransactionalMessage[G].of(records, passthrough)
-    *
-    * TransactionalMessage[G].of(records)
-    * }}}
-    */
-  def apply[G[+ _]](implicit G: NonEmptyTraverse[G]): ApplyBuilders[G] =
-    new ApplyBuilders[G](G)
+  def apply[F[_], G[+ _], K, V, P](
+    records: G[CommittableProducerRecords[F, G, K, V]],
+    passthrough: P
+  )(
+    implicit flatMap: FlatMap[G],
+    traverse: Traverse[G]
+  ): TransactionalProducerMessage[F, G, K, V, P] =
+    new TransactionalProducerMessageImpl(records, passthrough, flatMap, traverse)
 
-  implicit def transactionalMessageShow[G[+ _], K, V, P](
-    implicit
-    K: Show[K],
-    V: Show[V],
-    P: Show[P]
-  ): Show[TransactionalProducerMessage[G, K, V, P]] = Show.show { message =>
-    implicit val G: Foldable[G] = message.traverse
-    val offsets =
-      if (message.offsets.isEmpty) {
-        "<empty>"
-      } else {
-        message.offsets.toList.sorted.mkStringAppend {
-          case (append, (tp, oam)) =>
-            append(tp.show)
-            append(" -> ")
-            append(oam.show)
-        }(
-          start = "[",
-          sep = ", ",
-          end = "]"
-        )
-      }
+  def one[F[_], G[+ _], K, V, P](
+    record: CommittableProducerRecords[F, G, K, V]
+  )(
+    implicit monad: Monad[G],
+    traverse: Traverse[G]
+  ): TransactionalProducerMessage[F, G, K, V, Unit] =
+    one[F, G, K, V, Unit](record, ())
 
-    message.records.mkStringShow(
-      "TransactionalProducerMessage(",
-      ", ",
-      show", $offsets, ${message.consumerGroupId}, ${message.passthrough})"
-    )
-  }
+  def one[F[_], G[+ _], K, V, P](
+    record: CommittableProducerRecords[F, G, K, V],
+    passthrough: P
+  )(
+    implicit monad: Monad[G],
+    traverse: Traverse[G]
+  ): TransactionalProducerMessage[F, G, K, V, P] =
+    apply[F, G, K, V, P](record.pure[G], passthrough)
 }

--- a/src/main/scala/fs2/kafka/TransactionalProducerMessage.scala
+++ b/src/main/scala/fs2/kafka/TransactionalProducerMessage.scala
@@ -16,121 +16,81 @@
 
 package fs2.kafka
 
-import cats._
-import cats.data.Chain
+import fs2.Chunk
 
 /**
-  * [[TransactionalProducerMessage]] represents zero or more
-  * [[CommittableProducerRecords]], together with an arbitrary passthrough
-  * value, all of which can be used with [[TransactionalKafkaProducer]]
-  * to produce messages and commit offsets within a single transaction.
+  * Represents zero or more [[CommittableProducerRecords]], together with an
+  * arbitrary passthrough value, all of which can be used together with a
+  * [[TransactionalKafkaProducer]] to produce messages and commit offsets
+  * within a single transaction.<br>
+  * <br>
   * [[TransactionalProducerMessage]]s can be created using one of the
   * following options.<br>
   * <br>
   * - `TransactionalProducerMessage#apply` to produce zero or more records,
-  * commit the paired offsets, then emit a [[ProducerResult]] with the
-  * results and specified passthrough value.<br>
+  * commit the offsets, and then emit a [[ProducerResult]] with the results
+  * and specified passthrough value.<br>
   * - `TransactionalProducerMessage#one` to produce zero or more records,
   * commit exactly one offset, then emit a [[ProducerResult]] with the
-  * results and specified passthrough value.<br>
-  * <br>
-  * The [[passthrough]] and [[records]] can be retrieved from an existing
-  * [[TransactionalProducerMessage]] instance.
+  * results and specified passthrough value.
   */
-sealed abstract class TransactionalProducerMessage[F[_], G[+ _], H[+ _], +K, +V, +P] {
+sealed abstract class TransactionalProducerMessage[F[_], G[+ _], +K, +V, +P] {
 
   /** The records to produce and commit. Can be empty for passthrough-only. */
-  def records: G[CommittableProducerRecords[F, H, K, V]]
+  def records: Chunk[CommittableProducerRecords[F, G, K, V]]
 
   /** The passthrough to emit once all [[records]] have been produced and committed. */
   def passthrough: P
-
-  /** The `Monad` instance for `G[_]`. Required by [[TransactionalKafkaProducer]]. */
-  def monad: Monad[G]
-
-  /** The `Traverse` instance for `G[_]`. Required by [[TransactionalKafkaProducer]]. */
-  def traverse: Traverse[G]
-
-  /** The `MonoidK` instance for `G[_]`. Required by [[TransactionalKafkaProducer]]. */
-  def monoidK: MonoidK[G]
-
-  /** The `Foldable` instance for `H[_]`. Required by [[TransactionalKafkaProducer]]. */
-  def foldable: Foldable[H]
 }
 
 object TransactionalProducerMessage {
-  private[this] final class TransactionalProducerMessageImpl[F[_], G[+ _], H[+ _], +K, +V, +P](
-    override val records: G[CommittableProducerRecords[F, H, K, V]],
-    override val passthrough: P,
-    override val monad: Monad[G],
-    override val traverse: Traverse[G],
-    override val monoidK: MonoidK[G],
-    override val foldable: Foldable[H]
-  ) extends TransactionalProducerMessage[F, G, H, K, V, P] {
+  private[this] final class TransactionalProducerMessageImpl[F[_], G[+ _], +K, +V, +P](
+    override val records: Chunk[CommittableProducerRecords[F, G, K, V]],
+    override val passthrough: P
+  ) extends TransactionalProducerMessage[F, G, K, V, P] {
     override def toString: String =
       s"TransactionalProducerMessage($records, $passthrough)"
   }
 
   /**
-    * Creates a new [[TransactionalProducerMessage]] for producing
-    * zero or more [[CommittableProducerRecords]], then emitting a
-    * [[ProducerResult]] with the results and `Unit` passthrough value.
+    * Creates a new [[TransactionalProducerMessage]] for producing zero or
+    * more [[CommittableProducerRecords]], emitting a [[ProducerResult]]
+    * with the results and `Unit` passthrough value.
     */
-  def apply[F[_], G[+ _], H[+ _], K, V](
-    records: G[CommittableProducerRecords[F, H, K, V]]
-  )(
-    implicit monad: Monad[G],
-    traverse: Traverse[G],
-    monoidK: MonoidK[G],
-    foldable: Foldable[H]
-  ): TransactionalProducerMessage[F, G, H, K, V, Unit] =
+  def apply[F[_], G[+ _], K, V](
+    records: Chunk[CommittableProducerRecords[F, G, K, V]]
+  ): TransactionalProducerMessage[F, G, K, V, Unit] =
     apply(records, ())
 
   /**
-    * Creates a new [[TransactionalProducerMessage]] for producing
-    * zero or more [[CommittableProducerRecords]], then emitting a
-    * [[ProducerResult]] with the results and specified passthrough value.
+    * Creates a new [[TransactionalProducerMessage]] for producing zero or
+    * more [[CommittableProducerRecords]], emitting a [[ProducerResult]]
+    * with the results and specified passthrough value.
     */
-  def apply[F[_], G[+ _], H[+ _], K, V, P](
-    records: G[CommittableProducerRecords[F, H, K, V]],
+  def apply[F[_], G[+ _], K, V, P](
+    records: Chunk[CommittableProducerRecords[F, G, K, V]],
     passthrough: P
-  )(
-    implicit monad: Monad[G],
-    traverse: Traverse[G],
-    monoidK: MonoidK[G],
-    foldable: Foldable[H]
-  ): TransactionalProducerMessage[F, G, H, K, V, P] =
-    new TransactionalProducerMessageImpl(
-      records,
-      passthrough,
-      monad,
-      traverse,
-      monoidK,
-      foldable
-    )
+  ): TransactionalProducerMessage[F, G, K, V, P] =
+    new TransactionalProducerMessageImpl(records, passthrough)
 
   /**
     * Creates a new [[TransactionalProducerMessage]] for producing exactly
-    * one [[CommittableProducerRecords]], then emitting a [[ProducerResult]]
+    * one [[CommittableProducerRecords]], emitting a [[ProducerResult]]
     * with the result and `Unit` passthrough value.
     */
-  def one[F[_], H[+ _], K, V](
-    record: CommittableProducerRecords[F, H, K, V]
-  )(
-    implicit foldable: Foldable[H]
-  ): TransactionalProducerMessage[F, Chain, H, K, V, Unit] =
+  def one[F[_], G[+ _], K, V](
+    record: CommittableProducerRecords[F, G, K, V]
+  ): TransactionalProducerMessage[F, G, K, V, Unit] =
     one(record, ())
 
   /**
     * Creates a new [[TransactionalProducerMessage]] for producing exactly
-    * one [[CommittableProducerRecords]], then emitting a [[ProducerResult]]
+    * one [[CommittableProducerRecords]], emitting a [[ProducerResult]]
     * with the result and specified passthrough value.
     */
-  def one[F[_], H[+ _], K, V, P](
-    record: CommittableProducerRecords[F, H, K, V],
+  def one[F[_], G[+ _], K, V, P](
+    record: CommittableProducerRecords[F, G, K, V],
     passthrough: P
-  )(
-    implicit foldable: Foldable[H]
-  ): TransactionalProducerMessage[F, Chain, H, K, V, P] =
-    apply(Chain.one(record), passthrough)
+  ): TransactionalProducerMessage[F, G, K, V, P] =
+    apply(Chunk.singleton(record), passthrough)
 }

--- a/src/main/scala/fs2/kafka/TransactionalProducerMessage.scala
+++ b/src/main/scala/fs2/kafka/TransactionalProducerMessage.scala
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2018-2019 OVO Energy Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fs2.kafka
+
+import cats._
+import cats.implicits._
+import fs2.kafka.internal.syntax._
+
+/**
+  * [[TransactionalProducerMessage]] represents zero or more `ProducerRecord`s
+  * paired with corresponding `CommittableOffset`s, together with an arbitrary
+  * passthrough value, all of which can be used with [[TransactionalKafkaProducer]].
+  * [[TransactionalProducerMessage]]s can be created using one of the following options.<br>
+  * <br>
+  * - `TransactionalMessage#apply` to produce zero or more records
+  * and then emit a [[ProducerResult]] with the results and
+  * specified passthrough value.<br>
+  * - `TransactionalMessage#one` to produce exactly one record and
+  * then emit a [[ProducerResult]] with the result and specified
+  * passthrough value.<br>
+  * <br>
+  * The [[passthrough]] and [[records]] can be retrieved from an
+  * existing [[TransactionalProducerMessage]] instance.<br>
+  * <br>
+  * For a [[TransactionalProducerMessage]] to be usable by [[TransactionalKafkaProducer]],
+  * it needs a `Traverse[F]` instance. This requirement is
+  * captured in [[TransactionalProducerMessage]] as [[traverse]].
+  */
+sealed abstract class TransactionalProducerMessage[F[_], G[+ _], +K, +V, +P] {
+
+  def records: G[ProducerRecord[K, V]]
+
+  def offsetBatch: CommittableOffsetBatch[F]
+
+  def consumerGroupId: String
+
+  def passthrough: P
+
+  def traverse: Traverse[G]
+}
+
+object TransactionalProducerMessage {
+  private[this] final class TransactionalProducerMessageImpl[F[_], G[+ _], +K, +V, +P](
+    override val records: G[ProducerRecord[K, V]],
+    override val offsetBatch: CommittableOffsetBatch[F],
+    override val consumerGroupId: String,
+    override val passthrough: P,
+    override val traverse: NonEmptyTraverse[G]
+  ) extends TransactionalProducerMessage[F, G, K, V, P] {
+    override def toString: String = {
+      implicit val G: Foldable[G] = traverse
+      records.mkString(
+        "TransactionalProducerMessage(",
+        ", ",
+        s", $offsetBatch, $consumerGroupId, $passthrough)"
+      )
+    }
+  }
+
+  /**
+    * Enables creating [[TransactionalProducerMessage]]s with the following syntax.
+    *
+    * {{{
+    * TransactionalMessage[G].of(records, passthrough)
+    *
+    * TransactionalMessage[G].of(records)
+    * }}}
+    */
+  final class ApplyBuilders[G[+ _]] private[kafka] (
+    private val G: NonEmptyTraverse[G]
+  ) extends AnyVal {
+
+    /**
+      * Creates a new [[TransactionalProducerMessage]] for producing zero or more
+      * `ProducerRecord`s within a Kafka transaction, then emitting a
+      * [[ProducerResult]] with the results and specified passthrough value.
+      */
+    def of[F[_], K, V, P](
+      records: G[(ProducerRecord[K, V], CommittableOffset[F])],
+      passthrough: P
+    )(implicit F: MonadError[F, Throwable]): F[TransactionalProducerMessage[F, G, K, V, P]] =
+      TransactionalProducerMessage(records, passthrough)(F, G)
+
+    /**
+      * Creates a new [[TransactionalProducerMessage]] for producing zero or more
+      * `ProducerRecord`s within a Kafka transaction, then emitting a
+      * [[ProducerResult]] with the results and `Unit` passthrough value.
+      */
+    def of[F[_], K, V](
+      records: G[(ProducerRecord[K, V], CommittableOffset[F])]
+    )(implicit F: MonadError[F, Throwable]): F[TransactionalProducerMessage[F, G, K, V, Unit]] =
+      TransactionalProducerMessage(records)(F, G)
+  }
+
+  /**
+    * Creates a new [[TransactionalProducerMessage]] for producing exactly one
+    * `ProducerRecord` within a Kafka transaction, then emitting a
+    * [[ProducerResult]] with the results and specified passthrough value.
+    */
+  def one[F[_], K, V, P](
+    record: (ProducerRecord[K, V], CommittableOffset[F]),
+    passthrough: P
+  )(implicit F: MonadError[F, Throwable]): F[TransactionalProducerMessage[F, Id, K, V, P]] =
+    apply[F, Id, K, V, P](record, passthrough)
+
+  /**
+    * Creates a new [[TransactionalProducerMessage]] for producing exactly one
+    * `ProducerRecord` within a Kafka transaction, then emitting a
+    * [[ProducerResult]] with the results and `Unit` passthrough value.
+    */
+  def one[F[_], K, V](
+    record: (ProducerRecord[K, V], CommittableOffset[F])
+  )(implicit F: MonadError[F, Throwable]): F[TransactionalProducerMessage[F, Id, K, V, Unit]] =
+    one(record, ())
+
+  /**
+    * Creates a new [[TransactionalProducerMessage]] for producing zero or more
+    * `ProducerRecord`s within a Kafka transaction, then emitting a
+    * [[ProducerResult]] with the results and specified passthrough value.
+    */
+  def apply[F[_], G[+ _], K, V, P](
+    records: G[(ProducerRecord[K, V], CommittableOffset[F])],
+    passthrough: P
+  )(
+    implicit F: MonadError[F, Throwable],
+    G: NonEmptyTraverse[G]
+  ): F[TransactionalProducerMessage[F, G, K, V, P]] = {
+    val consumerGroups = records.foldMap {
+      case (_, offset) => Set(offset.consumerGroupId)
+    }
+
+    if (consumerGroups.size != 1) {
+      F.raiseError(new RuntimeException("multiple consumer group IDs given in transaction"))
+    } else {
+      consumerGroups.head.fold(
+        F.raiseError[TransactionalProducerMessage[F, G, K, V, P]](
+          new RuntimeException("no consumer group ID given for transaction")
+        )
+      ) { id =>
+        val offsetBatch = CommittableOffsetBatch.fromFoldable(records.map(_._2))
+        F.pure(
+          new TransactionalProducerMessageImpl(records.map(_._1), offsetBatch, id, passthrough, G)
+        )
+      }
+    }
+  }
+
+  /**
+    * Creates a new [[TransactionalProducerMessage]] for producing zero or more
+    * `ProducerRecord`s within a Kafka transaction, then emitting a
+    * [[ProducerResult]] with the results and `Unit` passthrough value.
+    */
+  def apply[F[_], G[+ _], K, V](
+    records: G[(ProducerRecord[K, V], CommittableOffset[F])]
+  )(
+    implicit F: MonadError[F, Throwable],
+    G: NonEmptyTraverse[G]
+  ): F[TransactionalProducerMessage[F, G, K, V, Unit]] =
+    apply(records, ())
+
+  /**
+    * Creates a new [[TransactionalProducerMessage]] for producing zero or more
+    * `ProducerRecord`s within a Kafka transaction, then emitting a
+    * [[ProducerResult]] with the results and a specified or `Unit`
+    * passthrough value.<br>
+    * <br>
+    * This version allows you to explicitly specify the context `G[_]`.
+    * This is useful when the context cannot otherwise be inferred correctly.<br>
+    * <br>
+    * This function enables the following syntax.
+    *
+    * {{{
+    * TransactionalMessage[G].of(records, passthrough)
+    *
+    * TransactionalMessage[G].of(records)
+    * }}}
+    */
+  def apply[G[+ _]](implicit G: NonEmptyTraverse[G]): ApplyBuilders[G] =
+    new ApplyBuilders[G](G)
+
+  implicit def transactionalMessageShow[F[_], G[+ _], K, V, P](
+    implicit
+    K: Show[K],
+    V: Show[V],
+    P: Show[P]
+  ): Show[TransactionalProducerMessage[F, G, K, V, P]] = Show.show { message =>
+    implicit val G: Foldable[G] = message.traverse
+    message.records.mkStringShow(
+      "TransactionalProducerMessage(",
+      ", ",
+      show", ${message.offsetBatch}, ${message.consumerGroupId}, ${message.passthrough})"
+    )
+  }
+}

--- a/src/main/scala/fs2/kafka/TransactionalProducerResource.scala
+++ b/src/main/scala/fs2/kafka/TransactionalProducerResource.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018-2019 OVO Energy Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fs2.kafka
+
+import cats.effect.{ConcurrentEffect, ContextShift, Resource}
+
+/**
+  * [[TransactionalProducerResource]] provides support for inferring
+  * the key and value type from [[ProducerSettings]] when using
+  * `transactionalProducerResource` with the following syntax.
+  *
+  * {{{
+  * transactionalProducerResource[F].using(settings)
+  * }}}
+  */
+final class TransactionalProducerResource[F[_]] private[kafka] (
+  private val F: ConcurrentEffect[F]
+) extends AnyVal {
+
+  /**
+    * Creates a new [[TransactionalKafkaProducer]] in the `Resource` context.
+    * This is equivalent to using `transactionalProducerResource` directly,
+    * except we're able to infer the key and value type.
+    */
+  def using[K, V](settings: ProducerSettings[F, K, V])(
+    implicit context: ContextShift[F]
+  ): Resource[F, TransactionalKafkaProducer[F, K, V]] =
+    transactionalProducerResource(settings)(F, context)
+
+  override def toString: String =
+    "TransactionalProducerResource$" + System.identityHashCode(this)
+}

--- a/src/main/scala/fs2/kafka/TransactionalProducerStream.scala
+++ b/src/main/scala/fs2/kafka/TransactionalProducerStream.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018-2019 OVO Energy Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fs2.kafka
+
+import cats.effect.{ConcurrentEffect, ContextShift}
+import fs2.Stream
+
+/**
+  * [[TransactionalProducerStream]] provides support for inferring
+  * the key and value type from [[ProducerSettings]] when using
+  * `transactionalProducerStream` with the following syntax.
+  *
+  * {{{
+  * transactionalProducerStream[F].using(settings)
+  * }}}
+  */
+final class TransactionalProducerStream[F[_]] private[kafka] (
+  private val F: ConcurrentEffect[F]
+) extends AnyVal {
+
+  /**
+    * Creates a new [[TransactionalKafkaProducer]] in the `Stream` context.
+    * This is equivalent to using `transactionalProducerStream` directly,
+    * except we're able to infer the key and value type.
+    */
+  def using[K, V](settings: ProducerSettings[F, K, V])(
+    implicit context: ContextShift[F]
+  ): Stream[F, TransactionalKafkaProducer[F, K, V]] =
+    transactionalProducerStream(settings)(F, context)
+
+  override def toString: String =
+    "TransactionalProducerStream$" + System.identityHashCode(this)
+}

--- a/src/main/scala/fs2/kafka/internal/KafkaConsumerActor.scala
+++ b/src/main/scala/fs2/kafka/internal/KafkaConsumerActor.scala
@@ -285,6 +285,7 @@ private[kafka] final class KafkaConsumerActor[F[_], K, V](
       record = record,
       committableOffset = CommittableOffset(
         topicPartition = partition,
+        consumerGroupId = settings.groupId,
         offsetAndMetadata = new OffsetAndMetadata(
           record.offset + 1L,
           settings.recordMetadata(record)

--- a/src/main/scala/fs2/kafka/internal/KafkaConsumerActor.scala
+++ b/src/main/scala/fs2/kafka/internal/KafkaConsumerActor.scala
@@ -31,6 +31,7 @@ import java.time.Duration
 import java.util
 import java.util.regex.Pattern
 import org.apache.kafka.clients.consumer.{
+  ConsumerConfig,
   ConsumerRebalanceListener,
   OffsetCommitCallback,
   OffsetAndMetadata
@@ -285,7 +286,7 @@ private[kafka] final class KafkaConsumerActor[F[_], K, V](
       record = record,
       committableOffset = CommittableOffset(
         topicPartition = partition,
-        consumerGroupId = settings.groupId,
+        consumerGroupId = settings.properties.get(ConsumerConfig.GROUP_ID_CONFIG),
         offsetAndMetadata = new OffsetAndMetadata(
           record.offset + 1L,
           settings.recordMetadata(record)

--- a/src/main/scala/fs2/kafka/internal/WithConsumer.scala
+++ b/src/main/scala/fs2/kafka/internal/WithConsumer.scala
@@ -27,7 +27,7 @@ private[kafka] sealed abstract class WithConsumer[F[_]] {
 }
 
 private[kafka] object WithConsumer {
-  def of[F[_], K, V](
+  def apply[F[_], K, V](
     settings: ConsumerSettings[F, K, V]
   )(
     implicit F: Concurrent[F],

--- a/src/main/scala/fs2/kafka/internal/WithProducer.scala
+++ b/src/main/scala/fs2/kafka/internal/WithProducer.scala
@@ -27,7 +27,7 @@ private[kafka] sealed abstract class WithProducer[F[_]] {
 }
 
 private[kafka] object WithProducer {
-  def of[F[_], K, V](
+  def apply[F[_], K, V](
     settings: ProducerSettings[F, K, V]
   )(
     implicit F: Sync[F],

--- a/src/main/scala/fs2/kafka/internal/WithProducer.scala
+++ b/src/main/scala/fs2/kafka/internal/WithProducer.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2018-2019 OVO Energy Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fs2.kafka.internal
+
+import cats.effect._
+import cats.implicits._
+import fs2.kafka._
+import fs2.kafka.internal.syntax._
+import scala.concurrent.ExecutionContext
+
+private[kafka] sealed abstract class WithProducer[F[_]] {
+  def apply[A](f: ByteProducer => F[A]): F[A]
+}
+
+private[kafka] object WithProducer {
+  def of[F[_], K, V](
+    settings: ProducerSettings[F, K, V]
+  )(
+    implicit F: Sync[F],
+    context: ContextShift[F]
+  ): Resource[F, WithProducer[F]] = {
+    val executionContextResource =
+      settings.executionContext
+        .map(Resource.pure[F, ExecutionContext])
+        .getOrElse(producerExecutionContextResource)
+
+    executionContextResource.flatMap { executionContext =>
+      Resource.make[F, WithProducer[F]] {
+        settings.createProducer
+          .map { producer =>
+            new WithProducer[F] {
+              override def apply[A](f: ByteProducer => F[A]): F[A] =
+                context.evalOn(executionContext) {
+                  f(producer)
+                }
+            }
+          }
+      } { withProducer =>
+        withProducer { producer =>
+          F.delay(producer.close(settings.closeTimeout.asJava))
+        }
+      }
+    }
+  }
+}

--- a/src/main/scala/fs2/kafka/package.scala
+++ b/src/main/scala/fs2/kafka/package.scala
@@ -626,4 +626,16 @@ package object kafka {
     */
   def producerStream[F[_]](implicit F: ConcurrentEffect[F]): ProducerStream[F] =
     new ProducerStream[F](F)
+
+  def transactionalProducerResource[F[_], K, V](settings: ProducerSettings[F, K, V])(
+    implicit F: ConcurrentEffect[F],
+    context: ContextShift[F]
+  ): Resource[F, TransactionalKafkaProducer[F, K, V]] =
+    TransactionalKafkaProducer.producerResource(settings)
+
+  def transactionalProducerStream[F[_], K, V](settings: ProducerSettings[F, K, V])(
+    implicit F: ConcurrentEffect[F],
+    C: ContextShift[F]
+  ): Stream[F, TransactionalKafkaProducer[F, K, V]] =
+    Stream.resource(transactionalProducerResource(settings))
 }

--- a/src/main/scala/fs2/kafka/package.scala
+++ b/src/main/scala/fs2/kafka/package.scala
@@ -585,7 +585,7 @@ package object kafka {
     implicit F: ConcurrentEffect[F],
     context: ContextShift[F]
   ): Resource[F, KafkaProducer[F, K, V]] =
-    KafkaProducer.producerResource(settings)
+    KafkaProducer.resource(settings)
 
   /**
     * Alternative version of `producerResource` where the `F[_]` is
@@ -598,7 +598,7 @@ package object kafka {
     * }}}
     */
   def producerResource[F[_]](implicit F: ConcurrentEffect[F]): ProducerResource[F] =
-    new ProducerResource[F](F)
+    new ProducerResource(F)
 
   /**
     * Creates a new [[KafkaProducer]] in the `Stream` context,
@@ -630,15 +630,69 @@ package object kafka {
   def producerStream[F[_]](implicit F: ConcurrentEffect[F]): ProducerStream[F] =
     new ProducerStream[F](F)
 
-  def transactionalProducerResource[F[_], K, V](settings: ProducerSettings[F, K, V])(
+  /**
+    * Creates a new [[TransactionalKafkaProducer]] in the `Resource` context,
+    * using the specified [[ProducerSettings]]. Note that there is another
+    * version where `F[_]` is specified explicitly and the key and value
+    * type can be inferred, which allows you to use the following syntax.
+    *
+    * {{{
+    * transactionalProducerResource[F].using(settings)
+    * }}}
+    */
+  def transactionalProducerResource[F[_], K, V](
+    settings: ProducerSettings[F, K, V]
+  )(
     implicit F: ConcurrentEffect[F],
     context: ContextShift[F]
   ): Resource[F, TransactionalKafkaProducer[F, K, V]] =
-    TransactionalKafkaProducer.producerResource(settings)
+    TransactionalKafkaProducer.resource(settings)
 
-  def transactionalProducerStream[F[_], K, V](settings: ProducerSettings[F, K, V])(
+  /**
+    * Alternative version of `transactionalProducerResource` where the `F[_]`
+    * is specified explicitly, and where the key and value type can be
+    * inferred from the [[ProducerSettings]]. This allows you to use
+    * the following syntax.
+    *
+    * {{{
+    * transactionalProducerResource[F].using(settings)
+    * }}}
+    */
+  def transactionalProducerResource[F[_]](
+    implicit F: ConcurrentEffect[F]
+  ): TransactionalProducerResource[F] =
+    new TransactionalProducerResource(F)
+
+  /**
+    * Creates a new [[TransactionalKafkaProducer]] in the `Stream` context,
+    * using the specified [[ProducerSettings]]. Note that there is another
+    * version where `F[_]` is specified explicitly and the key and value
+    * type can be inferred, which allows you to use the following syntax.
+    *
+    * {{{
+    * transactionalProducerStream[F].using(settings)
+    * }}}
+    */
+  def transactionalProducerStream[F[_], K, V](
+    settings: ProducerSettings[F, K, V]
+  )(
     implicit F: ConcurrentEffect[F],
-    C: ContextShift[F]
+    context: ContextShift[F]
   ): Stream[F, TransactionalKafkaProducer[F, K, V]] =
     Stream.resource(transactionalProducerResource(settings))
+
+  /**
+    * Alternative version of `transactionalProducerStream` where the `F[_]`
+    * is specified explicitly, and where the key and value type can be
+    * inferred from the [[ProducerSettings]]. This allows you to use
+    * the following syntax.
+    *
+    * {{{
+    * transactionalProducerStream[F].using(settings)
+    * }}}
+    */
+  def transactionalProducerStream[F[_]](
+    implicit F: ConcurrentEffect[F]
+  ): TransactionalProducerStream[F] =
+    new TransactionalProducerStream(F)
 }

--- a/src/main/scala/fs2/kafka/package.scala
+++ b/src/main/scala/fs2/kafka/package.scala
@@ -31,6 +31,9 @@ package object kafka {
   private[kafka] type ByteConsumer =
     org.apache.kafka.clients.consumer.Consumer[Array[Byte], Array[Byte]]
 
+  private[kafka] type ByteProducer =
+    org.apache.kafka.clients.producer.Producer[Array[Byte], Array[Byte]]
+
   private[kafka] type KafkaDeserializer[A] =
     org.apache.kafka.common.serialization.Deserializer[A]
 

--- a/src/test/scala/fs2/kafka/BaseGenerators.scala
+++ b/src/test/scala/fs2/kafka/BaseGenerators.scala
@@ -33,12 +33,13 @@ trait BaseGenerators {
     for {
       topicPartition <- genTopicPartition
       offsetAndMetadata <- genOffsetAndMetadata
-    } yield
-      CommittableOffset[F](
-        topicPartition = topicPartition,
-        offsetAndMetadata = offsetAndMetadata,
-        commit = _ => F.unit
-      )
+      groupId <- arbitrary[Option[String]]
+    } yield CommittableOffset[F](
+      topicPartition = topicPartition,
+      offsetAndMetadata = offsetAndMetadata,
+      consumerGroupId = groupId,
+      commit = _ => F.unit
+    )
 
   implicit def arbCommittableOffset[F[_]](
     implicit F: Applicative[F]

--- a/src/test/scala/fs2/kafka/BaseGenerators.scala
+++ b/src/test/scala/fs2/kafka/BaseGenerators.scala
@@ -49,12 +49,8 @@ trait BaseGenerators {
   def genCommittableOffsetBatch[F[_]](
     implicit F: Applicative[F]
   ): Gen[CommittableOffsetBatch[F]] =
-    for {
-      offsets <- arbitrary[Map[TopicPartition, OffsetAndMetadata]]
-      groups <- arbitrary[Set[String]]
-    } yield {
-      CommittableOffsetBatch[F](offsets, groups, _ => F.unit)
-    }
+    arbitrary[Map[TopicPartition, OffsetAndMetadata]]
+      .map(CommittableOffsetBatch[F](_, _ => F.unit))
 
   implicit def arbCommittableOffsetBatch[F[_]](
     implicit F: Applicative[F]

--- a/src/test/scala/fs2/kafka/BaseGenerators.scala
+++ b/src/test/scala/fs2/kafka/BaseGenerators.scala
@@ -34,13 +34,12 @@ trait BaseGenerators {
       topicPartition <- genTopicPartition
       offsetAndMetadata <- genOffsetAndMetadata
       groupId <- arbitrary[Option[String]]
-    } yield
-      CommittableOffset[F](
-        topicPartition = topicPartition,
-        offsetAndMetadata = offsetAndMetadata,
-        consumerGroupId = groupId,
-        commit = _ => F.unit
-      )
+    } yield CommittableOffset[F](
+      topicPartition = topicPartition,
+      offsetAndMetadata = offsetAndMetadata,
+      consumerGroupId = groupId,
+      commit = _ => F.unit
+    )
 
   implicit def arbCommittableOffset[F[_]](
     implicit F: Applicative[F]
@@ -50,8 +49,12 @@ trait BaseGenerators {
   def genCommittableOffsetBatch[F[_]](
     implicit F: Applicative[F]
   ): Gen[CommittableOffsetBatch[F]] =
-    arbitrary[Map[TopicPartition, OffsetAndMetadata]]
-      .map(CommittableOffsetBatch[F](_, _ => F.unit))
+    for {
+      offsets <- arbitrary[Map[TopicPartition, OffsetAndMetadata]]
+      groups <- arbitrary[Set[String]]
+    } yield {
+      CommittableOffsetBatch[F](offsets, groups, _ => F.unit)
+    }
 
   implicit def arbCommittableOffsetBatch[F[_]](
     implicit F: Applicative[F]

--- a/src/test/scala/fs2/kafka/BaseGenerators.scala
+++ b/src/test/scala/fs2/kafka/BaseGenerators.scala
@@ -34,12 +34,13 @@ trait BaseGenerators {
       topicPartition <- genTopicPartition
       offsetAndMetadata <- genOffsetAndMetadata
       groupId <- arbitrary[Option[String]]
-    } yield CommittableOffset[F](
-      topicPartition = topicPartition,
-      offsetAndMetadata = offsetAndMetadata,
-      consumerGroupId = groupId,
-      commit = _ => F.unit
-    )
+    } yield
+      CommittableOffset[F](
+        topicPartition = topicPartition,
+        offsetAndMetadata = offsetAndMetadata,
+        consumerGroupId = groupId,
+        commit = _ => F.unit
+      )
 
   implicit def arbCommittableOffset[F[_]](
     implicit F: Applicative[F]

--- a/src/test/scala/fs2/kafka/BaseKafkaSpec.scala
+++ b/src/test/scala/fs2/kafka/BaseKafkaSpec.scala
@@ -69,7 +69,11 @@ abstract class BaseKafkaSpec extends BaseAsyncSpec with EmbeddedKafka {
     Map(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG -> s"localhost:${config.kafkaPort}")
 
   final def withKafka[A](f: (EmbeddedKafkaConfig, String) => A): A =
-    withRunningKafkaOnFoundPort(EmbeddedKafkaConfig())(f(_, nextTopicName()))
+    withRunningKafkaOnFoundPort(
+      EmbeddedKafkaConfig(
+        customBrokerProperties = Map("transaction.state.log.replication.factor" -> "1")
+      )
+    )(f(_, nextTopicName()))
 
   final def withKafkaConsumer(
     nativeSettings: Map[String, AnyRef]

--- a/src/test/scala/fs2/kafka/CommittableMessageSpec.scala
+++ b/src/test/scala/fs2/kafka/CommittableMessageSpec.scala
@@ -13,13 +13,14 @@ final class CommittableMessageSpec extends BaseSpec {
           CommittableOffset[Id](
             topicPartition = new TopicPartition("topic", 0),
             offsetAndMetadata = new OffsetAndMetadata(0L),
+            consumerGroupId = Some("the-group"),
             commit = _ => ()
           )
         )
 
       assert {
-        message.toString == "CommittableMessage(ConsumerRecord(topic = topic, partition = 0, offset = 0, key = key, value = value), CommittableOffset(topic-0 -> 0))" &&
-        message.show == "CommittableMessage(ConsumerRecord(topic = topic, partition = 0, offset = 0, key = key, value = value), CommittableOffset(topic-0 -> 0))"
+        message.toString == "CommittableMessage(ConsumerRecord(topic = topic, partition = 0, offset = 0, key = key, value = value), CommittableOffset(topic-0 -> 0, the-group))" &&
+        message.show == "CommittableMessage(ConsumerRecord(topic = topic, partition = 0, offset = 0, key = key, value = value), CommittableOffset(topic-0 -> 0, the-group))"
       }
     }
   }

--- a/src/test/scala/fs2/kafka/CommittableOffsetBatchSpec.scala
+++ b/src/test/scala/fs2/kafka/CommittableOffsetBatchSpec.scala
@@ -43,6 +43,7 @@ final class CommittableOffsetBatchSpec extends BaseSpec {
               CommittableOffset[Id](
                 topicPartition = topicPartition,
                 offsetAndMetadata = newOffsetAndMetadata,
+                consumerGroupId = None,
                 commit = _ => ()
               )
 
@@ -59,7 +60,7 @@ final class CommittableOffsetBatchSpec extends BaseSpec {
 
         val offsets = batch2.offsets.map {
           case (topicPartition, offsetAndMetadata) =>
-            CommittableOffset[Id](topicPartition, offsetAndMetadata, _ => ())
+            CommittableOffset[Id](topicPartition, offsetAndMetadata, None, _ => ())
         }
 
         val expected = offsets.foldLeft(batch1)(_ updated _)
@@ -79,6 +80,7 @@ final class CommittableOffsetBatchSpec extends BaseSpec {
       val one = CommittableOffset[Id](
         new TopicPartition("topic", 0),
         new OffsetAndMetadata(0L),
+        None,
         _ => ()
       ).batch
 
@@ -90,6 +92,7 @@ final class CommittableOffsetBatchSpec extends BaseSpec {
       val oneMetadata = CommittableOffset[Id](
         new TopicPartition("topic", 1),
         new OffsetAndMetadata(0L, "metadata"),
+        None,
         _ => ()
       ).batch
 

--- a/src/test/scala/fs2/kafka/CommittableOffsetBatchSpec.scala
+++ b/src/test/scala/fs2/kafka/CommittableOffsetBatchSpec.scala
@@ -14,10 +14,6 @@ final class CommittableOffsetBatchSpec extends BaseSpec {
       assert(empty.offsets.isEmpty)
     }
 
-    it("should have no consumer group IDs") {
-      assert(empty.consumerGroupIds.isEmpty)
-    }
-
     it("should return updated offset as batch") {
       forAll { offset: CommittableOffset[Id] =>
         val updated = empty.updated(offset)
@@ -30,12 +26,10 @@ final class CommittableOffsetBatchSpec extends BaseSpec {
     it("should include the provided offset") {
       forAll { (batch: CommittableOffsetBatch[Id], offset: CommittableOffset[Id]) =>
         val updatedBatch = batch.updated(offset)
-        val updatedGroups = updatedBatch.consumerGroupIds
         val updatedOffset = updatedBatch.offsets.get(offset.topicPartition)
 
         assert {
-          updatedOffset.contains(offset.offsetAndMetadata) &&
-          offset.consumerGroupId.forall(updatedGroups.contains)
+          updatedOffset.contains(offset.offsetAndMetadata)
         }
       }
     }
@@ -76,8 +70,7 @@ final class CommittableOffsetBatchSpec extends BaseSpec {
         val expected = offsets.foldLeft(batch1)(_ updated _)
 
         assert {
-          result.offsets == expected.offsets &&
-          result.consumerGroupIds == batch1.consumerGroupIds.union(batch2.consumerGroupIds)
+          result.offsets == expected.offsets
         }
       }
     }

--- a/src/test/scala/fs2/kafka/CommittableOffsetSpec.scala
+++ b/src/test/scala/fs2/kafka/CommittableOffsetSpec.scala
@@ -37,7 +37,7 @@ final class CommittableOffsetSpec extends BaseSpec {
         val offset = CommittableOffset[Id](partition, offsetAndMetadata, Some("the-group"), _ => ())
 
         offset.toString == "CommittableOffset(topic-0 -> (0, metadata), the-group)" &&
-          offset.show == offset.toString
+        offset.show == offset.toString
       }
 
       assert {
@@ -53,7 +53,7 @@ final class CommittableOffsetSpec extends BaseSpec {
         val offset = CommittableOffset[Id](partition, offsetAndMetadata, Some("the-group"), _ => ())
 
         offset.toString == "CommittableOffset(topic-0 -> 0, the-group)" &&
-          offset.show == offset.toString
+        offset.show == offset.toString
       }
     }
   }

--- a/src/test/scala/fs2/kafka/CommittableOffsetSpec.scala
+++ b/src/test/scala/fs2/kafka/CommittableOffsetSpec.scala
@@ -14,6 +14,7 @@ final class CommittableOffsetSpec extends BaseSpec {
       CommittableOffset[Id](
         partition,
         offsetAndMetadata,
+        consumerGroupId = None,
         committed = _
       ).commit
 
@@ -25,18 +26,34 @@ final class CommittableOffsetSpec extends BaseSpec {
 
       assert {
         val offsetAndMetadata = new OffsetAndMetadata(0L, "metadata")
-        val offset = CommittableOffset[Id](partition, offsetAndMetadata, _ => ())
+        val offset = CommittableOffset[Id](partition, offsetAndMetadata, None, _ => ())
 
         offset.toString == "CommittableOffset(topic-0 -> (0, metadata))" &&
         offset.show == offset.toString
       }
 
       assert {
+        val offsetAndMetadata = new OffsetAndMetadata(0L, "metadata")
+        val offset = CommittableOffset[Id](partition, offsetAndMetadata, Some("the-group"), _ => ())
+
+        offset.toString == "CommittableOffset(topic-0 -> (0, metadata), the-group)" &&
+          offset.show == offset.toString
+      }
+
+      assert {
         val offsetAndMetadata = new OffsetAndMetadata(0L)
-        val offset = CommittableOffset[Id](partition, offsetAndMetadata, _ => ())
+        val offset = CommittableOffset[Id](partition, offsetAndMetadata, None, _ => ())
 
         offset.toString == "CommittableOffset(topic-0 -> 0)" &&
         offset.show == offset.toString
+      }
+
+      assert {
+        val offsetAndMetadata = new OffsetAndMetadata(0L)
+        val offset = CommittableOffset[Id](partition, offsetAndMetadata, Some("the-group"), _ => ())
+
+        offset.toString == "CommittableOffset(topic-0 -> 0, the-group)" &&
+          offset.show == offset.toString
       }
     }
   }

--- a/src/test/scala/fs2/kafka/ConsumerSettingsSpec.scala
+++ b/src/test/scala/fs2/kafka/ConsumerSettingsSpec.scala
@@ -54,9 +54,14 @@ final class ConsumerSettingsSpec extends BaseSpec {
 
     it("should provide withGroupId") {
       assert {
+        settings.groupId.isEmpty &&
         settings
           .withGroupId("group")
           .properties(ConsumerConfig.GROUP_ID_CONFIG)
+          .contains("group") &&
+        settings
+          .withGroupId("group")
+          .groupId
           .contains("group")
       }
     }

--- a/src/test/scala/fs2/kafka/ConsumerSettingsSpec.scala
+++ b/src/test/scala/fs2/kafka/ConsumerSettingsSpec.scala
@@ -52,15 +52,12 @@ final class ConsumerSettingsSpec extends BaseSpec {
     }
 
     it("should provide withGroupId") {
+      assert(settings.properties(ConsumerConfig.GROUP_ID_CONFIG).isEmpty)
+
       assert {
-        settings.groupId.isEmpty &&
         settings
           .withGroupId("group")
           .properties(ConsumerConfig.GROUP_ID_CONFIG)
-          .contains("group") &&
-        settings
-          .withGroupId("group")
-          .groupId
           .contains("group")
       }
     }

--- a/src/test/scala/fs2/kafka/ConsumerSettingsSpec.scala
+++ b/src/test/scala/fs2/kafka/ConsumerSettingsSpec.scala
@@ -3,7 +3,6 @@ package fs2.kafka
 import cats.effect.IO
 import cats.implicits._
 import org.apache.kafka.clients.consumer.ConsumerConfig
-import org.apache.kafka.common.requests.IsolationLevel
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
@@ -145,11 +144,11 @@ final class ConsumerSettingsSpec extends BaseSpec {
     it("should provide withIsolationLevel") {
       assert {
         settings
-          .withIsolationLevel(IsolationLevel.READ_COMMITTED)
+          .withIsolationLevel(IsolationLevel.ReadCommitted)
           .properties(ConsumerConfig.ISOLATION_LEVEL_CONFIG)
           .contains("read_committed")
         settings
-          .withIsolationLevel(IsolationLevel.READ_UNCOMMITTED)
+          .withIsolationLevel(IsolationLevel.ReadUncommitted)
           .properties(ConsumerConfig.ISOLATION_LEVEL_CONFIG)
           .contains("read_uncommitted")
       }

--- a/src/test/scala/fs2/kafka/ConsumerSettingsSpec.scala
+++ b/src/test/scala/fs2/kafka/ConsumerSettingsSpec.scala
@@ -52,9 +52,8 @@ final class ConsumerSettingsSpec extends BaseSpec {
     }
 
     it("should provide withGroupId") {
-      assert(settings.properties(ConsumerConfig.GROUP_ID_CONFIG).isEmpty)
-
       assert {
+        settings.properties.get(ConsumerConfig.GROUP_ID_CONFIG).isEmpty &&
         settings
           .withGroupId("group")
           .properties(ConsumerConfig.GROUP_ID_CONFIG)

--- a/src/test/scala/fs2/kafka/ConsumerSettingsSpec.scala
+++ b/src/test/scala/fs2/kafka/ConsumerSettingsSpec.scala
@@ -3,6 +3,7 @@ package fs2.kafka
 import cats.effect.IO
 import cats.implicits._
 import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.common.requests.IsolationLevel
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
@@ -133,6 +134,19 @@ final class ConsumerSettingsSpec extends BaseSpec {
           .withDefaultApiTimeout(10.seconds)
           .properties(ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG)
           .contains("10000")
+      }
+    }
+
+    it("should provide withIsolationLevel") {
+      assert {
+        settings
+          .withIsolationLevel(IsolationLevel.READ_COMMITTED)
+          .properties(ConsumerConfig.ISOLATION_LEVEL_CONFIG)
+          .contains("read_committed")
+        settings
+          .withIsolationLevel(IsolationLevel.READ_UNCOMMITTED)
+          .properties(ConsumerConfig.ISOLATION_LEVEL_CONFIG)
+          .contains("read_uncommitted")
       }
     }
 

--- a/src/test/scala/fs2/kafka/IsolationLevelSpec.scala
+++ b/src/test/scala/fs2/kafka/IsolationLevelSpec.scala
@@ -1,0 +1,10 @@
+package fs2.kafka
+
+final class IsolationLevelSpec extends BaseSpec {
+  describe("IsolationLevel") {
+    it("should have expected toString") {
+      assert(IsolationLevel.ReadCommitted.toString == "ReadCommitted")
+      assert(IsolationLevel.ReadUncommitted.toString == "ReadUncommitted")
+    }
+  }
+}

--- a/src/test/scala/fs2/kafka/KafkaSpec.scala
+++ b/src/test/scala/fs2/kafka/KafkaSpec.scala
@@ -167,11 +167,26 @@ final class KafkaSpec extends BaseAsyncSpec {
   def exampleOffsets[F[_]](
     commit: Map[TopicPartition, OffsetAndMetadata] => F[Unit]
   ): List[CommittableOffset[F]] = List(
-    CommittableOffset[F](new TopicPartition("topic", 0), new OffsetAndMetadata(1L), Some("group-1"), commit),
-    CommittableOffset[F](new TopicPartition("topic", 0), new OffsetAndMetadata(2L), Some("group-1"), commit),
-    CommittableOffset[F](new TopicPartition("topic", 1), new OffsetAndMetadata(1L), Some("group-1"), commit),
-    CommittableOffset[F](new TopicPartition("topic", 1), new OffsetAndMetadata(2L), Some("group-1"), commit),
-    CommittableOffset[F](new TopicPartition("topic", 1), new OffsetAndMetadata(3L), Some("group-1"), commit)
+    CommittableOffset[F](new TopicPartition("topic", 0),
+                         new OffsetAndMetadata(1L),
+                         Some("group-1"),
+                         commit),
+    CommittableOffset[F](new TopicPartition("topic", 0),
+                         new OffsetAndMetadata(2L),
+                         Some("group-1"),
+                         commit),
+    CommittableOffset[F](new TopicPartition("topic", 1),
+                         new OffsetAndMetadata(1L),
+                         Some("group-1"),
+                         commit),
+    CommittableOffset[F](new TopicPartition("topic", 1),
+                         new OffsetAndMetadata(2L),
+                         Some("group-1"),
+                         commit),
+    CommittableOffset[F](new TopicPartition("topic", 1),
+                         new OffsetAndMetadata(3L),
+                         Some("group-1"),
+                         commit)
   )
 
   val exampleOffsetsCommitted: Map[TopicPartition, OffsetAndMetadata] = Map(

--- a/src/test/scala/fs2/kafka/KafkaSpec.scala
+++ b/src/test/scala/fs2/kafka/KafkaSpec.scala
@@ -167,11 +167,11 @@ final class KafkaSpec extends BaseAsyncSpec {
   def exampleOffsets[F[_]](
     commit: Map[TopicPartition, OffsetAndMetadata] => F[Unit]
   ): List[CommittableOffset[F]] = List(
-    CommittableOffset[F](new TopicPartition("topic", 0), new OffsetAndMetadata(1L), commit),
-    CommittableOffset[F](new TopicPartition("topic", 0), new OffsetAndMetadata(2L), commit),
-    CommittableOffset[F](new TopicPartition("topic", 1), new OffsetAndMetadata(1L), commit),
-    CommittableOffset[F](new TopicPartition("topic", 1), new OffsetAndMetadata(2L), commit),
-    CommittableOffset[F](new TopicPartition("topic", 1), new OffsetAndMetadata(3L), commit)
+    CommittableOffset[F](new TopicPartition("topic", 0), new OffsetAndMetadata(1L), Some("group-1"), commit),
+    CommittableOffset[F](new TopicPartition("topic", 0), new OffsetAndMetadata(2L), Some("group-1"), commit),
+    CommittableOffset[F](new TopicPartition("topic", 1), new OffsetAndMetadata(1L), Some("group-1"), commit),
+    CommittableOffset[F](new TopicPartition("topic", 1), new OffsetAndMetadata(2L), Some("group-1"), commit),
+    CommittableOffset[F](new TopicPartition("topic", 1), new OffsetAndMetadata(3L), Some("group-1"), commit)
   )
 
   val exampleOffsetsCommitted: Map[TopicPartition, OffsetAndMetadata] = Map(

--- a/src/test/scala/fs2/kafka/PackageSpec.scala
+++ b/src/test/scala/fs2/kafka/PackageSpec.scala
@@ -43,6 +43,21 @@ final class PackageSpec extends BaseKafkaSpec {
     }
   }
 
+  describe("creating transactional producers") {
+    it("should support defined syntax") {
+      val settings =
+        ProducerSettings[IO, String, String]
+
+      transactionalProducerResource[IO, String, String](settings)
+      transactionalProducerResource[IO].toString should startWith("TransactionalProducerResource$")
+      transactionalProducerResource[IO].using(settings)
+
+      transactionalProducerStream[IO, String, String](settings)
+      transactionalProducerStream[IO].toString should startWith("TransactionalProducerStream$")
+      transactionalProducerStream[IO].using(settings)
+    }
+  }
+
   describe("creating consumer execution contexts") {
     it("should support defined syntax") {
       consumerExecutionContextResource[IO]

--- a/src/test/scala/fs2/kafka/ProducerSettingsSpec.scala
+++ b/src/test/scala/fs2/kafka/ProducerSettingsSpec.scala
@@ -114,6 +114,24 @@ final class ProducerSettingsSpec extends BaseSpec {
       }
     }
 
+    it("should provide withTransactionalId") {
+      assert {
+        settings
+          .withTransactionalId("transactional-id")
+          .properties(ProducerConfig.TRANSACTIONAL_ID_CONFIG)
+          .contains("transactional-id")
+      }
+    }
+
+    it("should provide withTransactionTimeout") {
+      assert {
+        settings
+          .withTransactionTimeout(10.seconds)
+          .properties(ProducerConfig.TRANSACTION_TIMEOUT_CONFIG)
+          .contains("10000")
+      }
+    }
+
     it("should provide withShiftSerialization") {
       assert {
         settings

--- a/src/test/scala/fs2/kafka/ProducerSettingsSpec.scala
+++ b/src/test/scala/fs2/kafka/ProducerSettingsSpec.scala
@@ -132,14 +132,6 @@ final class ProducerSettingsSpec extends BaseSpec {
       }
     }
 
-    it("should provide withShiftSerialization") {
-      assert {
-        settings
-          .withShiftSerialization(false)
-          .shiftSerialization == false
-      }
-    }
-
     it("should provide withCreateProducer") {
       assert {
         settings
@@ -167,7 +159,7 @@ final class ProducerSettingsSpec extends BaseSpec {
       val shown = settings.show
 
       assert(
-        shown == "ProducerSettings(closeTimeout = 60 seconds, shiftSerialization = true)" &&
+        shown == "ProducerSettings(closeTimeout = 60 seconds)" &&
           shown == settings.toString
       )
     }

--- a/src/test/scala/fs2/kafka/TransactionalKafkaProducerSpec.scala
+++ b/src/test/scala/fs2/kafka/TransactionalKafkaProducerSpec.scala
@@ -68,7 +68,7 @@ class TransactionalKafkaProducerSpec extends BaseKafkaSpec with OptionValues {
     withKafka { (config, topic) =>
       createCustomTopic(topic, partitions = 3)
       val toProduce =
-        (0 to 100).toList.map(n => s"key-$n" -> s"value-$n").toList
+        Chunk.seq((0 to 100).toList.map(n => s"key-$n" -> s"value-$n"))
 
       val toPassthrough = "passthrough"
 

--- a/src/test/scala/fs2/kafka/TransactionalKafkaProducerSpec.scala
+++ b/src/test/scala/fs2/kafka/TransactionalKafkaProducerSpec.scala
@@ -90,7 +90,7 @@ class TransactionalKafkaProducerSpec extends BaseKafkaSpec with OptionValues {
               )
           }
           message = TransactionalProducerMessage(
-            records.zip(offsets).map {
+            Chunk.seq(records.zip(offsets)).map {
               case (record, offset) =>
                 CommittableProducerRecords.one(
                   record,
@@ -169,7 +169,7 @@ class TransactionalKafkaProducerSpec extends BaseKafkaSpec with OptionValues {
               )
           }
           message = TransactionalProducerMessage(
-            records.zip(offsets).map {
+            Chunk.seq(records.zip(offsets)).map {
               case (record, offset) =>
                 CommittableProducerRecords(
                   NonEmptyList.one(record),

--- a/src/test/scala/fs2/kafka/TransactionalKafkaProducerSpec.scala
+++ b/src/test/scala/fs2/kafka/TransactionalKafkaProducerSpec.scala
@@ -1,0 +1,180 @@
+package fs2.kafka
+
+import java.util
+
+import cats.data.NonEmptyList
+import cats.effect.IO
+import cats.implicits._
+import fs2.{Chunk, Stream}
+import net.manub.embeddedkafka.EmbeddedKafkaConfig
+import org.apache.kafka.clients.consumer.{ConsumerConfig, OffsetAndMetadata}
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.serialization.ByteArraySerializer
+import org.scalatest.OptionValues
+
+import scala.collection.JavaConverters._
+
+class TransactionalKafkaProducerSpec extends BaseKafkaSpec with OptionValues {
+
+  it("should be able to produce single records in a transaction") {
+    withKafka { (config, topic) =>
+      createCustomTopic(topic, partitions = 3)
+      val toProduce = (0 to 10).map(n => s"key-$n" -> s"value-$n")
+
+      val produced =
+        (for {
+          producer <- transactionalProducerStream[IO, String, String](
+            producerSettings[IO](config).withTransactionalId("transactions")
+          )
+          _ <- Stream.eval(IO(producer.toString should startWith("TransactionalKafkaProducer$")))
+          message <- Stream.chunk(Chunk.seq(toProduce)).zipWithIndex.evalMap {
+            case ((key, value), i) =>
+              val offset = CommittableOffset[IO](
+                new TopicPartition(topic, (i % 3).toInt),
+                new OffsetAndMetadata(i),
+                Some("group"),
+                _ => IO.unit
+              )
+              TransactionalProducerMessage.one[IO, String, String, (String, String)](
+                ProducerRecord(topic, key, value) -> offset,
+                (key, value)
+              )
+          }
+          passthrough <- Stream.eval(producer.producePassthrough(message)).buffer(toProduce.size)
+        } yield passthrough).compile.toVector.unsafeRunSync()
+
+      produced should contain theSameElementsAs toProduce
+
+      val consumed = {
+        implicit val transactionalConfig: EmbeddedKafkaConfig = EmbeddedKafkaConfig(
+          kafkaPort = config.kafkaPort,
+          zooKeeperPort = config.zooKeeperPort,
+          customConsumerProperties = Map(ConsumerConfig.ISOLATION_LEVEL_CONFIG -> "read_committed")
+        )
+        consumeNumberKeyedMessagesFrom[String, String](topic, produced.size)
+      }
+
+      consumed should contain theSameElementsAs produced.toList
+    }
+  }
+
+  it("should be able to produce multiple records in a transaction") {
+    withKafka { (config, topic) =>
+      createCustomTopic(topic, partitions = 3)
+      val toProduce = NonEmptyList
+        .fromList(
+          (0 to 100).map(n => s"key-$n" -> s"value-$n").toList
+        )
+        .value
+      val toPassthrough = "passthrough"
+
+      val produced =
+        (for {
+          producer <- transactionalProducerStream[IO, String, String](
+            producerSettings[IO](config).withTransactionalId("transactions")
+          )
+          records = toProduce.zipWithIndex.map {
+            case ((key, value), i) =>
+              ProducerRecord(topic, key, value) -> CommittableOffset[IO](
+                new TopicPartition(topic, i % 3),
+                new OffsetAndMetadata(i.toLong),
+                Some("group"),
+                _ => IO.unit
+              )
+          }
+          message <- Stream.eval(
+            TransactionalProducerMessage[NonEmptyList]
+              .of[IO, String, String, String](records, toPassthrough)
+          )
+          result <- Stream.eval(producer.produce(message))
+        } yield result).compile.lastOrError.unsafeRunSync()
+
+      val records =
+        produced.records.map {
+          case (record, _) =>
+            record.key -> record.value
+        }
+
+      assert(records == toProduce && produced.passthrough == toPassthrough)
+
+      val consumed = {
+        implicit val transactionalConfig: EmbeddedKafkaConfig = EmbeddedKafkaConfig(
+          kafkaPort = config.kafkaPort,
+          zooKeeperPort = config.zooKeeperPort,
+          customConsumerProperties = Map(ConsumerConfig.ISOLATION_LEVEL_CONFIG -> "read_committed")
+        )
+        consumeNumberKeyedMessagesFrom[String, String](topic, records.size)
+      }
+
+      consumed should contain theSameElementsAs records.toList
+    }
+  }
+
+  it("should abort transactions if committing offsets fails") {
+    withKafka { (config, topic) =>
+      createCustomTopic(topic, partitions = 3)
+      val toProduce = NonEmptyList
+        .fromList(
+          (0 to 100).map(n => s"key-$n" -> s"value-$n").toList
+        )
+        .value
+      val toPassthrough = "passthrough"
+
+      val error = new RuntimeException("BOOM")
+
+      val produced =
+        (for {
+          producer <- transactionalProducerStream[IO, String, String](
+            producerSettings[IO](config)
+              .withTransactionalId("transactions")
+              .withCreateProducer { properties =>
+                IO.delay {
+                  new org.apache.kafka.clients.producer.KafkaProducer[Array[Byte], Array[Byte]](
+                    (properties: Map[String, AnyRef]).asJava,
+                    new ByteArraySerializer,
+                    new ByteArraySerializer
+                  ) {
+                    override def sendOffsetsToTransaction(
+                      offsets: util.Map[TopicPartition, OffsetAndMetadata],
+                      consumerGroupId: String
+                    ): Unit =
+                      if (offsets.containsKey(new TopicPartition(topic, 2))) {
+                        throw error
+                      } else {
+                        super.sendOffsetsToTransaction(offsets, consumerGroupId)
+                      }
+                  }
+                }
+              }
+          )
+          records = toProduce.zipWithIndex.map {
+            case ((key, value), i) =>
+              ProducerRecord(topic, key, value) -> CommittableOffset(
+                new TopicPartition(topic, i % 3),
+                new OffsetAndMetadata(i.toLong),
+                Some("group"),
+                _ => IO.unit
+              )
+          }
+          message <- Stream.eval(
+            TransactionalProducerMessage[NonEmptyList]
+              .of[IO, String, String, String](records, toPassthrough)
+          )
+          result <- Stream.eval(producer.produce(message).attempt)
+        } yield result).compile.lastOrError.unsafeRunSync()
+
+      produced shouldBe Left(error)
+
+      val consumedOrError = {
+        implicit val transactionalConfig: EmbeddedKafkaConfig = EmbeddedKafkaConfig(
+          kafkaPort = config.kafkaPort,
+          zooKeeperPort = config.zooKeeperPort,
+          customConsumerProperties = Map(ConsumerConfig.ISOLATION_LEVEL_CONFIG -> "read_committed")
+        )
+        Either.catchNonFatal(consumeFirstKeyedMessageFrom[String, String](topic))
+      }
+
+      consumedOrError.isLeft shouldBe true
+    }
+  }
+}

--- a/src/test/scala/fs2/kafka/TransactionalKafkaProducerSpec.scala
+++ b/src/test/scala/fs2/kafka/TransactionalKafkaProducerSpec.scala
@@ -90,7 +90,7 @@ class TransactionalKafkaProducerSpec extends BaseKafkaSpec with OptionValues {
               )
           }
           message = TransactionalProducerMessage(
-            Chunk.seq(records.zip(offsets)).map {
+            records.zip(offsets).map {
               case (record, offset) =>
                 CommittableProducerRecords.one(
                   record,

--- a/src/test/scala/fs2/kafka/TransactionalProducerMessageSpec.scala
+++ b/src/test/scala/fs2/kafka/TransactionalProducerMessageSpec.scala
@@ -4,6 +4,7 @@ import cats.effect.IO
 import cats.instances.list._
 import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import org.apache.kafka.common.TopicPartition
+import fs2.Chunk
 
 class TransactionalProducerMessageSpec extends BaseSpec {
   describe("TransactionalProducerMessageSpec") {
@@ -21,10 +22,10 @@ class TransactionalProducerMessageSpec extends BaseSpec {
       assert {
         TransactionalProducerMessage
           .one(CommittableProducerRecords.one(record, offset), 123)
-          .toString == "TransactionalProducerMessage(Chain(CommittableProducerRecords(Chain(ProducerRecord(topic = topic, key = key, value = value)), CommittableOffset(topic-1 -> 1, the-group))), 123)" &&
+          .toString == "TransactionalProducerMessage(Chunk(CommittableProducerRecords(ProducerRecord(topic = topic, key = key, value = value), CommittableOffset(topic-1 -> 1, the-group))), 123)" &&
         TransactionalProducerMessage
           .one(CommittableProducerRecords.one(record, offset))
-          .toString == "TransactionalProducerMessage(Chain(CommittableProducerRecords(Chain(ProducerRecord(topic = topic, key = key, value = value)), CommittableOffset(topic-1 -> 1, the-group))), ())"
+          .toString == "TransactionalProducerMessage(Chunk(CommittableProducerRecords(ProducerRecord(topic = topic, key = key, value = value), CommittableOffset(topic-1 -> 1, the-group))), ())"
       }
     }
 
@@ -44,17 +45,17 @@ class TransactionalProducerMessageSpec extends BaseSpec {
       assert {
         TransactionalProducerMessage
           .one(CommittableProducerRecords(records, offset), 123)
-          .toString == "TransactionalProducerMessage(Chain(CommittableProducerRecords(List(ProducerRecord(topic = topic, key = key, value = value), ProducerRecord(topic = topic2, key = key2, value = value2)), CommittableOffset(topic-1 -> 1, the-group))), 123)" &&
+          .toString == "TransactionalProducerMessage(Chunk(CommittableProducerRecords(List(ProducerRecord(topic = topic, key = key, value = value), ProducerRecord(topic = topic2, key = key2, value = value2)), CommittableOffset(topic-1 -> 1, the-group))), 123)" &&
         TransactionalProducerMessage
           .one(CommittableProducerRecords(records, offset))
-          .toString == "TransactionalProducerMessage(Chain(CommittableProducerRecords(List(ProducerRecord(topic = topic, key = key, value = value), ProducerRecord(topic = topic2, key = key2, value = value2)), CommittableOffset(topic-1 -> 1, the-group))), ())"
+          .toString == "TransactionalProducerMessage(Chunk(CommittableProducerRecords(List(ProducerRecord(topic = topic, key = key, value = value), ProducerRecord(topic = topic2, key = key2, value = value2)), CommittableOffset(topic-1 -> 1, the-group))), ())"
       }
     }
 
     it("should be able to create with zero records") {
       assert {
-        TransactionalProducerMessage[IO, List, List, String, String, Int](Nil, 123).toString == "TransactionalProducerMessage(List(), 123)" &&
-        TransactionalProducerMessage[IO, List, List, String, String](Nil).toString == "TransactionalProducerMessage(List(), ())"
+        TransactionalProducerMessage[IO, List, String, String, Int](Chunk.empty, 123).toString == "TransactionalProducerMessage(empty, 123)" &&
+        TransactionalProducerMessage[IO, List, String, String](Chunk.empty).toString == "TransactionalProducerMessage(empty, ())"
       }
     }
   }

--- a/src/test/scala/fs2/kafka/TransactionalProducerMessageSpec.scala
+++ b/src/test/scala/fs2/kafka/TransactionalProducerMessageSpec.scala
@@ -2,7 +2,6 @@ package fs2.kafka
 
 import cats.data.NonEmptyList
 import cats.effect.IO
-import cats.implicits._
 import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import org.apache.kafka.common.TopicPartition
 
@@ -10,6 +9,7 @@ class TransactionalProducerMessageSpec extends BaseSpec {
   describe("TransactionalProducerMessageSpec") {
     it("should be able to create with one record") {
       val record = ProducerRecord("topic", "key", "value")
+
       val offset =
         CommittableOffset[IO](
           new TopicPartition("topic", 1),
@@ -20,21 +20,11 @@ class TransactionalProducerMessageSpec extends BaseSpec {
 
       assert {
         TransactionalProducerMessage
-          .one(record, offset.batch, 123)
-          .unsafeRunSync()
-          .toString == "TransactionalProducerMessage(ProducerRecord(topic = topic, key = key, value = value), [topic-1 -> 1], the-group, 123)" &&
+          .one(CommittableProducerRecords.one(record, offset), 123)
+          .toString == "TransactionalProducerMessage(CommittableProducerRecords(ProducerRecord(topic = topic, key = key, value = value), CommittableOffset(topic-1 -> 1, the-group)), 123)" &&
         TransactionalProducerMessage
-          .one(record, offset.batch, 123)
-          .unsafeRunSync()
-          .show == "TransactionalProducerMessage(ProducerRecord(topic = topic, key = key, value = value), [topic-1 -> 1], the-group, 123)" &&
-        TransactionalProducerMessage
-          .one(record, offset.batch)
-          .unsafeRunSync()
-          .toString == "TransactionalProducerMessage(ProducerRecord(topic = topic, key = key, value = value), [topic-1 -> 1], the-group, ())" &&
-        TransactionalProducerMessage
-          .one(record, offset.batch)
-          .unsafeRunSync()
-          .show == "TransactionalProducerMessage(ProducerRecord(topic = topic, key = key, value = value), [topic-1 -> 1], the-group, ())"
+          .one(CommittableProducerRecords.one(record, offset))
+          .toString == "TransactionalProducerMessage(CommittableProducerRecords(ProducerRecord(topic = topic, key = key, value = value), CommittableOffset(topic-1 -> 1, the-group)), ())"
       }
     }
 
@@ -43,6 +33,7 @@ class TransactionalProducerMessageSpec extends BaseSpec {
         ProducerRecord("topic", "key", "value"),
         ProducerRecord("topic2", "key2", "value2")
       )
+
       val offset = CommittableOffset[IO](
         new TopicPartition("topic", 1),
         new OffsetAndMetadata(1),
@@ -51,97 +42,13 @@ class TransactionalProducerMessageSpec extends BaseSpec {
       )
 
       assert {
-        TransactionalProducerMessage(records, offset.batch, 123)
-          .unsafeRunSync()
-          .toString == "TransactionalProducerMessage(ProducerRecord(topic = topic, key = key, value = value), ProducerRecord(topic = topic2, key = key2, value = value2), [topic-1 -> 1], the-group, 123)" &&
-        TransactionalProducerMessage(records, offset.batch, 123)
-          .unsafeRunSync()
-          .show == "TransactionalProducerMessage(ProducerRecord(topic = topic, key = key, value = value), ProducerRecord(topic = topic2, key = key2, value = value2), [topic-1 -> 1], the-group, 123)" &&
-        TransactionalProducerMessage(records, offset.batch)
-          .unsafeRunSync()
-          .toString == "TransactionalProducerMessage(ProducerRecord(topic = topic, key = key, value = value), ProducerRecord(topic = topic2, key = key2, value = value2), [topic-1 -> 1], the-group, ())" &&
-        TransactionalProducerMessage(records, offset.batch)
-          .unsafeRunSync()
-          .show == "TransactionalProducerMessage(ProducerRecord(topic = topic, key = key, value = value), ProducerRecord(topic = topic2, key = key2, value = value2), [topic-1 -> 1], the-group, ())" &&
-        TransactionalProducerMessage[NonEmptyList]
-          .of(records, offset.batch, 123)
-          .unsafeRunSync()
-          .toString == "TransactionalProducerMessage(ProducerRecord(topic = topic, key = key, value = value), ProducerRecord(topic = topic2, key = key2, value = value2), [topic-1 -> 1], the-group, 123)" &&
-        TransactionalProducerMessage[NonEmptyList]
-          .of(records, offset.batch, 123)
-          .unsafeRunSync()
-          .show == "TransactionalProducerMessage(ProducerRecord(topic = topic, key = key, value = value), ProducerRecord(topic = topic2, key = key2, value = value2), [topic-1 -> 1], the-group, 123)" &&
-        TransactionalProducerMessage[NonEmptyList]
-          .of(records, offset.batch)
-          .unsafeRunSync()
-          .toString == "TransactionalProducerMessage(ProducerRecord(topic = topic, key = key, value = value), ProducerRecord(topic = topic2, key = key2, value = value2), [topic-1 -> 1], the-group, ())" &&
-        TransactionalProducerMessage[NonEmptyList]
-          .of(records, offset.batch)
-          .unsafeRunSync()
-          .show == "TransactionalProducerMessage(ProducerRecord(topic = topic, key = key, value = value), ProducerRecord(topic = topic2, key = key2, value = value2), [topic-1 -> 1], the-group, ())"
-      }
-    }
-
-    it("should be able to create with multiple offsets from the same consumer group") {
-      val record = ProducerRecord("topic", "key", "value")
-      val offsets = NonEmptyList
-        .of(1, 2)
-        .map { i =>
-          CommittableOffset[IO](
-            new TopicPartition("topic", i),
-            new OffsetAndMetadata(1),
-            Some("the-group"),
-            _ => IO.unit
-          )
-        }
-      val batch = CommittableOffsetBatch.fromFoldable(offsets)
-
-      assert {
         TransactionalProducerMessage
-          .one(record, batch, 123)
-          .unsafeRunSync()
-          .toString == "TransactionalProducerMessage(ProducerRecord(topic = topic, key = key, value = value), [topic-1 -> 1, topic-2 -> 1], the-group, 123)" &&
-          TransactionalProducerMessage
-            .one(record, batch, 123)
-            .unsafeRunSync()
-            .show == "TransactionalProducerMessage(ProducerRecord(topic = topic, key = key, value = value), [topic-1 -> 1, topic-2 -> 1], the-group, 123)" &&
-          TransactionalProducerMessage
-            .one(record, batch)
-            .unsafeRunSync()
-            .toString == "TransactionalProducerMessage(ProducerRecord(topic = topic, key = key, value = value), [topic-1 -> 1, topic-2 -> 1], the-group, ())" &&
-          TransactionalProducerMessage
-            .one(record, batch)
-            .unsafeRunSync()
-            .show == "TransactionalProducerMessage(ProducerRecord(topic = topic, key = key, value = value), [topic-1 -> 1, topic-2 -> 1], the-group, ())"
+          .one(CommittableProducerRecords(records, offset), 123)
+          .toString == "TransactionalProducerMessage(NonEmptyList(CommittableProducerRecords(NonEmptyList(ProducerRecord(topic = topic, key = key, value = value), ProducerRecord(topic = topic2, key = key2, value = value2)), CommittableOffset(topic-1 -> 1, the-group))), 123)" &&
+        TransactionalProducerMessage
+          .one(CommittableProducerRecords(records, offset))
+          .toString == "TransactionalProducerMessage(NonEmptyList(CommittableProducerRecords(NonEmptyList(ProducerRecord(topic = topic, key = key, value = value), ProducerRecord(topic = topic2, key = key2, value = value2)), CommittableOffset(topic-1 -> 1, the-group))), ())"
       }
-    }
-
-    it("should fail to create with multiple consumer group IDs") {
-      val records = NonEmptyList.of(1, 2).map(i => ProducerRecord("topic", "key", s"value-$i"))
-      val batch = CommittableOffsetBatch.fromFoldable {
-        NonEmptyList
-          .of(1, 2)
-          .map { i =>
-            CommittableOffset[IO](
-              new TopicPartition("topic", 1),
-              new OffsetAndMetadata(1),
-              Some(s"the-group-$i"),
-              _ => IO.unit
-            )
-          }
-      }
-
-      TransactionalProducerMessage(records, batch).attempt.unsafeRunSync().isLeft shouldBe true
-    }
-
-    it("should fail to create with no consumer group IDs") {
-      val record = ProducerRecord("topic", "key", "value")
-
-      TransactionalProducerMessage
-        .one(record, CommittableOffsetBatch.empty[IO])
-        .attempt
-        .unsafeRunSync()
-        .isLeft shouldBe true
     }
   }
 }

--- a/src/test/scala/fs2/kafka/TransactionalProducerMessageSpec.scala
+++ b/src/test/scala/fs2/kafka/TransactionalProducerMessageSpec.scala
@@ -20,98 +20,125 @@ class TransactionalProducerMessageSpec extends BaseSpec {
 
       assert {
         TransactionalProducerMessage
-          .one(record -> offset, 123)
+          .one(record, offset.batch, 123)
           .unsafeRunSync()
-          .toString == "TransactionalProducerMessage(ProducerRecord(topic = topic, key = key, value = value), CommittableOffsetBatch(topic-1 -> 1), the-group, 123)" &&
+          .toString == "TransactionalProducerMessage(ProducerRecord(topic = topic, key = key, value = value), [topic-1 -> 1], the-group, 123)" &&
         TransactionalProducerMessage
-          .one(record -> offset, 123)
+          .one(record, offset.batch, 123)
           .unsafeRunSync()
-          .show == "TransactionalProducerMessage(ProducerRecord(topic = topic, key = key, value = value), CommittableOffsetBatch(topic-1 -> 1), the-group, 123)" &&
+          .show == "TransactionalProducerMessage(ProducerRecord(topic = topic, key = key, value = value), [topic-1 -> 1], the-group, 123)" &&
         TransactionalProducerMessage
-          .one(record -> offset)
+          .one(record, offset.batch)
           .unsafeRunSync()
-          .toString == "TransactionalProducerMessage(ProducerRecord(topic = topic, key = key, value = value), CommittableOffsetBatch(topic-1 -> 1), the-group, ())" &&
+          .toString == "TransactionalProducerMessage(ProducerRecord(topic = topic, key = key, value = value), [topic-1 -> 1], the-group, ())" &&
         TransactionalProducerMessage
-          .one(record -> offset)
+          .one(record, offset.batch)
           .unsafeRunSync()
-          .show == "TransactionalProducerMessage(ProducerRecord(topic = topic, key = key, value = value), CommittableOffsetBatch(topic-1 -> 1), the-group, ())"
+          .show == "TransactionalProducerMessage(ProducerRecord(topic = topic, key = key, value = value), [topic-1 -> 1], the-group, ())"
       }
     }
 
     it("should be able to create with multiple records") {
-      val records = NonEmptyList.of(ProducerRecord("topic", "key", "value"))
-      val offsets = NonEmptyList.of(
-        CommittableOffset[IO](
-          new TopicPartition("topic", 1),
-          new OffsetAndMetadata(1),
-          Some("the-group"),
-          _ => IO.unit
-        )
+      val records = NonEmptyList.of(
+        ProducerRecord("topic", "key", "value"),
+        ProducerRecord("topic2", "key2", "value2")
       )
-      val zipped = records.zipWith(offsets)(Tuple2.apply)
+      val offset = CommittableOffset[IO](
+        new TopicPartition("topic", 1),
+        new OffsetAndMetadata(1),
+        Some("the-group"),
+        _ => IO.unit
+      )
 
       assert {
-        TransactionalProducerMessage(zipped, 123)
+        TransactionalProducerMessage(records, offset.batch, 123)
           .unsafeRunSync()
-          .toString == "TransactionalProducerMessage(ProducerRecord(topic = topic, key = key, value = value), CommittableOffsetBatch(topic-1 -> 1), the-group, 123)" &&
-        TransactionalProducerMessage(zipped, 123)
+          .toString == "TransactionalProducerMessage(ProducerRecord(topic = topic, key = key, value = value), ProducerRecord(topic = topic2, key = key2, value = value2), [topic-1 -> 1], the-group, 123)" &&
+        TransactionalProducerMessage(records, offset.batch, 123)
           .unsafeRunSync()
-          .show == "TransactionalProducerMessage(ProducerRecord(topic = topic, key = key, value = value), CommittableOffsetBatch(topic-1 -> 1), the-group, 123)" &&
-        TransactionalProducerMessage(zipped)
+          .show == "TransactionalProducerMessage(ProducerRecord(topic = topic, key = key, value = value), ProducerRecord(topic = topic2, key = key2, value = value2), [topic-1 -> 1], the-group, 123)" &&
+        TransactionalProducerMessage(records, offset.batch)
           .unsafeRunSync()
-          .toString == "TransactionalProducerMessage(ProducerRecord(topic = topic, key = key, value = value), CommittableOffsetBatch(topic-1 -> 1), the-group, ())" &&
-        TransactionalProducerMessage(zipped)
+          .toString == "TransactionalProducerMessage(ProducerRecord(topic = topic, key = key, value = value), ProducerRecord(topic = topic2, key = key2, value = value2), [topic-1 -> 1], the-group, ())" &&
+        TransactionalProducerMessage(records, offset.batch)
           .unsafeRunSync()
-          .show == "TransactionalProducerMessage(ProducerRecord(topic = topic, key = key, value = value), CommittableOffsetBatch(topic-1 -> 1), the-group, ())" &&
+          .show == "TransactionalProducerMessage(ProducerRecord(topic = topic, key = key, value = value), ProducerRecord(topic = topic2, key = key2, value = value2), [topic-1 -> 1], the-group, ())" &&
         TransactionalProducerMessage[NonEmptyList]
-          .of(zipped, 123)
+          .of(records, offset.batch, 123)
           .unsafeRunSync()
-          .toString == "TransactionalProducerMessage(ProducerRecord(topic = topic, key = key, value = value), CommittableOffsetBatch(topic-1 -> 1), the-group, 123)" &&
+          .toString == "TransactionalProducerMessage(ProducerRecord(topic = topic, key = key, value = value), ProducerRecord(topic = topic2, key = key2, value = value2), [topic-1 -> 1], the-group, 123)" &&
         TransactionalProducerMessage[NonEmptyList]
-          .of(zipped, 123)
+          .of(records, offset.batch, 123)
           .unsafeRunSync()
-          .show == "TransactionalProducerMessage(ProducerRecord(topic = topic, key = key, value = value), CommittableOffsetBatch(topic-1 -> 1), the-group, 123)" &&
+          .show == "TransactionalProducerMessage(ProducerRecord(topic = topic, key = key, value = value), ProducerRecord(topic = topic2, key = key2, value = value2), [topic-1 -> 1], the-group, 123)" &&
         TransactionalProducerMessage[NonEmptyList]
-          .of(zipped)
+          .of(records, offset.batch)
           .unsafeRunSync()
-          .toString == "TransactionalProducerMessage(ProducerRecord(topic = topic, key = key, value = value), CommittableOffsetBatch(topic-1 -> 1), the-group, ())" &&
+          .toString == "TransactionalProducerMessage(ProducerRecord(topic = topic, key = key, value = value), ProducerRecord(topic = topic2, key = key2, value = value2), [topic-1 -> 1], the-group, ())" &&
         TransactionalProducerMessage[NonEmptyList]
-          .of(zipped)
+          .of(records, offset.batch)
           .unsafeRunSync()
-          .show == "TransactionalProducerMessage(ProducerRecord(topic = topic, key = key, value = value), CommittableOffsetBatch(topic-1 -> 1), the-group, ())"
+          .show == "TransactionalProducerMessage(ProducerRecord(topic = topic, key = key, value = value), ProducerRecord(topic = topic2, key = key2, value = value2), [topic-1 -> 1], the-group, ())"
+      }
+    }
+
+    it("should be able to create with multiple offsets from the same consumer group") {
+      val record = ProducerRecord("topic", "key", "value")
+      val offsets = NonEmptyList
+        .of(1, 2)
+        .map { i =>
+          CommittableOffset[IO](
+            new TopicPartition("topic", i),
+            new OffsetAndMetadata(1),
+            Some("the-group"),
+            _ => IO.unit
+          )
+        }
+      val batch = CommittableOffsetBatch.fromFoldable(offsets)
+
+      assert {
+        TransactionalProducerMessage
+          .one(record, batch, 123)
+          .unsafeRunSync()
+          .toString == "TransactionalProducerMessage(ProducerRecord(topic = topic, key = key, value = value), [topic-1 -> 1, topic-2 -> 1], the-group, 123)" &&
+          TransactionalProducerMessage
+            .one(record, batch, 123)
+            .unsafeRunSync()
+            .show == "TransactionalProducerMessage(ProducerRecord(topic = topic, key = key, value = value), [topic-1 -> 1, topic-2 -> 1], the-group, 123)" &&
+          TransactionalProducerMessage
+            .one(record, batch)
+            .unsafeRunSync()
+            .toString == "TransactionalProducerMessage(ProducerRecord(topic = topic, key = key, value = value), [topic-1 -> 1, topic-2 -> 1], the-group, ())" &&
+          TransactionalProducerMessage
+            .one(record, batch)
+            .unsafeRunSync()
+            .show == "TransactionalProducerMessage(ProducerRecord(topic = topic, key = key, value = value), [topic-1 -> 1, topic-2 -> 1], the-group, ())"
       }
     }
 
     it("should fail to create with multiple consumer group IDs") {
       val records = NonEmptyList.of(1, 2).map(i => ProducerRecord("topic", "key", s"value-$i"))
-      val offsets = NonEmptyList
-        .of(1, 2)
-        .map(
-          i =>
+      val batch = CommittableOffsetBatch.fromFoldable {
+        NonEmptyList
+          .of(1, 2)
+          .map { i =>
             CommittableOffset[IO](
               new TopicPartition("topic", 1),
               new OffsetAndMetadata(1),
               Some(s"the-group-$i"),
               _ => IO.unit
-          )
-        )
-      val zipped = records.zipWith(offsets)(Tuple2.apply)
+            )
+          }
+      }
 
-      TransactionalProducerMessage(zipped).attempt.unsafeRunSync().isLeft shouldBe true
+      TransactionalProducerMessage(records, batch).attempt.unsafeRunSync().isLeft shouldBe true
     }
 
     it("should fail to create with no consumer group IDs") {
       val record = ProducerRecord("topic", "key", "value")
-      val offset =
-        CommittableOffset[IO](
-          new TopicPartition("topic", 1),
-          new OffsetAndMetadata(1),
-          None,
-          _ => IO.unit
-        )
 
       TransactionalProducerMessage
-        .one(record -> offset)
+        .one(record, CommittableOffsetBatch.empty[IO])
         .attempt
         .unsafeRunSync()
         .isLeft shouldBe true

--- a/src/test/scala/fs2/kafka/TransactionalProducerMessageSpec.scala
+++ b/src/test/scala/fs2/kafka/TransactionalProducerMessageSpec.scala
@@ -1,0 +1,116 @@
+package fs2.kafka
+
+import cats.data.NonEmptyList
+import cats.effect.IO
+import cats.implicits._
+import org.apache.kafka.clients.consumer.OffsetAndMetadata
+import org.apache.kafka.common.TopicPartition
+
+class TransactionalProducerMessageSpec extends BaseSpec {
+  describe("TransactionalProducerMessageSpec") {
+    it("should be able to create with one record") {
+      val record = ProducerRecord("topic", "key", "value")
+      val offset =
+        CommittableOffset[IO](
+          new TopicPartition("topic", 1),
+          new OffsetAndMetadata(1),
+          Some("the-group"),
+          _ => IO.unit
+        )
+
+      assert {
+        TransactionalProducerMessage
+          .one(record -> offset, 123)
+          .unsafeRunSync()
+          .toString == "TransactionalProducerMessage(ProducerRecord(topic = topic, key = key, value = value), CommittableOffsetBatch(topic-1 -> 1), the-group, 123)" &&
+        TransactionalProducerMessage
+          .one(record -> offset, 123)
+          .unsafeRunSync()
+          .show == "TransactionalProducerMessage(ProducerRecord(topic = topic, key = key, value = value), CommittableOffsetBatch(topic-1 -> 1), the-group, 123)" &&
+        TransactionalProducerMessage
+          .one(record -> offset)
+          .unsafeRunSync()
+          .toString == "TransactionalProducerMessage(ProducerRecord(topic = topic, key = key, value = value), CommittableOffsetBatch(topic-1 -> 1), the-group, ())" &&
+        TransactionalProducerMessage
+          .one(record -> offset)
+          .unsafeRunSync()
+          .show == "TransactionalProducerMessage(ProducerRecord(topic = topic, key = key, value = value), CommittableOffsetBatch(topic-1 -> 1), the-group, ())"
+      }
+    }
+
+    it("should be able to create with multiple records") {
+      val records = NonEmptyList.of(ProducerRecord("topic", "key", "value"))
+      val offsets = NonEmptyList.of(
+        CommittableOffset[IO](
+          new TopicPartition("topic", 1),
+          new OffsetAndMetadata(1),
+          Some("the-group"),
+          _ => IO.unit
+        )
+      )
+      val zipped = records.zipWith(offsets)(Tuple2.apply)
+
+      assert {
+        TransactionalProducerMessage(zipped, 123)
+          .unsafeRunSync()
+          .toString == "TransactionalProducerMessage(ProducerRecord(topic = topic, key = key, value = value), CommittableOffsetBatch(topic-1 -> 1), the-group, 123)" &&
+        TransactionalProducerMessage(zipped, 123)
+          .unsafeRunSync()
+          .show == "TransactionalProducerMessage(ProducerRecord(topic = topic, key = key, value = value), CommittableOffsetBatch(topic-1 -> 1), the-group, 123)" &&
+        TransactionalProducerMessage(zipped)
+          .unsafeRunSync()
+          .toString == "TransactionalProducerMessage(ProducerRecord(topic = topic, key = key, value = value), CommittableOffsetBatch(topic-1 -> 1), the-group, ())" &&
+        TransactionalProducerMessage(zipped)
+          .unsafeRunSync()
+          .show == "TransactionalProducerMessage(ProducerRecord(topic = topic, key = key, value = value), CommittableOffsetBatch(topic-1 -> 1), the-group, ())" &&
+        TransactionalProducerMessage[NonEmptyList]
+          .of(zipped, 123)
+          .unsafeRunSync()
+          .toString == "TransactionalProducerMessage(ProducerRecord(topic = topic, key = key, value = value), CommittableOffsetBatch(topic-1 -> 1), the-group, 123)" &&
+        TransactionalProducerMessage[NonEmptyList]
+          .of(zipped, 123)
+          .unsafeRunSync()
+          .show == "TransactionalProducerMessage(ProducerRecord(topic = topic, key = key, value = value), CommittableOffsetBatch(topic-1 -> 1), the-group, 123)" &&
+        TransactionalProducerMessage[NonEmptyList]
+          .of(zipped)
+          .unsafeRunSync()
+          .toString == "TransactionalProducerMessage(ProducerRecord(topic = topic, key = key, value = value), CommittableOffsetBatch(topic-1 -> 1), the-group, ())" &&
+        TransactionalProducerMessage[NonEmptyList]
+          .of(zipped)
+          .unsafeRunSync()
+          .show == "TransactionalProducerMessage(ProducerRecord(topic = topic, key = key, value = value), CommittableOffsetBatch(topic-1 -> 1), the-group, ())"
+      }
+    }
+
+    it("should fail to create with multiple consumer group IDs") {
+      val records = NonEmptyList.of(1, 2).map(i => ProducerRecord("topic", "key", s"value-$i"))
+      val offsets = NonEmptyList
+        .of(1, 2)
+        .map(
+          i =>
+            CommittableOffset[IO](
+              new TopicPartition("topic", 1),
+              new OffsetAndMetadata(1),
+              Some(s"the-group-$i"),
+              _ => IO.unit
+            )
+        )
+      val zipped = records.zipWith(offsets)(Tuple2.apply)
+
+      TransactionalProducerMessage(zipped).attempt.unsafeRunSync().isLeft shouldBe true
+    }
+
+    it("should fail to create with no consumer group IDs") {
+      val record = ProducerRecord("topic", "key", "value")
+      val offset =
+        CommittableOffset[IO](
+          new TopicPartition("topic", 1),
+          new OffsetAndMetadata(1),
+          None,
+          _ => IO.unit
+        )
+
+      TransactionalProducerMessage.one(record -> offset).attempt.unsafeRunSync().isLeft shouldBe true
+    }
+  }
+}

--- a/src/test/scala/fs2/kafka/TransactionalProducerMessageSpec.scala
+++ b/src/test/scala/fs2/kafka/TransactionalProducerMessageSpec.scala
@@ -1,7 +1,7 @@
 package fs2.kafka
 
-import cats.data.NonEmptyList
 import cats.effect.IO
+import cats.instances.list._
 import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import org.apache.kafka.common.TopicPartition
 
@@ -29,7 +29,7 @@ class TransactionalProducerMessageSpec extends BaseSpec {
     }
 
     it("should be able to create with multiple records") {
-      val records = NonEmptyList.of(
+      val records = List(
         ProducerRecord("topic", "key", "value"),
         ProducerRecord("topic2", "key2", "value2")
       )
@@ -44,10 +44,17 @@ class TransactionalProducerMessageSpec extends BaseSpec {
       assert {
         TransactionalProducerMessage
           .one(CommittableProducerRecords(records, offset), 123)
-          .toString == "TransactionalProducerMessage(NonEmptyList(CommittableProducerRecords(NonEmptyList(ProducerRecord(topic = topic, key = key, value = value), ProducerRecord(topic = topic2, key = key2, value = value2)), CommittableOffset(topic-1 -> 1, the-group))), 123)" &&
+          .toString == "TransactionalProducerMessage(List(CommittableProducerRecords(List(ProducerRecord(topic = topic, key = key, value = value), ProducerRecord(topic = topic2, key = key2, value = value2)), CommittableOffset(topic-1 -> 1, the-group))), 123)" &&
         TransactionalProducerMessage
           .one(CommittableProducerRecords(records, offset))
-          .toString == "TransactionalProducerMessage(NonEmptyList(CommittableProducerRecords(NonEmptyList(ProducerRecord(topic = topic, key = key, value = value), ProducerRecord(topic = topic2, key = key2, value = value2)), CommittableOffset(topic-1 -> 1, the-group))), ())"
+          .toString == "TransactionalProducerMessage(List(CommittableProducerRecords(List(ProducerRecord(topic = topic, key = key, value = value), ProducerRecord(topic = topic2, key = key2, value = value2)), CommittableOffset(topic-1 -> 1, the-group))), ())"
+      }
+    }
+
+    it("should be able to create with zero records") {
+      assert {
+        TransactionalProducerMessage[IO, List, String, String, Int](Nil, 123).toString == "TransactionalProducerMessage(List(), 123)" &&
+        TransactionalProducerMessage[IO, List, String, String](Nil).toString == "TransactionalProducerMessage(List(), ())"
       }
     }
   }

--- a/src/test/scala/fs2/kafka/TransactionalProducerMessageSpec.scala
+++ b/src/test/scala/fs2/kafka/TransactionalProducerMessageSpec.scala
@@ -93,7 +93,7 @@ class TransactionalProducerMessageSpec extends BaseSpec {
               new OffsetAndMetadata(1),
               Some(s"the-group-$i"),
               _ => IO.unit
-            )
+          )
         )
       val zipped = records.zipWith(offsets)(Tuple2.apply)
 
@@ -110,7 +110,11 @@ class TransactionalProducerMessageSpec extends BaseSpec {
           _ => IO.unit
         )
 
-      TransactionalProducerMessage.one(record -> offset).attempt.unsafeRunSync().isLeft shouldBe true
+      TransactionalProducerMessage
+        .one(record -> offset)
+        .attempt
+        .unsafeRunSync()
+        .isLeft shouldBe true
     }
   }
 }

--- a/src/test/scala/fs2/kafka/TransactionalProducerMessageSpec.scala
+++ b/src/test/scala/fs2/kafka/TransactionalProducerMessageSpec.scala
@@ -21,10 +21,10 @@ class TransactionalProducerMessageSpec extends BaseSpec {
       assert {
         TransactionalProducerMessage
           .one(CommittableProducerRecords.one(record, offset), 123)
-          .toString == "TransactionalProducerMessage(CommittableProducerRecords(ProducerRecord(topic = topic, key = key, value = value), CommittableOffset(topic-1 -> 1, the-group)), 123)" &&
+          .toString == "TransactionalProducerMessage(Chain(CommittableProducerRecords(Chain(ProducerRecord(topic = topic, key = key, value = value)), CommittableOffset(topic-1 -> 1, the-group))), 123)" &&
         TransactionalProducerMessage
           .one(CommittableProducerRecords.one(record, offset))
-          .toString == "TransactionalProducerMessage(CommittableProducerRecords(ProducerRecord(topic = topic, key = key, value = value), CommittableOffset(topic-1 -> 1, the-group)), ())"
+          .toString == "TransactionalProducerMessage(Chain(CommittableProducerRecords(Chain(ProducerRecord(topic = topic, key = key, value = value)), CommittableOffset(topic-1 -> 1, the-group))), ())"
       }
     }
 
@@ -44,17 +44,17 @@ class TransactionalProducerMessageSpec extends BaseSpec {
       assert {
         TransactionalProducerMessage
           .one(CommittableProducerRecords(records, offset), 123)
-          .toString == "TransactionalProducerMessage(List(CommittableProducerRecords(List(ProducerRecord(topic = topic, key = key, value = value), ProducerRecord(topic = topic2, key = key2, value = value2)), CommittableOffset(topic-1 -> 1, the-group))), 123)" &&
+          .toString == "TransactionalProducerMessage(Chain(CommittableProducerRecords(List(ProducerRecord(topic = topic, key = key, value = value), ProducerRecord(topic = topic2, key = key2, value = value2)), CommittableOffset(topic-1 -> 1, the-group))), 123)" &&
         TransactionalProducerMessage
           .one(CommittableProducerRecords(records, offset))
-          .toString == "TransactionalProducerMessage(List(CommittableProducerRecords(List(ProducerRecord(topic = topic, key = key, value = value), ProducerRecord(topic = topic2, key = key2, value = value2)), CommittableOffset(topic-1 -> 1, the-group))), ())"
+          .toString == "TransactionalProducerMessage(Chain(CommittableProducerRecords(List(ProducerRecord(topic = topic, key = key, value = value), ProducerRecord(topic = topic2, key = key2, value = value2)), CommittableOffset(topic-1 -> 1, the-group))), ())"
       }
     }
 
     it("should be able to create with zero records") {
       assert {
-        TransactionalProducerMessage[IO, List, String, String, Int](Nil, 123).toString == "TransactionalProducerMessage(List(), 123)" &&
-        TransactionalProducerMessage[IO, List, String, String](Nil).toString == "TransactionalProducerMessage(List(), ())"
+        TransactionalProducerMessage[IO, List, List, String, String, Int](Nil, 123).toString == "TransactionalProducerMessage(List(), 123)" &&
+        TransactionalProducerMessage[IO, List, List, String, String](Nil).toString == "TransactionalProducerMessage(List(), ())"
       }
     }
   }


### PR DESCRIPTION
Fixes #128.

Here's an implementation which (mostly) avoids touching existing classes. There's a bunch of code copy-pasted from the existing `KafkaProducer` and `ProducerMessage` which might be nice to consolidate 😄