### PR TITLE
Change KafkaAdminClient to use blocking ExecutionContext

### DIFF
--- a/src/main/scala/fs2/kafka/internal/WithAdminClient.scala
+++ b/src/main/scala/fs2/kafka/internal/WithAdminClient.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2018-2019 OVO Energy Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fs2.kafka.internal
+
+import cats.effect._
+import cats.implicits._
+import fs2.kafka._
+import fs2.kafka.internal.syntax._
+import org.apache.kafka.clients.admin.AdminClient
+import org.apache.kafka.common.KafkaFuture
+import scala.concurrent.ExecutionContext
+
+private[kafka] sealed abstract class WithAdminClient[F[_]] {
+  def apply[A](f: AdminClient => KafkaFuture[A]): F[A]
+
+  def close: F[Unit]
+}
+
+private[kafka] object WithAdminClient {
+  def apply[F[_]](
+    settings: AdminClientSettings[F]
+  )(
+    implicit F: Concurrent[F],
+    context: ContextShift[F]
+  ): Resource[F, WithAdminClient[F]] = {
+    val executionContextResource =
+      settings.executionContext
+        .map(Resource.pure[F, ExecutionContext])
+        .getOrElse(adminClientExecutionContextResource)
+
+    executionContextResource.flatMap { executionContext =>
+      Resource.make[F, WithAdminClient[F]] {
+        settings.createAdminClient
+          .map { adminClient =>
+            new WithAdminClient[F] {
+              override def apply[A](f: AdminClient => KafkaFuture[A]): F[A] =
+                context.evalOn(executionContext) {
+                  F.suspend(f(adminClient).cancelable)
+                }
+
+              override def close: F[Unit] =
+                context.evalOn(executionContext) {
+                  F.delay(adminClient.close(settings.closeTimeout.asJava))
+                }
+            }
+          }
+      }(_.close)
+    }
+  }
+}

--- a/src/test/scala/fs2/kafka/AdminClientSettingsSpec.scala
+++ b/src/test/scala/fs2/kafka/AdminClientSettingsSpec.scala
@@ -4,6 +4,7 @@ import cats.effect.IO
 import cats.implicits._
 import org.apache.kafka.clients.admin.AdminClientConfig
 import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext
 
 final class AdminClientSettingsSpec extends BaseSpec {
   describe("AdminClientSettings") {
@@ -126,6 +127,21 @@ final class AdminClientSettingsSpec extends BaseSpec {
           .attempt
           .unsafeRunSync()
           .isLeft
+      }
+    }
+
+    it("should provide withExecutionContext") {
+      assert {
+        settings
+          .withExecutionContext(ExecutionContext.global)
+          .executionContext
+          .isDefined
+      }
+    }
+
+    it("should not provide an executionContext unless set") {
+      assert {
+        settings.executionContext.isEmpty
       }
     }
 


### PR DESCRIPTION
The Java `KafkaAdminClient` relies on synchronization and can therefore block, so we should therefore shift to a blocking `ExecutionContext`. This also lets us run the blocking `close` function on a dedicated context.