### PR TITLE
Change to require Sync for deserializers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,8 @@ import ReleaseTransformations._
 
 val fs2Version = "1.0.4"
 
+val catsEffectVersion = "1.3.0"
+
 val kafkaVersion = "2.2.0"
 
 lazy val `fs2-kafka` = project
@@ -32,13 +34,13 @@ lazy val docs = project
 lazy val dependencySettings = Seq(
   libraryDependencies ++= Seq(
     "co.fs2" %% "fs2-core" % fs2Version,
-    "org.typelevel" %% "cats-effect" % "1.3.0",
+    "org.typelevel" %% "cats-effect" % catsEffectVersion,
     "org.apache.kafka" % "kafka-clients" % kafkaVersion
   ),
   libraryDependencies ++= Seq(
     "org.scalatest" %% "scalatest" % "3.0.7",
     "org.typelevel" %% "cats-testkit" % "1.6.0",
-    "org.scalacheck" %% "scalacheck" % "1.14.0",
+    "org.typelevel" %% "cats-effect-laws" % catsEffectVersion,
     "ch.qos.logback" % "logback-classic" % "1.2.3",
     "io.github.embeddedkafka" %% "embedded-kafka" % kafkaVersion,
     "org.apache.kafka" %% "kafka" % kafkaVersion

--- a/src/test/scala/fs2/kafka/BaseCatsSpec.scala
+++ b/src/test/scala/fs2/kafka/BaseCatsSpec.scala
@@ -1,12 +1,13 @@
 package fs2.kafka
 
 import cats._
+import cats.effect.IO
 import cats.tests._
 import org.scalacheck._
 import scala.util.Try
 
 trait BaseCatsSpec extends CatsSuite with BaseGenerators {
-  implicit def deserializerEq[A](implicit A: Eq[A]): Eq[Deserializer[Id, A]] =
+  implicit def deserializerEq[A](implicit A: Eq[IO[A]]): Eq[Deserializer[IO, A]] =
     Eq.instance { (d1, d2) =>
       Try {
         forAll { (topic: String, headers: Headers, bytes: Array[Byte]) =>
@@ -16,6 +17,9 @@ trait BaseCatsSpec extends CatsSuite with BaseGenerators {
         }
       }.isSuccess
     }
+
+  implicit val deserializerUnitArbitrary: Arbitrary[Deserializer[IO, Unit]] =
+    Arbitrary(Gen.const(Deserializer.unit[IO]))
 
   implicit def serializerEq[A](implicit A: Arbitrary[A]): Eq[Serializer[Id, A]] =
     Eq.instance { (s1, s2) =>

--- a/src/test/scala/fs2/kafka/ConsumerRecordSpec.scala
+++ b/src/test/scala/fs2/kafka/ConsumerRecordSpec.scala
@@ -1,5 +1,6 @@
 package fs2.kafka
 
+import cats.effect.IO
 import cats.implicits._
 import org.apache.kafka.clients.consumer.ConsumerRecord.{NULL_SIZE, NO_TIMESTAMP}
 import org.apache.kafka.common.record.TimestampType
@@ -26,7 +27,11 @@ final class ConsumerRecordSpec extends BaseSpec {
             "value".getBytes
           )
 
-        f(ConsumerRecord.fromJava(record, Deserializer[Id, String], Deserializer[Id, String]))
+        f(
+          ConsumerRecord
+            .fromJava(record, Deserializer[IO, String], Deserializer[IO, String])
+            .unsafeRunSync
+        )
       }
 
       check(NO_TIMESTAMP, NO_TIMESTAMP_TYPE)(_.timestamp.isEmpty shouldBe true)
@@ -56,7 +61,11 @@ final class ConsumerRecordSpec extends BaseSpec {
             "value".getBytes
           )
 
-        f(ConsumerRecord.fromJava(record, Deserializer[Id, String], Deserializer[Id, String]))
+        f(
+          ConsumerRecord
+            .fromJava(record, Deserializer[IO, String], Deserializer[IO, String])
+            .unsafeRunSync
+        )
       }
 
       check(NULL_SIZE)(_.serializedKeySize shouldBe None)
@@ -81,7 +90,11 @@ final class ConsumerRecordSpec extends BaseSpec {
             "value".getBytes
           )
 
-        f(ConsumerRecord.fromJava(record, Deserializer[Id, String], Deserializer[Id, String]))
+        f(
+          ConsumerRecord
+            .fromJava(record, Deserializer[IO, String], Deserializer[IO, String])
+            .unsafeRunSync
+        )
       }
 
       check(NULL_SIZE)(_.serializedValueSize shouldBe None)
@@ -110,7 +123,11 @@ final class ConsumerRecordSpec extends BaseSpec {
             else java.util.Optional.empty()
           )
 
-        f(ConsumerRecord.fromJava(record, Deserializer[Id, String], Deserializer[Id, String]))
+        f(
+          ConsumerRecord
+            .fromJava(record, Deserializer[IO, String], Deserializer[IO, String])
+            .unsafeRunSync
+        )
       }
 
       check(None)(_.leaderEpoch shouldBe None)

--- a/src/test/scala/fs2/kafka/SerializerSpec.scala
+++ b/src/test/scala/fs2/kafka/SerializerSpec.scala
@@ -190,75 +190,75 @@ final class SerializerSpec extends BaseCatsSpec {
   }
 
   def roundtrip[A: Arbitrary: Eq](
-    serializer: Serializer[Id, A],
-    deserializer: Deserializer[Id, A]
+    serializer: Serializer[IO, A],
+    deserializer: Deserializer[IO, A]
   ): Assertion = forAll { (topic: String, headers: Headers, a: A) =>
-    val serialized = serializer.serialize(topic, headers, a)
-    val deserialized = deserializer.deserialize(topic, headers, serialized)
+    val serialized = serializer.serialize(topic, headers, a).unsafeRunSync
+    val deserialized = deserializer.deserialize(topic, headers, serialized).unsafeRunSync
     assert(deserialized === a)
   }
 
   def roundtripAttempt[A: Arbitrary: Eq](
-    serializer: Serializer[Id, A],
+    serializer: Serializer[IO, A],
     deserializer: Deserializer[IO, A]
   ): Assertion = forAll { (topic: String, headers: Headers, a: A) =>
-    val serialized = serializer.serialize(topic, headers, a)
+    val serialized = serializer.serialize(topic, headers, a).unsafeRunSync
     val deserialized = deserializer.deserialize(topic, headers, serialized)
     assert(deserialized.attempt.unsafeRunSync.toOption === Option(a))
   }
 
   test("Serializer#string") {
     roundtrip(
-      Serializer.string[Id](StandardCharsets.UTF_8),
+      Serializer.string[IO](StandardCharsets.UTF_8),
       Deserializer.string(StandardCharsets.UTF_8)
     )
   }
 
   test("Serializer#uuid") {
     roundtripAttempt(
-      Serializer.uuid[Id](StandardCharsets.UTF_8),
+      Serializer.uuid[IO](StandardCharsets.UTF_8),
       Deserializer.uuid(StandardCharsets.UTF_8)
     )
   }
 
   test("Serializer#uuid.default") {
     roundtripAttempt(
-      Serializer[Id, UUID],
+      Serializer[IO, UUID],
       Deserializer.uuid
     )
   }
 
   test("Serializer#double") {
     roundtripAttempt(
-      Serializer.double[Id],
+      Serializer.double[IO],
       Deserializer.double
     )
   }
 
   test("Serializer#float") {
     roundtripAttempt(
-      Serializer.float[Id],
+      Serializer.float[IO],
       Deserializer.float
     )
   }
 
   test("Serializer#int") {
     roundtripAttempt(
-      Serializer.int[Id],
+      Serializer.int[IO],
       Deserializer.int
     )
   }
 
   test("Serializer#long") {
     roundtripAttempt(
-      Serializer.long[Id],
+      Serializer.long[IO],
       Deserializer.long
     )
   }
 
   test("Serializer#short") {
     roundtripAttempt(
-      Serializer.short[Id],
+      Serializer.short[IO],
       Deserializer.short
     )
   }


### PR DESCRIPTION
`Deserializer`s become less surprising when used with `ConsumerSettings` if they require `F[_]` to be an effect type (since `ConsumerSettings` has the same requirement).