### PR TITLE
Change to support creation effect for serializers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -92,6 +92,7 @@ lazy val publishSettings =
         organizationName.value
       )
     ),
+    excludeFilter.in(headerSources) := HiddenFileFilter || "*OrElse.scala",
     developers := List(
       Developer(
         id = "vlovgr",

--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,7 @@ lazy val `fs2-kafka` = project
     moduleName := "fs2-kafka",
     name := moduleName.value,
     dependencySettings,
+    coverageSettings,
     publishSettings,
     mimaSettings,
     scalaSettings,
@@ -75,6 +76,12 @@ lazy val metadataSettings = Seq(
   organization := "com.ovoenergy",
   organizationName := "OVO Energy Limited",
   organizationHomepage := Some(url("https://ovoenergy.com"))
+)
+
+lazy val coverageSettings = Seq(
+  coverageExcludedPackages := List(
+    "fs2.kafka.internal.OrElse"
+  ).mkString(";")
 )
 
 lazy val publishSettings =

--- a/src/main/scala/fs2/kafka/ConsumerSettings.scala
+++ b/src/main/scala/fs2/kafka/ConsumerSettings.scala
@@ -18,6 +18,7 @@ package fs2.kafka
 
 import cats.effect.Sync
 import cats.Show
+import fs2.kafka.internal._
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.common.requests.OffsetFetchResponse
 import org.apache.kafka.common.serialization.ByteArrayDeserializer
@@ -51,12 +52,12 @@ sealed abstract class ConsumerSettings[F[_], K, V] {
   /**
     * The `Deserializer` to use for deserializing record keys.
     */
-  def keyDeserializer: Deserializer[F, K]
+  def keyDeserializer: F[Deserializer[F, K]]
 
   /**
     * The `Deserializer` to use for deserializing record values.
     */
-  def valueDeserializer: Deserializer[F, V]
+  def valueDeserializer: F[Deserializer[F, V]]
 
   /**
     * The `ExecutionContext` on which to run blocking Kafka operations.
@@ -380,8 +381,8 @@ sealed abstract class ConsumerSettings[F[_], K, V] {
 
 object ConsumerSettings {
   private[this] final case class ConsumerSettingsImpl[F[_], K, V](
-    override val keyDeserializer: Deserializer[F, K],
-    override val valueDeserializer: Deserializer[F, V],
+    override val keyDeserializer: F[Deserializer[F, K]],
+    override val valueDeserializer: F[Deserializer[F, V]],
     override val executionContext: Option[ExecutionContext],
     override val properties: Map[String, String],
     override val closeTimeout: FiniteDuration,
@@ -510,8 +511,8 @@ object ConsumerSettings {
   }
 
   private[this] def create[F[_], K, V](
-    keyDeserializer: Deserializer[F, K],
-    valueDeserializer: Deserializer[F, V]
+    keyDeserializer: F[Deserializer[F, K]],
+    valueDeserializer: F[Deserializer[F, V]]
   )(implicit F: Sync[F]): ConsumerSettings[F, K, V] =
     ConsumerSettingsImpl(
       keyDeserializer = keyDeserializer,
@@ -547,6 +548,42 @@ object ConsumerSettings {
     keyDeserializer: Deserializer[F, K],
     valueDeserializer: Deserializer[F, V]
   )(implicit F: Sync[F]): ConsumerSettings[F, K, V] =
+    create(F.pure(keyDeserializer), F.pure(valueDeserializer))
+
+  /**
+    * Creates a new [[ConsumerSettings]] instance using the
+    * specified [[Deserializer]]s for the key and value, in
+    * the case where the key deserializer is wrapped in a
+    * creation effect.
+    */
+  def apply[F[_], K, V](
+    keyDeserializer: F[Deserializer[F, K]],
+    valueDeserializer: Deserializer[F, V]
+  )(implicit F: Sync[F]): ConsumerSettings[F, K, V] =
+    create(keyDeserializer, F.pure(valueDeserializer))
+
+  /**
+    * Creates a new [[ConsumerSettings]] instance using the
+    * specified [[Deserializer]]s for the key and value, in
+    * the case where the value deserializer is wrapped in a
+    * creation effect.
+    */
+  def apply[F[_], K, V](
+    keyDeserializer: Deserializer[F, K],
+    valueDeserializer: F[Deserializer[F, V]]
+  )(implicit F: Sync[F]): ConsumerSettings[F, K, V] =
+    create(F.pure(keyDeserializer), valueDeserializer)
+
+  /**
+    * Creates a new [[ConsumerSettings]] instance using the
+    * specified [[Deserializer]]s for the key and value, in
+    * the case where both the key and  value deserializers
+    * are wrapped in a creation effect.
+    */
+  def apply[F[_], K, V](
+    keyDeserializer: F[Deserializer[F, K]],
+    valueDeserializer: F[Deserializer[F, V]]
+  )(implicit F: Sync[F]): ConsumerSettings[F, K, V] =
     create(keyDeserializer, valueDeserializer)
 
   /**
@@ -555,10 +592,10 @@ object ConsumerSettings {
     */
   def apply[F[_], K, V](
     implicit F: Sync[F],
-    keyDeserializer: Deserializer[F, K],
-    valueDeserializer: Deserializer[F, V]
+    keyDeserializer: F[Deserializer[F, K]] OrElse Deserializer[F, K],
+    valueDeserializer: F[Deserializer[F, V]] OrElse Deserializer[F, V]
   ): ConsumerSettings[F, K, V] =
-    create(keyDeserializer, valueDeserializer)
+    create(keyDeserializer.fold(identity, F.pure), valueDeserializer.fold(identity, F.pure))
 
   implicit def consumerSettingsShow[F[_], K, V]: Show[ConsumerSettings[F, K, V]] =
     Show.fromToString

--- a/src/main/scala/fs2/kafka/ConsumerSettings.scala
+++ b/src/main/scala/fs2/kafka/ConsumerSettings.scala
@@ -577,7 +577,7 @@ object ConsumerSettings {
   /**
     * Creates a new [[ConsumerSettings]] instance using the
     * specified [[Deserializer]]s for the key and value, in
-    * the case where both the key and  value deserializers
+    * the case where both the key and value deserializers
     * are wrapped in a creation effect.
     */
   def apply[F[_], K, V](

--- a/src/main/scala/fs2/kafka/KafkaConsumer.scala
+++ b/src/main/scala/fs2/kafka/KafkaConsumer.scala
@@ -610,7 +610,16 @@ private[kafka] object KafkaConsumer {
       ref <- Resource.liftF(Ref.of[F, State[F, K, V]](State.empty))
       streamId <- Resource.liftF(Ref.of[F, Int](0))
       withConsumer <- WithConsumer(settings)
-      actor = new KafkaConsumerActor(settings, ref, requests, withConsumer)
+      keyDeserializer <- Resource.liftF(settings.keyDeserializer)
+      valueDeserializer <- Resource.liftF(settings.valueDeserializer)
+      actor = new KafkaConsumerActor(
+        settings = settings,
+        keyDeserializer = keyDeserializer,
+        valueDeserializer = valueDeserializer,
+        ref = ref,
+        requests = requests,
+        withConsumer = withConsumer
+      )
       actor <- startConsumerActor(requests, polls, actor)
       polls <- startPollScheduler(polls, settings.pollInterval)
     } yield createKafkaConsumer(requests, settings, actor, polls, streamId, id, withConsumer)

--- a/src/main/scala/fs2/kafka/KafkaConsumer.scala
+++ b/src/main/scala/fs2/kafka/KafkaConsumer.scala
@@ -602,6 +602,8 @@ private[kafka] object KafkaConsumer {
     timer: Timer[F]
   ): Resource[F, KafkaConsumer[F, K, V]] =
     for {
+      keyDeserializer <- Resource.liftF(settings.keyDeserializer)
+      valueDeserializer <- Resource.liftF(settings.valueDeserializer)
       id <- Resource.liftF(F.delay(new Object().hashCode))
       implicit0(jitter: Jitter[F]) <- Resource.liftF(Jitter.default[F])
       implicit0(logging: Logging[F]) <- Resource.liftF(Logging.default[F](id))
@@ -610,8 +612,6 @@ private[kafka] object KafkaConsumer {
       ref <- Resource.liftF(Ref.of[F, State[F, K, V]](State.empty))
       streamId <- Resource.liftF(Ref.of[F, Int](0))
       withConsumer <- WithConsumer(settings)
-      keyDeserializer <- Resource.liftF(settings.keyDeserializer)
-      valueDeserializer <- Resource.liftF(settings.valueDeserializer)
       actor = new KafkaConsumerActor(
         settings = settings,
         keyDeserializer = keyDeserializer,

--- a/src/main/scala/fs2/kafka/internal/OrElse.scala
+++ b/src/main/scala/fs2/kafka/internal/OrElse.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2014-2019 by The Monix Project Developers.
+ * See the project homepage at: https://monix.io
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Changes:
+ *   1. Change package to fs2.kafka.internal.
+ *   2. Change outer scopes to private[kafka].
+ */
+
+package fs2.kafka.internal
+
+/** A type class for prioritized implicit search.
+  *
+  * Useful for specifying type class instance alternatives.
+  * Examples:
+  *
+  *  - `Async[F] OrElse Sync[F]`
+  *  - `Concurrent[F] OrElse Async[F]`
+  *
+  * Inspired by the implementations in Shapeless and Algebra.
+  */
+private[kafka] sealed trait OrElse[+A, +B] {
+  def fold[C](prim: A => C, sec: B => C): C
+  def unify[C >: B](implicit ev: A <:< C): C
+}
+
+private[kafka] object OrElse extends OrElse0 {
+  implicit def primary[A, B](implicit a: A): A OrElse B =
+    new Primary(a)
+}
+
+private[kafka] abstract class OrElse0 {
+  implicit def secondary[A, B](implicit b: B): A OrElse B =
+    new Secondary(b)
+
+  final class Primary[+A](value: A) extends OrElse[A, Nothing] {
+    def fold[C](prim: A => C, sec: Nothing => C) = prim(value)
+    def unify[C >: Nothing](implicit ev: <:<[A, C]): C = value
+  }
+
+  final class Secondary[+B](value: B) extends OrElse[Nothing, B] {
+    def fold[C](prim: Nothing => C, sec: B => C) = sec(value)
+    def unify[C >: B](implicit ev: <:<[Nothing, C]): C = value
+  }
+}

--- a/src/test/scala/fs2/kafka/ConsumerSettingsSpec.scala
+++ b/src/test/scala/fs2/kafka/ConsumerSettingsSpec.scala
@@ -245,6 +245,27 @@ final class ConsumerSettingsSpec extends BaseSpec {
       }
     }
 
+    it("should be able to create with and without deserializer creation effects") {
+      val deserializer = Deserializer[IO, String]
+
+      ConsumerSettings(deserializer, deserializer)
+      ConsumerSettings(IO.pure(deserializer), deserializer)
+      ConsumerSettings(deserializer, IO.pure(deserializer))
+      ConsumerSettings(IO.pure(deserializer), IO.pure(deserializer))
+    }
+
+    it("should be able to implicitly create with and without deserializer creation effects") {
+      val deserializerInstance = Deserializer[IO, String]
+
+      implicit val deserializer: IO[Deserializer[IO, String]] =
+        IO.pure(deserializerInstance)
+
+      ConsumerSettings[IO, Int, Int]
+      ConsumerSettings[IO, String, Int].keyDeserializer.unsafeRunSync shouldBe deserializerInstance
+      ConsumerSettings[IO, Int, String].valueDeserializer.unsafeRunSync shouldBe deserializerInstance
+      ConsumerSettings[IO, String, String]
+    }
+
     it("should have a Show instance and matching toString") {
       assert {
         settings.show == "ConsumerSettings(closeTimeout = 20 seconds, commitTimeout = 15 seconds, pollInterval = 50 milliseconds, pollTimeout = 50 milliseconds, commitRecovery = Default)" &&

--- a/src/test/scala/fs2/kafka/ConsumerSettingsSpec.scala
+++ b/src/test/scala/fs2/kafka/ConsumerSettingsSpec.scala
@@ -255,7 +255,9 @@ final class ConsumerSettingsSpec extends BaseSpec {
     }
 
     it("should be able to implicitly create with and without deserializer creation effects") {
-      val deserializerInstance = Deserializer[IO, String]
+      val deserializerInstance =
+        Deserializer[IO, String]
+          .map(identity)
 
       implicit val deserializer: IO[Deserializer[IO, String]] =
         IO.pure(deserializerInstance)

--- a/src/test/scala/fs2/kafka/ProducerSettingsSpec.scala
+++ b/src/test/scala/fs2/kafka/ProducerSettingsSpec.scala
@@ -163,6 +163,29 @@ final class ProducerSettingsSpec extends BaseSpec {
           shown == settings.toString
       )
     }
+
+    it("should be able to create with and without serializer creation effects") {
+      val serializer = Serializer[IO, String]
+
+      ProducerSettings(serializer, serializer)
+      ProducerSettings(IO.pure(serializer), serializer)
+      ProducerSettings(serializer, IO.pure(serializer))
+      ProducerSettings(IO.pure(serializer), IO.pure(serializer))
+    }
+
+    it("should be able to implicitly create with and without serializer creation effects") {
+      val serializerInstance =
+        Serializer[IO, String]
+          .mapBytes(identity)
+
+      implicit val serializer: IO[Serializer[IO, String]] =
+        IO.pure(serializerInstance)
+
+      ProducerSettings[IO, Int, Int]
+      ProducerSettings[IO, String, Int].keySerializer.unsafeRunSync shouldBe serializerInstance
+      ProducerSettings[IO, Int, String].valueSerializer.unsafeRunSync shouldBe serializerInstance
+      ProducerSettings[IO, String, String]
+    }
   }
 
   val settings = ProducerSettings[IO, String, String]

--- a/src/test/scala/fs2/kafka/SerializerSpec.scala
+++ b/src/test/scala/fs2/kafka/SerializerSpec.scala
@@ -313,25 +313,4 @@ final class SerializerSpec extends BaseCatsSpec with TestInstances {
       Deserializer.short
     )
   }
-
-  test("should be able to create with and without serializer creation effects") {
-    val serializer = Serializer[IO, String]
-
-    ProducerSettings(serializer, serializer)
-    ProducerSettings(IO.pure(serializer), serializer)
-    ProducerSettings(serializer, IO.pure(serializer))
-    ProducerSettings(IO.pure(serializer), IO.pure(serializer))
-  }
-
-  test("should be able to implicitly create with and without serializer creation effects") {
-    val serializerInstance = Serializer[IO, String]
-
-    implicit val serializer: IO[Serializer[IO, String]] =
-      IO.pure(serializerInstance)
-
-    ProducerSettings[IO, Int, Int]
-    ProducerSettings[IO, String, Int].keySerializer.unsafeRunSync shouldBe serializerInstance
-    ProducerSettings[IO, Int, String].valueSerializer.unsafeRunSync shouldBe serializerInstance
-    ProducerSettings[IO, String, String]
-  }
 }

--- a/src/test/scala/fs2/kafka/SerializerSpec.scala
+++ b/src/test/scala/fs2/kafka/SerializerSpec.scala
@@ -313,4 +313,25 @@ final class SerializerSpec extends BaseCatsSpec with TestInstances {
       Deserializer.short
     )
   }
+
+  test("should be able to create with and without serializer creation effects") {
+    val serializer = Serializer[IO, String]
+
+    ProducerSettings(serializer, serializer)
+    ProducerSettings(IO.pure(serializer), serializer)
+    ProducerSettings(serializer, IO.pure(serializer))
+    ProducerSettings(IO.pure(serializer), IO.pure(serializer))
+  }
+
+  test("should be able to implicitly create with and without serializer creation effects") {
+    val serializerInstance = Serializer[IO, String]
+
+    implicit val serializer: IO[Serializer[IO, String]] =
+      IO.pure(serializerInstance)
+
+    ProducerSettings[IO, Int, Int]
+    ProducerSettings[IO, String, Int].keySerializer.unsafeRunSync shouldBe serializerInstance
+    ProducerSettings[IO, Int, String].valueSerializer.unsafeRunSync shouldBe serializerInstance
+    ProducerSettings[IO, String, String]
+  }
 }


### PR DESCRIPTION
In some cases, serializers need a creation effect, i.e. `F[Deserializer[F, A]]` or `F[Serializer[F, A]]`. One example is the Confluent Avro serializer, which allocates mutable state as part of initialization. Typically, we want one instance per consumer or producer, which means we end up with code similar to the following.

```scala
import cats.effect.IO
import fs2.kafka._

val keyDeserializer = 
  IO { println("key"); Deserializer[IO, Int] }

val valueDeserializer = 
  IO { println("value"); Deserializer[IO, String] }

val settings: IO[ConsumerSettings[IO, Int, String]] =
  keyDeserializer.flatMap { keyDeserializer =>
    valueDeserializer.map { valueDeserializer =>
      ConsumerSettings(
        keyDeserializer = keyDeserializer,
        valueDeserializer = valueDeserializer
      )
    }
  }
```

This pull request changes `ConsumerSettings` and `ProducerSettings` to accept serializers with creation effects, which will then be evaluated as part of consumer or producer creation. The above example can now be written as follows.

```scala
import cats.effect.IO
import fs2.kafka._

val keyDeserializer = 
  IO { println("key"); Deserializer[IO, Int] }

val valueDeserializer = 
  IO { println("value"); Deserializer[IO, String] }

val settings: ConsumerSettings[IO, Int, String] =
  ConsumerSettings(
    keyDeserializer = keyDeserializer,
    valueDeserializer = valueDeserializer
  )
```

Additionally, we use the `OrElse` construct from Monix to support implicit serializers with and without creation effects. This enables implicit generic derivation of serializers with creation effects. Essentially, this means we can write the example above using implicit serializers, as follows.

```scala
import cats.effect.IO
import fs2.kafka._

implicit val keyDeserializer: IO[Deserializer[IO, Int]] = 
  IO { println("key"); Deserializer[IO, Int] }

implicit val valueDeserializer: IO[Deserializer[IO, String]] = 
  IO { println("value"); Deserializer[IO, String] }

val settings =
  ConsumerSettings[IO, Int, String]
```

Note that settings can also be created for serializers without creation effects, just like before.