### PR TITLE
Change to simplify produce and commit

### DIFF
--- a/docs/src/main/mdoc/quick-example.md
+++ b/docs/src/main/mdoc/quick-example.md
@@ -6,8 +6,8 @@ title: Quick Example
 Following is an example showing how to:
 
 - use `consumerStream` in order to stream records from Kafka,
-- use `producerStream` to produce newly created records to Kafka,
-- use `commitBatchWithinF` to commit consumed offsets in batches.
+- use `produce` to produce newly created records to Kafka,
+- use `commitBatchWithin` to commit consumed offsets in batches.
 
 ```scala mdoc
 import cats.effect.{ExitCode, IO, IOApp}
@@ -31,23 +31,20 @@ object Main extends IOApp {
         .withBootstrapServers("localhost")
 
     val stream =
-      producerStream[IO]
-        .using(producerSettings)
-        .flatMap { producer =>
-          consumerStream[IO]
-            .using(consumerSettings)
-            .evalTap(_.subscribeTo("topic"))
-            .flatMap(_.stream)
-            .mapAsync(25) { committable =>
-              processRecord(committable.record)
-                .map { case (key, value) =>
-                  val record = ProducerRecord("topic", key, value)
-                  ProducerRecords.one(record, committable.offset)
-                }
+      consumerStream[IO]
+        .using(consumerSettings)
+        .evalTap(_.subscribeTo("topic"))
+        .flatMap(_.stream)
+        .mapAsync(25) { committable =>
+          processRecord(committable.record)
+            .map { case (key, value) =>
+              val record = ProducerRecord("topic", key, value)
+              ProducerRecords.one(record, committable.offset)
             }
-            .evalMap(producer.producePassthrough)
-            .through(commitBatchWithinF(500, 15.seconds))
         }
+        .through(produce(producerSettings))
+        .map(_.passthrough)
+        .through(commitBatchWithin(500, 15.seconds))
 
     stream.compile.drain.as(ExitCode.Success)
   }

--- a/modules/core/src/main/scala/fs2/kafka/CommittableConsumerRecord.scala
+++ b/modules/core/src/main/scala/fs2/kafka/CommittableConsumerRecord.scala
@@ -24,9 +24,9 @@ import cats.syntax.show._
   * instance of [[CommittableOffset]], which can be used commit
   * the record offset to Kafka. Offsets are normally committed in
   * batches, either using [[CommittableOffsetBatch]] or via pipes,
-  * like [[commitBatch]] and [[commitBatchWithin]]. If you are not
-  * committing offsets to Kafka then you can use [[record]] to get
-  * the underlying record and also discard the [[offset]].<br>
+  * like [[commitBatchWithin]]. If you are not committing offsets
+  * to Kafka then you can use [[record]] to get the underlying
+  * record and also discard the [[offset]].<br>
   * <br>
   * While normally not necessary, [[CommittableConsumerRecord#apply]]
   * can be used to create a new instance.
@@ -43,9 +43,8 @@ sealed abstract class CommittableConsumerRecord[F[_], +K, +V] {
   /**
     * A [[CommittableOffset]] instance, providing a way to commit the
     * [[record]] offset to Kafka. This is normally done in batches as
-    * it achieves better performance. Pipes like [[commitBatch]] and
-    * [[commitBatchWithin]] use [[CommittableOffsetBatch]] to batch
-    * and commit offsets.
+    * it achieves better performance. Pipes like [[commitBatchWithin]]
+    * use [[CommittableOffsetBatch]] to batch and commit offsets.
     */
   def offset: CommittableOffset[F]
 }

--- a/modules/core/src/main/scala/fs2/kafka/CommittableOffset.scala
+++ b/modules/core/src/main/scala/fs2/kafka/CommittableOffset.scala
@@ -27,9 +27,8 @@ import org.apache.kafka.common.TopicPartition
   * [[CommittableOffset]] represents an [[offsetAndMetadata]] for a
   * [[topicPartition]], along with the ability to commit that offset
   * to Kafka with [[commit]]. Note that offsets are normally committed
-  * in batches for performance reasons. Pipes like [[commitBatch]] and
-  * [[commitBatchWithin]] use [[CommittableOffsetBatch]] to commit the
-  * offsets in batches.<br>
+  * in batches for performance reasons. Pipes like [[commitBatchWithin]]
+  * use [[CommittableOffsetBatch]] to commit the offsets in batches.<br>
   * <br>
   * While normally not necessary, [[CommittableOffset#apply]] can be
   * used to create a new instance.
@@ -76,9 +75,8 @@ sealed abstract class CommittableOffset[F[_]] {
   /**
     * Commits the [[offsetAndMetadata]] for the [[topicPartition]] to
     * Kafka. Note that offsets are normally committed in batches for
-    * performance reasons. Prefer to use pipes like [[commitBatch]]
-    * or [[commitBatchWithin]], or [[CommittableOffsetBatch]] for
-    * that reason.
+    * performance reasons. Prefer pipes like [[commitBatchWithin]]
+    * or [[CommittableOffsetBatch]] for that reason.
     */
   def commit: F[Unit]
 

--- a/modules/core/src/main/scala/fs2/kafka/CommittableOffsetBatch.scala
+++ b/modules/core/src/main/scala/fs2/kafka/CommittableOffsetBatch.scala
@@ -40,8 +40,8 @@ import org.apache.kafka.common.TopicPartition
   * them together using [[CommittableOffsetBatch#empty]] and `updated`,
   * or you can use [[CommittableOffsetBatch#fromFoldable]]. Generally,
   * prefer to use `fromFoldable`, as it has better performance. Provided
-  * pipes like [[commitBatch]] and [[commitBatchWithin]] are also to be
-  * preferred, as they also achieve better performance.
+  * pipes like [[commitBatchWithin]] are also to be preferred, as they
+  * also achieve better performance.
   */
 sealed abstract class CommittableOffsetBatch[F[_]] {
 

--- a/modules/core/src/main/scala/fs2/kafka/KafkaConsumer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/KafkaConsumer.scala
@@ -53,10 +53,10 @@ import scala.util.matching.Regex
   * which provide [[CommittableOffset]]s with the ability to commit
   * record offsets to Kafka. For performance reasons, offsets are
   * usually committed in batches using [[CommittableOffsetBatch]].
-  * Provided `Pipe`s, like [[commitBatch]] or [[commitBatchWithin]]
-  * are available for batch committing offsets. If you are not
-  * committing offsets to Kafka, you can simply discard the
-  * [[CommittableOffset]], and only make use of the record.<br>
+  * Provided `Pipe`s, like [[commitBatchWithin]] are available for
+  * batch committing offsets. If you are not committing offsets to
+  * Kafka, you can simply discard the [[CommittableOffset]], and
+  * only make use of the record.<br>
   * <br>
   * While it's technically possible to start more than one stream from a
   * single [[KafkaConsumer]], it is generally not recommended as there is

--- a/modules/core/src/main/scala/fs2/kafka/KafkaProducer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/KafkaProducer.scala
@@ -32,7 +32,7 @@ import org.apache.kafka.clients.producer.{Callback, RecordMetadata}
   * used for keeping the [[CommittableOffset]]s, in order to commit
   * offsets, but any value can be used as passthrough value.
   */
-sealed abstract class KafkaProducer[F[_], K, V] {
+abstract class KafkaProducer[F[_], K, V] {
 
   /**
     * Produces the `ProducerRecord`s in the specified [[ProducerRecords]]

--- a/modules/core/src/main/scala/fs2/kafka/KafkaProducer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/KafkaProducer.scala
@@ -40,23 +40,11 @@ sealed abstract class KafkaProducer[F[_], K, V] {
     * producer, and the second effect waits for the records to have been
     * sent. Note that it is very slow to wait for individual records to
     * complete sending, but if you're sure that's what you want, then
-    * simply `flatten` the result from this function.<br>
-    * <br>
-    * If you're only interested in the passthrough value, and not the whole
-    * [[ProducerResult]], you can instead use [[producePassthrough]] which
-    * only keeps the passthrough value in the output.
+    * simply `flatten` the result from this function.
     */
   def produce[G[+_], P](
     records: ProducerRecords[G, K, V, P]
   ): F[F[ProducerResult[G, K, V, P]]]
-
-  /**
-    * Like [[produce]] but only keeps the passthrough value of the
-    * [[ProducerResult]] rather than the whole [[ProducerResult]].
-    */
-  def producePassthrough[G[+_], P](
-    records: ProducerRecords[G, K, V, P]
-  ): F[F[P]]
 }
 
 private[kafka] object KafkaProducer {
@@ -79,18 +67,6 @@ private[kafka] object KafkaProducer {
                 records.records
                   .traverse(produceRecord(keySerializer, valueSerializer, producer))
                   .map(_.sequence.map(ProducerResult(_, records.passthrough)))
-              }
-            }
-
-            override def producePassthrough[G[+_], P](
-              records: ProducerRecords[G, K, V, P]
-            ): F[F[P]] = {
-              implicit val G: Traverse[G] = records.traverse
-
-              withProducer { producer =>
-                records.records
-                  .traverse(produceRecord(keySerializer, valueSerializer, producer))
-                  .map(_.sequence_.as(records.passthrough))
               }
             }
 

--- a/modules/core/src/main/scala/fs2/kafka/TransactionalKafkaProducer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/TransactionalKafkaProducer.scala
@@ -32,7 +32,7 @@ import scala.collection.mutable.ArrayBuffer
   * Records are wrapped in [[TransactionalProducerRecords]] which allow an
   * arbitrary passthrough value to be included in the result.
   */
-sealed abstract class TransactionalKafkaProducer[F[_], K, V] {
+abstract class TransactionalKafkaProducer[F[_], K, V] {
 
   /**
     * Produces the `ProducerRecord`s in the specified [[TransactionalProducerRecords]]

--- a/modules/core/src/test/scala/fs2/kafka/KafkaAdminClientSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/KafkaAdminClientSpec.scala
@@ -19,7 +19,8 @@ final class KafkaAdminClientSpec extends BaseKafkaSpec {
           .flatMap(_.stream)
           .take(produced.size.toLong)
           .map(_.offset)
-          .through(commitBatch)
+          .chunks
+          .evalMap(CommittableOffsetBatch.fromFoldable(_).commit)
           .compile
           .lastOrError
           .unsafeRunSync

--- a/modules/core/src/test/scala/fs2/kafka/KafkaConsumerSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/KafkaConsumerSpec.scala
@@ -261,7 +261,8 @@ final class KafkaConsumerSpec extends BaseKafkaSpec {
             consumer.stream
               .take(produced.size.toLong)
               .map(_.offset)
-              .through(commitBatch)
+              .chunks
+              .evalMap(CommittableOffsetBatch.fromFoldable(_).commit)
           }
           .evalTap { consumer =>
             for {

--- a/modules/core/src/test/scala/fs2/kafka/KafkaProducerSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/KafkaProducerSpec.scala
@@ -19,7 +19,10 @@ final class KafkaProducerSpec extends BaseKafkaSpec {
             case passthrough @ (key, value) =>
               ProducerRecords.one(ProducerRecord(topic, key, value), passthrough)
           })
-          batched <- Stream.eval(producer.producePassthrough(records)).buffer(toProduce.size)
+          batched <- Stream
+            .eval(producer.produce(records))
+            .map(_.map(_.passthrough))
+            .buffer(toProduce.size)
           passthrough <- Stream.eval(batched)
         } yield passthrough).compile.toVector.unsafeRunSync()
 

--- a/modules/core/src/test/scala/fs2/kafka/KafkaSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/KafkaSpec.scala
@@ -9,80 +9,6 @@ import org.apache.kafka.common.TopicPartition
 import scala.concurrent.duration._
 
 final class KafkaSpec extends BaseAsyncSpec {
-  describe("commitBatch") {
-    it("should batch commit each chunk") {
-      val committed =
-        (for {
-          ref <- Stream.eval(Ref[IO].of(Option.empty[Map[TopicPartition, OffsetAndMetadata]]))
-          commit = (offsets: Map[TopicPartition, OffsetAndMetadata]) => ref.set(Some(offsets))
-          offsets = Chunk.seq(exampleOffsets(commit))
-          _ <- Stream
-            .chunk(offsets)
-            .covary[IO]
-            .through(commitBatch)
-          result <- Stream.eval(ref.get)
-        } yield result).compile.lastOrError.unsafeRunSync
-
-      assert(committed.contains(exampleOffsetsCommitted))
-    }
-  }
-
-  describe("commitBatchF") {
-    it("should batch commit each chunk") {
-      val committed =
-        (for {
-          ref <- Stream.eval(Ref[IO].of(Option.empty[Map[TopicPartition, OffsetAndMetadata]]))
-          commit = (offsets: Map[TopicPartition, OffsetAndMetadata]) => ref.set(Some(offsets))
-          offsets = Chunk.seq(exampleOffsets(commit))
-          _ <- Stream
-            .chunk(offsets)
-            .covary[IO]
-            .map(IO.pure)
-            .through(commitBatchF)
-          result <- Stream.eval(ref.get)
-        } yield result).compile.lastOrError.unsafeRunSync
-
-      assert(committed.contains(exampleOffsetsCommitted))
-    }
-  }
-
-  describe("commitBatchOption") {
-    it("should batch commit each chunk") {
-      val committed =
-        (for {
-          ref <- Stream.eval(Ref[IO].of(Option.empty[Map[TopicPartition, OffsetAndMetadata]]))
-          commit = (offsets: Map[TopicPartition, OffsetAndMetadata]) => ref.set(Some(offsets))
-          offsets = Chunk.seq(exampleOffsetsOption(commit))
-          _ <- Stream
-            .chunk(offsets)
-            .covary[IO]
-            .through(commitBatchOption)
-          result <- Stream.eval(ref.get)
-        } yield result).compile.lastOrError.unsafeRunSync
-
-      assert(committed.contains(exampleOffsetsCommitted))
-    }
-  }
-
-  describe("commitBatchOptionF") {
-    it("should batch commit each chunk") {
-      val committed =
-        (for {
-          ref <- Stream.eval(Ref[IO].of(Option.empty[Map[TopicPartition, OffsetAndMetadata]]))
-          commit = (offsets: Map[TopicPartition, OffsetAndMetadata]) => ref.set(Some(offsets))
-          offsets = Chunk.seq(exampleOffsetsOption(commit))
-          _ <- Stream
-            .chunk(offsets)
-            .covary[IO]
-            .map(IO.pure)
-            .through(commitBatchOptionF)
-          result <- Stream.eval(ref.get)
-        } yield result).compile.lastOrError.unsafeRunSync
-
-      assert(committed.contains(exampleOffsetsCommitted))
-    }
-  }
-
   describe("commitBatchWithin") {
     it("should batch commit according specified arguments") {
       val committed =
@@ -101,92 +27,39 @@ final class KafkaSpec extends BaseAsyncSpec {
     }
   }
 
-  describe("commitBatchWithinF") {
-    it("should batch commit according specified arguments") {
-      val committed =
-        (for {
-          ref <- Stream.eval(Ref[IO].of(Option.empty[Map[TopicPartition, OffsetAndMetadata]]))
-          commit = (offsets: Map[TopicPartition, OffsetAndMetadata]) => ref.set(Some(offsets))
-          offsets = Chunk.seq(exampleOffsets(commit))
-          _ <- Stream
-            .chunk(offsets)
-            .covary[IO]
-            .map(IO.pure)
-            .through(commitBatchWithinF(offsets.size, 10.seconds))
-          result <- Stream.eval(ref.get)
-        } yield result).compile.lastOrError.unsafeRunSync
-
-      assert(committed.contains(exampleOffsetsCommitted))
-    }
-  }
-
-  describe("commitBatchOptionWithin") {
-    it("should batch commit according specified arguments") {
-      val committed =
-        (for {
-          ref <- Stream.eval(Ref[IO].of(Option.empty[Map[TopicPartition, OffsetAndMetadata]]))
-          commit = (offsets: Map[TopicPartition, OffsetAndMetadata]) => ref.set(Some(offsets))
-          offsets = Chunk.seq(exampleOffsetsOption(commit))
-          _ <- Stream
-            .chunk(offsets)
-            .covary[IO]
-            .through(commitBatchOptionWithin(offsets.size, 10.seconds))
-          result <- Stream.eval(ref.get)
-        } yield result).compile.lastOrError.unsafeRunSync
-
-      assert(committed.contains(exampleOffsetsCommitted))
-    }
-  }
-
-  describe("commitBatchOptionWithinF") {
-    it("should batch commit according specified arguments") {
-      val committed =
-        (for {
-          ref <- Stream.eval(Ref[IO].of(Option.empty[Map[TopicPartition, OffsetAndMetadata]]))
-          commit = (offsets: Map[TopicPartition, OffsetAndMetadata]) => ref.set(Some(offsets))
-          offsets = Chunk.seq(exampleOffsetsOption(commit))
-          _ <- Stream
-            .chunk(offsets)
-            .covary[IO]
-            .map(IO.pure)
-            .through(commitBatchOptionWithinF(offsets.size, 10.seconds))
-          result <- Stream.eval(ref.get)
-        } yield result).compile.lastOrError.unsafeRunSync
-
-      assert(committed.contains(exampleOffsetsCommitted))
-    }
-  }
-
-  def exampleOffsetsOption[F[_]](
-    commit: Map[TopicPartition, OffsetAndMetadata] => F[Unit]
-  ): List[Option[CommittableOffset[F]]] = {
-    val (first, rest) = exampleOffsets(commit).map(Some(_)).splitAt(2)
-    List(None) ++ first ++ List(None) ++ rest ++ List(None)
-  }
-
   def exampleOffsets[F[_]](
     commit: Map[TopicPartition, OffsetAndMetadata] => F[Unit]
   ): List[CommittableOffset[F]] = List(
-    CommittableOffset[F](new TopicPartition("topic", 0),
-                         new OffsetAndMetadata(1L),
-                         Some("group-1"),
-                         commit),
-    CommittableOffset[F](new TopicPartition("topic", 0),
-                         new OffsetAndMetadata(2L),
-                         Some("group-1"),
-                         commit),
-    CommittableOffset[F](new TopicPartition("topic", 1),
-                         new OffsetAndMetadata(1L),
-                         Some("group-1"),
-                         commit),
-    CommittableOffset[F](new TopicPartition("topic", 1),
-                         new OffsetAndMetadata(2L),
-                         Some("group-1"),
-                         commit),
-    CommittableOffset[F](new TopicPartition("topic", 1),
-                         new OffsetAndMetadata(3L),
-                         Some("group-1"),
-                         commit)
+    CommittableOffset[F](
+      new TopicPartition("topic", 0),
+      new OffsetAndMetadata(1L),
+      Some("group-1"),
+      commit
+    ),
+    CommittableOffset[F](
+      new TopicPartition("topic", 0),
+      new OffsetAndMetadata(2L),
+      Some("group-1"),
+      commit
+    ),
+    CommittableOffset[F](
+      new TopicPartition("topic", 1),
+      new OffsetAndMetadata(1L),
+      Some("group-1"),
+      commit
+    ),
+    CommittableOffset[F](
+      new TopicPartition("topic", 1),
+      new OffsetAndMetadata(2L),
+      Some("group-1"),
+      commit
+    ),
+    CommittableOffset[F](
+      new TopicPartition("topic", 1),
+      new OffsetAndMetadata(3L),
+      Some("group-1"),
+      commit
+    )
   )
 
   val exampleOffsetsCommitted: Map[TopicPartition, OffsetAndMetadata] = Map(

--- a/modules/core/src/test/scala/fs2/kafka/TransactionalKafkaProducerSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/TransactionalKafkaProducerSpec.scala
@@ -46,7 +46,10 @@ class TransactionalKafkaProducerSpec extends BaseKafkaSpec with OptionValues {
                 (key, value)
               )
           }
-          passthrough <- Stream.eval(producer.producePassthrough(records)).buffer(toProduce.size)
+          passthrough <- Stream
+            .eval(producer.produce(records))
+            .map(_.passthrough)
+            .buffer(toProduce.size)
         } yield passthrough).compile.toVector.unsafeRunSync()
 
       produced should contain theSameElementsAs toProduce


### PR DESCRIPTION
The fact that `KafkaProducer#produce` returns two effects (`F[F[ProducerResult[...]]]`) can be hard to understand and use correctly. To remedy the situation, we introduce a `produce` function, accepting `ProducerSettings`, which produces records in batches, and waits for them to finish sending. Batches are limited in size by `ProducerSettings#parallelism`.

Additionally, we remove most commit `Pipe`s and `producePassthrough`, since they are not really needed anymore, and some can result in poor performance if used incorrectly. We only leave the `commitBatchWithin` pipe for convenience.