### PR TITLE
Change to require Sync for serializers

### DIFF
--- a/src/main/scala/fs2/kafka/Serializer.scala
+++ b/src/main/scala/fs2/kafka/Serializer.scala
@@ -16,24 +16,23 @@
 
 package fs2.kafka
 
-import cats._
-import cats.effect._
+import cats.Contravariant
+import cats.effect.Sync
 import cats.implicits._
 import java.nio.charset.{Charset, StandardCharsets}
 import java.util.UUID
 import org.apache.kafka.common.utils.Bytes
 
 /**
-  * Kafka serializer with support for serialization effects by
-  * returning serialized bytes in an abstract context `F[_]`,
-  * which can include effects.
+  * Functional composable Kafka key- and record serializer with
+  * support for effect types.
   */
 sealed abstract class Serializer[F[_], A] {
 
   /**
-    * Serializes the specified value of type `A` into bytes. The
-    * Kafka topic name, to which the serialized bytes are going
-    * to be sent, and record headers are available.
+    * Attempts to serialize the specified value of type `A` into
+    * bytes. The Kafka topic name, to which the serialized bytes
+    * are going to be sent, and record headers are available.
     */
   def serialize(topic: String, headers: Headers, a: A): F[Array[Byte]]
 
@@ -42,46 +41,25 @@ sealed abstract class Serializer[F[_], A] {
     * function `f` on a value of type `B`, and then serializes
     * the result with this [[Serializer]].
     */
-  final def contramap[B](f: B => A): Serializer[F, B] =
-    Serializer.instance { (topic, headers, b) =>
-      serialize(topic, headers, f(b))
-    }
+  def contramap[B](f: B => A): Serializer[F, B]
 
   /**
     * Creates a new [[Serializer]] which applies the specified
     * function `f` on the output bytes of this [[Serializer]].
     */
-  final def mapBytes(f: Array[Byte] => Array[Byte])(implicit F: Functor[F]): Serializer[F, A] =
-    Serializer.instance { (topic, headers, a) =>
-      serialize(topic, headers, a).map(f)
-    }
+  def mapBytes(f: Array[Byte] => Array[Byte]): Serializer[F, A]
 
   /**
     * Creates a new [[Serializer]] which serializes `Some` values
     * using this [[Serializer]], and serializes `None` as `null`.
     */
-  final def option(implicit F: Applicative[F]): Serializer[F, Option[A]] =
-    Serializer.instance {
-      case (topic, headers, Some(a)) => serialize(topic, headers, a)
-      case (_, _, None)              => F.pure(null)
-    }
-
-  /**
-    * Creates a new [[Serializer]] which defers serialization.
-    */
-  final def defer(implicit F: Defer[F]): Serializer[F, A] =
-    Serializer.instance { (topic, headers, a) =>
-      F.defer(serialize(topic, headers, a))
-    }
+  def option: Serializer[F, Option[A]]
 
   /**
     * Creates a new [[Serializer]] which suspends serialization,
     * capturing any impure behaviours of this [[Serializer]].
     */
-  final def suspend(implicit F: Sync[F]): Serializer[F, A] =
-    Serializer.instance { (topic, headers, a) =>
-      F.suspend(serialize(topic, headers, a))
-    }
+  def suspend: Serializer[F, A]
 }
 
 object Serializer {
@@ -91,14 +69,14 @@ object Serializer {
     * Creates a new [[Serializer]] which serializes
     * all values of type `A` as `null`.
     */
-  def asNull[F[_], A](implicit F: Applicative[F]): Serializer[F, A] =
+  def asNull[F[_], A](implicit F: Sync[F]): Serializer[F, A] =
     Serializer.const(null)
 
   /**
     * Creates a new [[Serializer]] which serializes
     * all values of type `A` to the specified `bytes`.
     */
-  def const[F[_], A](bytes: Array[Byte])(implicit F: Applicative[F]): Serializer[F, A] =
+  def const[F[_], A](bytes: Array[Byte])(implicit F: Sync[F]): Serializer[F, A] =
     Serializer.lift(_ => F.pure(bytes))
 
   /**
@@ -111,7 +89,7 @@ object Serializer {
     * so the impure behaviours can be captured properly.
     */
   def delegate[F[_], A](serializer: KafkaSerializer[A])(
-    implicit F: Applicative[F]
+    implicit F: Sync[F]
   ): Serializer[F, A] =
     Serializer.instance[F, A] { (topic, headers, a) =>
       F.pure(serializer.serialize(topic, headers.asJava, a))
@@ -122,7 +100,7 @@ object Serializer {
     * serialization with the specified exception `e`.
     */
   def fail[F[_], A](e: Throwable)(
-    implicit F: ApplicativeError[F, Throwable]
+    implicit F: Sync[F]
   ): Serializer[F, A] =
     Serializer.lift(_ => F.raiseError(e))
 
@@ -130,14 +108,14 @@ object Serializer {
     * Creates a new [[Serializer]] which serializes all
     * values of type `A` as the empty `Array[Byte]`.
     */
-  def empty[F[_], A](implicit F: Applicative[F]): Serializer[F, A] =
+  def empty[F[_], A](implicit F: Sync[F]): Serializer[F, A] =
     Serializer.const(Array.emptyByteArray)
 
   /**
     * Creates a new [[Serializer]] which can use different
     * [[Serializer]]s depending on the record headers.
     */
-  def headers[F[_], A](f: Headers => Serializer[F, A]): Serializer[F, A] =
+  def headers[F[_], A](f: Headers => Serializer[F, A])(implicit F: Sync[F]): Serializer[F, A] =
     Serializer.instance { (topic, headers, a) =>
       f(headers).serialize(topic, headers, a)
     }
@@ -147,10 +125,33 @@ object Serializer {
     * Use [[lift]] instead if the serializer doesn't need
     * access to the Kafka topic name or record headers.
     */
-  def instance[F[_], A](f: (String, Headers, A) => F[Array[Byte]]): Serializer[F, A] =
+  def instance[F[_], A](
+    f: (String, Headers, A) => F[Array[Byte]]
+  )(implicit F: Sync[F]): Serializer[F, A] =
     new Serializer[F, A] {
       override def serialize(topic: String, headers: Headers, a: A): F[Array[Byte]] =
         f(topic, headers, a)
+
+      override def contramap[B](f: B => A): Serializer[F, B] =
+        Serializer.instance { (topic, headers, b) =>
+          serialize(topic, headers, f(b))
+        }
+
+      override def mapBytes(f: Array[Byte] => Array[Byte]): Serializer[F, A] =
+        Serializer.instance { (topic, headers, a) =>
+          serialize(topic, headers, a).map(f)
+        }
+
+      override def option: Serializer[F, Option[A]] =
+        Serializer.instance {
+          case (topic, headers, Some(a)) => serialize(topic, headers, a)
+          case (_, _, None)              => F.pure(null)
+        }
+
+      override def suspend: Serializer[F, A] =
+        Serializer.instance { (topic, headers, a) =>
+          F.suspend(serialize(topic, headers, a))
+        }
 
       override def toString: String =
         "Serializer$" + System.identityHashCode(this)
@@ -163,7 +164,7 @@ object Serializer {
     * if the serializer needs access to the Kafka topic
     * name or the record headers.
     */
-  def lift[F[_], A](f: A => F[Array[Byte]]): Serializer[F, A] =
+  def lift[F[_], A](f: A => F[Array[Byte]])(implicit F: Sync[F]): Serializer[F, A] =
     Serializer.instance((_, _, a) => f(a))
 
   /**
@@ -171,7 +172,7 @@ object Serializer {
     * [[Serializer]]s depending on the Kafka topic name to
     * which the bytes are going to be sent.
     */
-  def topic[F[_], A](f: String => Serializer[F, A]): Serializer[F, A] =
+  def topic[F[_], A](f: String => Serializer[F, A])(implicit F: Sync[F]): Serializer[F, A] =
     Serializer.instance { (topic, headers, a) =>
       f(topic).serialize(topic, headers, a)
     }
@@ -181,7 +182,7 @@ object Serializer {
     * values using the specified `Charset`. Note that the
     * default `String` serializer uses `UTF-8`.
     */
-  def string[F[_]](charset: Charset)(implicit F: Applicative[F]): Serializer[F, String] =
+  def string[F[_]](charset: Charset)(implicit F: Sync[F]): Serializer[F, String] =
     Serializer.lift(s => F.pure(s.getBytes(charset)))
 
   /**
@@ -189,14 +190,14 @@ object Serializer {
     * as `String`s with the specified `Charset`. Note that the
     * default `UUID` serializer uses `UTF-8.`
     */
-  def uuid[F[_]](charset: Charset)(implicit F: Applicative[F]): Serializer[F, UUID] =
+  def uuid[F[_]](charset: Charset)(implicit F: Sync[F]): Serializer[F, UUID] =
     Serializer.string[F](charset).contramap(_.toString)
 
   /**
     * The identity [[Serializer]], which does not perform any kind
     * of serialization, simply using the input bytes as the output.
     */
-  implicit def identity[F[_]](implicit F: Applicative[F]): Serializer[F, Array[Byte]] =
+  implicit def identity[F[_]](implicit F: Sync[F]): Serializer[F, Array[Byte]] =
     Serializer.lift(bytes => F.pure(bytes))
 
   /**
@@ -204,8 +205,7 @@ object Serializer {
     * serializes `Some` values using the serializer for type `A`.
     */
   implicit def option[F[_], A](
-    implicit F: Applicative[F],
-    serializer: Serializer[F, A]
+    implicit serializer: Serializer[F, A]
   ): Serializer[F, Option[A]] =
     serializer.option
 
@@ -215,45 +215,45 @@ object Serializer {
         serializer.contramap(f)
     }
 
-  implicit def bytes[F[_]](implicit F: Applicative[F]): Serializer[F, Bytes] =
+  implicit def bytes[F[_]](implicit F: Sync[F]): Serializer[F, Bytes] =
     Serializer.identity[F].contramap(_.get)
 
-  implicit def double[F[_]](implicit F: Applicative[F]): Serializer[F, Double] =
+  implicit def double[F[_]](implicit F: Sync[F]): Serializer[F, Double] =
     Serializer.delegate {
       (new org.apache.kafka.common.serialization.DoubleSerializer)
         .asInstanceOf[org.apache.kafka.common.serialization.Serializer[Double]]
     }
 
-  implicit def float[F[_]](implicit F: Applicative[F]): Serializer[F, Float] =
+  implicit def float[F[_]](implicit F: Sync[F]): Serializer[F, Float] =
     Serializer.delegate {
       (new org.apache.kafka.common.serialization.FloatSerializer)
         .asInstanceOf[org.apache.kafka.common.serialization.Serializer[Float]]
     }
 
-  implicit def int[F[_]](implicit F: Applicative[F]): Serializer[F, Int] =
+  implicit def int[F[_]](implicit F: Sync[F]): Serializer[F, Int] =
     Serializer.delegate {
       (new org.apache.kafka.common.serialization.IntegerSerializer)
         .asInstanceOf[org.apache.kafka.common.serialization.Serializer[Int]]
     }
 
-  implicit def long[F[_]](implicit F: Applicative[F]): Serializer[F, Long] =
+  implicit def long[F[_]](implicit F: Sync[F]): Serializer[F, Long] =
     Serializer.delegate {
       (new org.apache.kafka.common.serialization.LongSerializer)
         .asInstanceOf[org.apache.kafka.common.serialization.Serializer[Long]]
     }
 
-  implicit def short[F[_]](implicit F: Applicative[F]): Serializer[F, Short] =
+  implicit def short[F[_]](implicit F: Sync[F]): Serializer[F, Short] =
     Serializer.delegate {
       (new org.apache.kafka.common.serialization.ShortSerializer)
         .asInstanceOf[org.apache.kafka.common.serialization.Serializer[Short]]
     }
 
-  implicit def string[F[_]](implicit F: Applicative[F]): Serializer[F, String] =
+  implicit def string[F[_]](implicit F: Sync[F]): Serializer[F, String] =
     Serializer.string(StandardCharsets.UTF_8)
 
-  implicit def unit[F[_]](implicit F: Applicative[F]): Serializer[F, Unit] =
+  implicit def unit[F[_]](implicit F: Sync[F]): Serializer[F, Unit] =
     Serializer.const(null)
 
-  implicit def uuid[F[_]](implicit F: Applicative[F]): Serializer[F, UUID] =
+  implicit def uuid[F[_]](implicit F: Sync[F]): Serializer[F, UUID] =
     Serializer.string[F].contramap(_.toString)
 }

--- a/src/test/scala/fs2/kafka/BaseGenerators.scala
+++ b/src/test/scala/fs2/kafka/BaseGenerators.scala
@@ -104,11 +104,11 @@ trait BaseGenerators {
       }
     }
 
-  def genSerializerString[F[_]](implicit F: Applicative[F]): Gen[Serializer[F, String]] =
+  def genSerializerString[F[_]](implicit F: Sync[F]): Gen[Serializer[F, String]] =
     genCharset.map(Serializer.string[F])
 
   implicit def arbSerializerString[F[_]](
-    implicit F: Applicative[F]
+    implicit F: Sync[F]
   ): Arbitrary[Serializer[F, String]] =
     Arbitrary(genSerializerString)
 


### PR DESCRIPTION
Similarly to #135, this pull request changes to require `Sync` for `Serializer`s.