### PR TITLE
Change to expose Java Kafka type aliases

### DIFF
--- a/src/main/scala/fs2/kafka/ConsumerRecord.scala
+++ b/src/main/scala/fs2/kafka/ConsumerRecord.scala
@@ -168,7 +168,7 @@ object ConsumerRecord {
     )
 
   private[this] def deserializeFromBytes[F[_], K, V](
-    record: KafkaConsumerRecord,
+    record: KafkaByteConsumerRecord,
     headers: Headers,
     keyDeserializer: Deserializer[F, K],
     valueDeserializer: Deserializer[F, V]
@@ -179,7 +179,7 @@ object ConsumerRecord {
   }
 
   private[kafka] def fromJava[F[_], K, V](
-    record: KafkaConsumerRecord,
+    record: KafkaByteConsumerRecord,
     keyDeserializer: Deserializer[F, K],
     valueDeserializer: Deserializer[F, V]
   )(implicit F: Apply[F]): F[ConsumerRecord[K, V]] = {

--- a/src/main/scala/fs2/kafka/ConsumerSettings.scala
+++ b/src/main/scala/fs2/kafka/ConsumerSettings.scala
@@ -18,7 +18,7 @@ package fs2.kafka
 
 import cats.effect.Sync
 import cats.Show
-import org.apache.kafka.clients.consumer.{Consumer, ConsumerConfig}
+import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.common.requests.OffsetFetchResponse
 import org.apache.kafka.common.serialization.ByteArrayDeserializer
 import scala.collection.JavaConverters._
@@ -326,7 +326,7 @@ sealed abstract class ConsumerSettings[F[_], K, V] {
     * operation should be bracketed, using e.g. `Resource`, to ensure
     * the `close` function on the consumer is called.
     */
-  def createConsumer: F[Consumer[Array[Byte], Array[Byte]]]
+  def createConsumer: F[KafkaByteConsumer]
 
   /**
     * Creates a new [[ConsumerSettings]] with the specified function for
@@ -334,7 +334,7 @@ sealed abstract class ConsumerSettings[F[_], K, V] {
     * is the [[properties]] of the settings instance.
     */
   def withCreateConsumer(
-    createConsumer: Map[String, String] => F[Consumer[Array[Byte], Array[Byte]]]
+    createConsumer: Map[String, String] => F[KafkaByteConsumer]
   ): ConsumerSettings[F, K, V]
 
   /**
@@ -391,7 +391,7 @@ object ConsumerSettings {
     override val commitRecovery: CommitRecovery,
     override val recordMetadata: ConsumerRecord[K, V] => String,
     override val maxPrefetchBatches: Int,
-    val createConsumerWith: Map[String, String] => F[Consumer[Array[Byte], Array[Byte]]]
+    val createConsumerWith: Map[String, String] => F[KafkaByteConsumer]
   ) extends ConsumerSettings[F, K, V] {
     override def withExecutionContext(
       executionContext: ExecutionContext
@@ -489,11 +489,11 @@ object ConsumerSettings {
     override def withCommitRecovery(commitRecovery: CommitRecovery): ConsumerSettings[F, K, V] =
       copy(commitRecovery = commitRecovery)
 
-    override def createConsumer: F[Consumer[Array[Byte], Array[Byte]]] =
+    override def createConsumer: F[KafkaByteConsumer] =
       createConsumerWith(properties)
 
     override def withCreateConsumer(
-      createConsumerWith: Map[String, String] => F[Consumer[Array[Byte], Array[Byte]]]
+      createConsumerWith: Map[String, String] => F[KafkaByteConsumer]
     ): ConsumerSettings[F, K, V] =
       copy(createConsumerWith = createConsumerWith)
 

--- a/src/main/scala/fs2/kafka/KafkaProducer.scala
+++ b/src/main/scala/fs2/kafka/KafkaProducer.scala
@@ -99,7 +99,7 @@ private[kafka] object KafkaProducer {
 
   private[kafka] def produceRecord[F[_], K, V](
     settings: ProducerSettings[F, K, V],
-    producer: ByteProducer
+    producer: KafkaByteProducer
   )(
     implicit F: ConcurrentEffect[F]
   ): ProducerRecord[K, V] => F[F[(ProducerRecord[K, V], RecordMetadata)]] =
@@ -143,10 +143,10 @@ private[kafka] object KafkaProducer {
   private[this] def asJavaRecord[F[_], K, V](
     settings: ProducerSettings[F, K, V],
     record: ProducerRecord[K, V]
-  )(implicit F: Apply[F]): F[KafkaProducerRecord] =
+  )(implicit F: Apply[F]): F[KafkaByteProducerRecord] =
     serializeToBytes(settings, record).map {
       case (keyBytes, valueBytes) =>
-        new KafkaProducerRecord(
+        new KafkaByteProducerRecord(
           record.topic,
           if (record.partition.isDefined)
             record.partition.get: java.lang.Integer

--- a/src/main/scala/fs2/kafka/ProducerSettings.scala
+++ b/src/main/scala/fs2/kafka/ProducerSettings.scala
@@ -18,7 +18,7 @@ package fs2.kafka
 
 import cats.effect.Sync
 import cats.Show
-import org.apache.kafka.clients.producer.{Producer, ProducerConfig}
+import org.apache.kafka.clients.producer.ProducerConfig
 import org.apache.kafka.common.serialization.ByteArraySerializer
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._
@@ -253,7 +253,7 @@ sealed abstract class ProducerSettings[F[_], K, V] {
     * operation should be bracketed, using e.g. `Resource`, to ensure
     * the `close` function on the producer is called.
     */
-  def createProducer: F[Producer[Array[Byte], Array[Byte]]]
+  def createProducer: F[KafkaByteProducer]
 
   /**
     * Creates a new [[ProducerSettings]] with the specified function for
@@ -261,7 +261,7 @@ sealed abstract class ProducerSettings[F[_], K, V] {
     * is the [[properties]] of the settings instance.
     */
   def withCreateProducer(
-    createProducer: Map[String, String] => F[Producer[Array[Byte], Array[Byte]]]
+    createProducer: Map[String, String] => F[KafkaByteProducer]
   ): ProducerSettings[F, K, V]
 }
 
@@ -272,7 +272,7 @@ object ProducerSettings {
     override val executionContext: Option[ExecutionContext],
     override val properties: Map[String, String],
     override val closeTimeout: FiniteDuration,
-    val createProducerWith: Map[String, String] => F[Producer[Array[Byte], Array[Byte]]]
+    val createProducerWith: Map[String, String] => F[KafkaByteProducer]
   ) extends ProducerSettings[F, K, V] {
     override def withExecutionContext(
       executionContext: ExecutionContext
@@ -338,11 +338,11 @@ object ProducerSettings {
     override def withCloseTimeout(closeTimeout: FiniteDuration): ProducerSettings[F, K, V] =
       copy(closeTimeout = closeTimeout)
 
-    override def createProducer: F[Producer[Array[Byte], Array[Byte]]] =
+    override def createProducer: F[KafkaByteProducer] =
       createProducerWith(properties)
 
     override def withCreateProducer(
-      createProducerWith: Map[String, String] => F[Producer[Array[Byte], Array[Byte]]]
+      createProducerWith: Map[String, String] => F[KafkaByteProducer]
     ): ProducerSettings[F, K, V] =
       copy(createProducerWith = createProducerWith)
 

--- a/src/main/scala/fs2/kafka/internal/KafkaConsumerActor.scala
+++ b/src/main/scala/fs2/kafka/internal/KafkaConsumerActor.scala
@@ -295,7 +295,7 @@ private[kafka] final class KafkaConsumerActor[F[_], K, V](
       )
     )
 
-  private[this] def records(batch: KafkaConsumerRecords): F[ConsumerRecords] =
+  private[this] def records(batch: KafkaByteConsumerRecords): F[ConsumerRecords] =
     batch.partitions.toVector
       .traverse { partition =>
         NonEmptyVector

--- a/src/main/scala/fs2/kafka/internal/WithConsumer.scala
+++ b/src/main/scala/fs2/kafka/internal/WithConsumer.scala
@@ -23,7 +23,7 @@ import fs2.kafka.internal.syntax._
 import scala.concurrent.ExecutionContext
 
 private[kafka] sealed abstract class WithConsumer[F[_]] {
-  def apply[A](f: ByteConsumer => F[A]): F[A]
+  def apply[A](f: KafkaByteConsumer => F[A]): F[A]
 }
 
 private[kafka] object WithConsumer {
@@ -44,7 +44,7 @@ private[kafka] object WithConsumer {
           .flatMap(Synchronized[F].of)
           .map { synchronizedConsumer =>
             new WithConsumer[F] {
-              override def apply[A](f: ByteConsumer => F[A]): F[A] =
+              override def apply[A](f: KafkaByteConsumer => F[A]): F[A] =
                 synchronizedConsumer.use { consumer =>
                   context.evalOn(executionContext) {
                     f(consumer)

--- a/src/main/scala/fs2/kafka/internal/WithProducer.scala
+++ b/src/main/scala/fs2/kafka/internal/WithProducer.scala
@@ -23,7 +23,7 @@ import fs2.kafka.internal.syntax._
 import scala.concurrent.ExecutionContext
 
 private[kafka] sealed abstract class WithProducer[F[_]] {
-  def apply[A](f: ByteProducer => F[A]): F[A]
+  def apply[A](f: KafkaByteProducer => F[A]): F[A]
 }
 
 private[kafka] object WithProducer {
@@ -43,7 +43,7 @@ private[kafka] object WithProducer {
         settings.createProducer
           .map { producer =>
             new WithProducer[F] {
-              override def apply[A](f: ByteProducer => F[A]): F[A] =
+              override def apply[A](f: KafkaByteProducer => F[A]): F[A] =
                 context.evalOn(executionContext) {
                   f(producer)
                 }

--- a/src/main/scala/fs2/kafka/package.scala
+++ b/src/main/scala/fs2/kafka/package.scala
@@ -28,31 +28,40 @@ import scala.concurrent.duration.FiniteDuration
 package object kafka {
   type Id[+A] = A
 
-  private[kafka] type ByteConsumer =
+  /** Alias for Java Kafka `Consumer[Array[Byte], Array[Byte]]`. */
+  type KafkaByteConsumer =
     org.apache.kafka.clients.consumer.Consumer[Array[Byte], Array[Byte]]
 
-  private[kafka] type ByteProducer =
+  /** Alias for Java Kafka `Producer[Array[Byte], Array[Byte]]`. */
+  type KafkaByteProducer =
     org.apache.kafka.clients.producer.Producer[Array[Byte], Array[Byte]]
 
-  private[kafka] type KafkaDeserializer[A] =
+  /** Alias for Java Kafka `Deserializer[A]`. */
+  type KafkaDeserializer[A] =
     org.apache.kafka.common.serialization.Deserializer[A]
 
-  private[kafka] type KafkaSerializer[A] =
+  /** Alias for Java Kafka `Serializer[A]`. */
+  type KafkaSerializer[A] =
     org.apache.kafka.common.serialization.Serializer[A]
 
-  private[kafka] type KafkaHeader =
+  /** Alias for Java Kafka `Header`. */
+  type KafkaHeader =
     org.apache.kafka.common.header.Header
 
-  private[kafka] type KafkaHeaders =
+  /** Alias for Java Kafka `Headers`. */
+  type KafkaHeaders =
     org.apache.kafka.common.header.Headers
 
-  private[kafka] type KafkaConsumerRecords =
+  /** Alias for Java Kafka `ConsumerRecords[Array[Byte], Array[Byte]]`. */
+  type KafkaByteConsumerRecords =
     org.apache.kafka.clients.consumer.ConsumerRecords[Array[Byte], Array[Byte]]
 
-  private[kafka] type KafkaConsumerRecord =
+  /** Alias for Java Kafka `ConsumerRecord[Array[Byte], Array[Byte]]`. */
+  type KafkaByteConsumerRecord =
     org.apache.kafka.clients.consumer.ConsumerRecord[Array[Byte], Array[Byte]]
 
-  private[kafka] type KafkaProducerRecord =
+  /** Alias for Java Kafka `ProducerRecord[Array[Byte], Array[Byte]]`. */
+  type KafkaByteProducerRecord =
     org.apache.kafka.clients.producer.ProducerRecord[Array[Byte], Array[Byte]]
 
   /**

--- a/src/test/scala/fs2/kafka/ConsumerRecordSpec.scala
+++ b/src/test/scala/fs2/kafka/ConsumerRecordSpec.scala
@@ -13,7 +13,7 @@ final class ConsumerRecordSpec extends BaseSpec {
         f: ConsumerRecord[String, String] => Assertion
       ): Assertion = {
         val record =
-          new KafkaConsumerRecord(
+          new KafkaByteConsumerRecord(
             "topic",
             0,
             1,
@@ -43,7 +43,7 @@ final class ConsumerRecordSpec extends BaseSpec {
         f: ConsumerRecord[String, String] => Assertion
       ): Assertion = {
         val record =
-          new KafkaConsumerRecord(
+          new KafkaByteConsumerRecord(
             "topic",
             0,
             1,
@@ -68,7 +68,7 @@ final class ConsumerRecordSpec extends BaseSpec {
         f: ConsumerRecord[String, String] => Assertion
       ): Assertion = {
         val record =
-          new KafkaConsumerRecord(
+          new KafkaByteConsumerRecord(
             "topic",
             0,
             1,
@@ -93,7 +93,7 @@ final class ConsumerRecordSpec extends BaseSpec {
         f: ConsumerRecord[String, String] => Assertion
       ): Assertion = {
         val record =
-          new KafkaConsumerRecord(
+          new KafkaByteConsumerRecord(
             "topic",
             0,
             1,


### PR DESCRIPTION
Exposes some existing type aliases for Java Kafka types. Some of these were already part of the public API, although the aliases themselves were private.