### PR TITLE
Remove ConsumerSettings#shiftDeserialization

### DIFF
--- a/src/test/scala/fs2/kafka/ConsumerSettingsSpec.scala
+++ b/src/test/scala/fs2/kafka/ConsumerSettingsSpec.scala
@@ -245,17 +245,9 @@ final class ConsumerSettingsSpec extends BaseSpec {
       }
     }
 
-    it("should provide withShiftDeserialization") {
-      assert {
-        settings
-          .withShiftDeserialization(false)
-          .shiftDeserialization == false
-      }
-    }
-
     it("should have a Show instance and matching toString") {
       assert {
-        settings.show == "ConsumerSettings(closeTimeout = 20 seconds, commitTimeout = 15 seconds, pollInterval = 50 milliseconds, pollTimeout = 50 milliseconds, commitRecovery = Default, shiftDeserialization = true)" &&
+        settings.show == "ConsumerSettings(closeTimeout = 20 seconds, commitTimeout = 15 seconds, pollInterval = 50 milliseconds, pollTimeout = 50 milliseconds, commitRecovery = Default)" &&
         settings.show == settings.toString
       }
     }


### PR DESCRIPTION
Removed `ProducerSettings#shiftSerialization` in #130, so this is to do the same for `ConsumerSettings`. 