### PR TITLE
Prevent mixing consumer group ids

### DIFF
--- a/modules/core/src/main/scala/fs2/kafka/CommittableOffset.scala
+++ b/modules/core/src/main/scala/fs2/kafka/CommittableOffset.scala
@@ -16,6 +16,7 @@
 
 package fs2.kafka
 
+import cats.ApplicativeError
 import cats.instances.string._
 import cats.Show
 import cats.syntax.show._
@@ -100,7 +101,7 @@ object CommittableOffset {
     offsetAndMetadata: OffsetAndMetadata,
     consumerGroupId: Option[String],
     commit: Map[TopicPartition, OffsetAndMetadata] => F[Unit]
-  ): CommittableOffset[F] = {
+  )(implicit F: ApplicativeError[F, Throwable]): CommittableOffset[F] = {
     val _topicPartition = topicPartition
     val _offsetAndMetadata = offsetAndMetadata
     val _consumerGroupId = consumerGroupId
@@ -120,7 +121,7 @@ object CommittableOffset {
         Map(_topicPartition -> _offsetAndMetadata)
 
       override def batch: CommittableOffsetBatch[F] =
-        CommittableOffsetBatch(offsets, _commit)
+        CommittableOffsetBatch(offsets, consumerGroupId.toSet, consumerGroupId.isEmpty, _commit)
 
       override def commit: F[Unit] =
         _commit(offsets)

--- a/modules/core/src/main/scala/fs2/kafka/CommittableOffsetBatch.scala
+++ b/modules/core/src/main/scala/fs2/kafka/CommittableOffsetBatch.scala
@@ -16,6 +16,7 @@
 
 package fs2.kafka
 
+import cats.ApplicativeError
 import cats.instances.list._
 import cats.syntax.foldable._
 import cats.syntax.show._
@@ -67,7 +68,39 @@ sealed abstract class CommittableOffsetBatch[F[_]] {
   def offsets: Map[TopicPartition, OffsetAndMetadata]
 
   /**
+    * The consumer group IDs for the [[offsets]] in the batch.
+    * For the batch to be valid and for [[commit]] to succeed,
+    * there should be exactly one ID in the set and the flag
+    * [[consumerGroupIdsMissing]] should be `false`.<br>
+    * <br>
+    * There might be more than one consumer group ID in the set
+    * if offsets from multiple consumers, with different group
+    * IDs, have accidentally been mixed. The set might also be
+    * empty if no consumer group IDs have been specified.
+    */
+  def consumerGroupIds: Set[String]
+
+  /**
+    * `true` if any offset in the batch came from a consumer
+    * without a group ID; `false` otherwise. For the batch to
+    * be valid and for [[commit]] to succeed, this flag must
+    * be `false` and there should be exactly one consumer
+    * group ID in [[consumerGroupIds]].
+    */
+  def consumerGroupIdsMissing: Boolean
+
+  /**
     * Commits the [[offsets]] to Kafka in a single commit.
+    * For the batch to be valid and for commit to succeed,
+    * the following conditions must hold:<br>
+    * - [[consumerGroupIdsMissing]] must be false, and<br>
+    * - [[consumerGroupIds]] must have exactly one ID.<br>
+    * <br>
+    * If one of the conditions above do not hold, there will
+    * be a [[ConsumerGroupException]] exception raised and a
+    * commit will not be attempted. If [[offsets]] is empty
+    * then these conditions do not need to hold, as there
+    * is nothing to commit.
     */
   def commit: F[Unit]
 }
@@ -75,29 +108,45 @@ sealed abstract class CommittableOffsetBatch[F[_]] {
 object CommittableOffsetBatch {
   private[kafka] def apply[F[_]](
     offsets: Map[TopicPartition, OffsetAndMetadata],
+    consumerGroupIds: Set[String],
+    consumerGroupIdsMissing: Boolean,
     commit: Map[TopicPartition, OffsetAndMetadata] => F[Unit]
-  ): CommittableOffsetBatch[F] = {
+  )(implicit F: ApplicativeError[F, Throwable]): CommittableOffsetBatch[F] = {
     val _offsets = offsets
+    val _consumerGroupIds = consumerGroupIds
+    val _consumerGroupIdsMissing = consumerGroupIdsMissing
     val _commit = commit
 
     new CommittableOffsetBatch[F] {
       override def updated(that: CommittableOffset[F]): CommittableOffsetBatch[F] =
         CommittableOffsetBatch(
           _offsets.updated(that.topicPartition, that.offsetAndMetadata),
+          that.consumerGroupId.fold(_consumerGroupIds)(_consumerGroupIds + _),
+          _consumerGroupIdsMissing || that.consumerGroupId.isEmpty,
           _commit
         )
 
       override def updated(that: CommittableOffsetBatch[F]): CommittableOffsetBatch[F] =
         CommittableOffsetBatch(
           _offsets ++ that.offsets,
+          _consumerGroupIds ++ that.consumerGroupIds,
+          _consumerGroupIdsMissing || that.consumerGroupIdsMissing,
           _commit
         )
 
       override val offsets: Map[TopicPartition, OffsetAndMetadata] =
         _offsets
 
+      override val consumerGroupIds: Set[String] =
+        _consumerGroupIds
+
+      override val consumerGroupIdsMissing: Boolean =
+        _consumerGroupIdsMissing
+
       override def commit: F[Unit] =
-        _commit(offsets)
+        if (_consumerGroupIdsMissing || _consumerGroupIds.size != 1)
+          F.raiseError(ConsumerGroupException(consumerGroupIds))
+        else _commit(offsets)
 
       override def toString: String =
         Show[CommittableOffsetBatch[F]].show(this)
@@ -120,7 +169,7 @@ object CommittableOffsetBatch {
     * @see [[CommittableOffsetBatch#fromFoldableOption]]
     */
   def fromFoldable[F[_], G[_]](offsets: G[CommittableOffset[F]])(
-    implicit F: Applicative[F],
+    implicit F: ApplicativeError[F, Throwable],
     G: Foldable[G]
   ): CommittableOffsetBatch[F] =
     fromFoldableMap(offsets)(identity)
@@ -142,11 +191,13 @@ object CommittableOffsetBatch {
     * @see [[CommittableOffsetBatch#fromFoldableOption]]
     */
   def fromFoldableMap[F[_], G[_], A](ga: G[A])(f: A => CommittableOffset[F])(
-    implicit F: Applicative[F],
+    implicit F: ApplicativeError[F, Throwable],
     G: Foldable[G]
   ): CommittableOffsetBatch[F] = {
     var commit: Map[TopicPartition, OffsetAndMetadata] => F[Unit] = null
     var offsetsMap: Map[TopicPartition, OffsetAndMetadata] = Map.empty
+    var consumerGroupIds: Set[String] = Set.empty
+    var consumerGroupIdsMissing: Boolean = false
     var empty: Boolean = true
 
     ga.foldLeft(()) { (_, a) =>
@@ -158,10 +209,14 @@ object CommittableOffsetBatch {
       }
 
       offsetsMap = offsetsMap.updated(offset.topicPartition, offset.offsetAndMetadata)
+      offset.consumerGroupId match {
+        case Some(consumerGroupId) => consumerGroupIds = consumerGroupIds + consumerGroupId
+        case None                  => consumerGroupIdsMissing = true
+      }
     }
 
     if (empty) CommittableOffsetBatch.empty[F]
-    else CommittableOffsetBatch(offsetsMap, commit)
+    else CommittableOffsetBatch(offsetsMap, consumerGroupIds, consumerGroupIdsMissing, commit)
   }
 
   /**
@@ -183,11 +238,13 @@ object CommittableOffsetBatch {
     * @see [[CommittableOffsetBatch#fromFoldableMap]]
     */
   def fromFoldableOption[F[_], G[_]](offsets: G[Option[CommittableOffset[F]]])(
-    implicit F: Applicative[F],
+    implicit F: ApplicativeError[F, Throwable],
     G: Foldable[G]
   ): CommittableOffsetBatch[F] = {
     var commit: Map[TopicPartition, OffsetAndMetadata] => F[Unit] = null
     var offsetsMap: Map[TopicPartition, OffsetAndMetadata] = Map.empty
+    var consumerGroupIds: Set[String] = Set.empty
+    var consumerGroupIdsMissing: Boolean = false
     var empty: Boolean = true
 
     offsets.foldLeft(()) {
@@ -198,11 +255,15 @@ object CommittableOffsetBatch {
         }
 
         offsetsMap = offsetsMap.updated(offset.topicPartition, offset.offsetAndMetadata)
+        offset.consumerGroupId match {
+          case Some(consumerGroupId) => consumerGroupIds = consumerGroupIds + consumerGroupId
+          case None                  => consumerGroupIdsMissing = true
+        }
       case (_, None) => ()
     }
 
     if (empty) CommittableOffsetBatch.empty[F]
-    else CommittableOffsetBatch(offsetsMap, commit)
+    else CommittableOffsetBatch(offsetsMap, consumerGroupIds, consumerGroupIdsMissing, commit)
   }
 
   /**
@@ -223,6 +284,12 @@ object CommittableOffsetBatch {
 
       override val offsets: Map[TopicPartition, OffsetAndMetadata] =
         Map.empty
+
+      override val consumerGroupIds: Set[String] =
+        Set.empty
+
+      override val consumerGroupIdsMissing: Boolean =
+        false
 
       override val commit: F[Unit] =
         F.unit

--- a/modules/core/src/main/scala/fs2/kafka/ConsumerGroupException.scala
+++ b/modules/core/src/main/scala/fs2/kafka/ConsumerGroupException.scala
@@ -19,9 +19,8 @@ package fs2.kafka
 import org.apache.kafka.common.KafkaException
 
 /**
-  * [[ConsumerGroupException]] indicates that one of the two following
-  * conditions occurred before records were produced transactionally
-  * with the [[TransactionalKafkaProducer]].<br>
+  * Indicates that one or more of the following conditions occurred
+  * while attempting to commit offsets.<br>
   * <br>
   * - There were [[CommittableOffset]]s without a consumer group ID.<br>
   * - There were [[CommittableOffset]]s for multiple consumer group IDs.
@@ -29,7 +28,7 @@ import org.apache.kafka.common.KafkaException
 sealed abstract class ConsumerGroupException(groupIds: Set[String])
     extends KafkaException({
       val groupIdsString = groupIds.toList.sorted.mkString(", ")
-      s"multiple or missing consumer group ids in transaction [$groupIdsString]"
+      s"multiple or missing consumer group ids [$groupIdsString]"
     })
 
 private[kafka] object ConsumerGroupException {

--- a/modules/core/src/test/scala/fs2/kafka/BaseGenerators.scala
+++ b/modules/core/src/test/scala/fs2/kafka/BaseGenerators.scala
@@ -1,6 +1,6 @@
 package fs2.kafka
 
-import cats.Applicative
+import cats.ApplicativeError
 import cats.effect._
 import cats.implicits._
 import org.apache.kafka.clients.consumer.OffsetAndMetadata
@@ -30,7 +30,7 @@ trait BaseGenerators {
     Arbitrary(genOffsetAndMetadata)
 
   def genCommittableOffset[F[_]](
-    implicit F: Applicative[F]
+    implicit F: ApplicativeError[F, Throwable]
   ): Gen[CommittableOffset[F]] =
     for {
       topicPartition <- genTopicPartition
@@ -44,18 +44,18 @@ trait BaseGenerators {
     )
 
   implicit def arbCommittableOffset[F[_]](
-    implicit F: Applicative[F]
+    implicit F: ApplicativeError[F, Throwable]
   ): Arbitrary[CommittableOffset[F]] =
     Arbitrary(genCommittableOffset[F])
 
   def genCommittableOffsetBatch[F[_]](
-    implicit F: Applicative[F]
+    implicit F: ApplicativeError[F, Throwable]
   ): Gen[CommittableOffsetBatch[F]] =
     arbitrary[Map[TopicPartition, OffsetAndMetadata]]
-      .map(CommittableOffsetBatch[F](_, _ => F.unit))
+      .map(CommittableOffsetBatch[F](_, Set.empty, false, _ => F.unit))
 
   implicit def arbCommittableOffsetBatch[F[_]](
-    implicit F: Applicative[F]
+    implicit F: ApplicativeError[F, Throwable]
   ): Arbitrary[CommittableOffsetBatch[F]] =
     Arbitrary(genCommittableOffsetBatch[F])
 

--- a/modules/core/src/test/scala/fs2/kafka/CommittableConsumerRecordSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/CommittableConsumerRecordSpec.scala
@@ -1,5 +1,6 @@
 package fs2.kafka
 
+import cats.effect.IO
 import cats.implicits._
 import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import org.apache.kafka.common.TopicPartition
@@ -10,11 +11,11 @@ final class CommittableConsumerRecordSpec extends BaseSpec {
       val record =
         CommittableConsumerRecord(
           ConsumerRecord("topic", 0, 0L, "key", "value"),
-          CommittableOffset[Id](
+          CommittableOffset[IO](
             topicPartition = new TopicPartition("topic", 0),
             offsetAndMetadata = new OffsetAndMetadata(0L),
             consumerGroupId = Some("the-group"),
-            commit = _ => ()
+            commit = _ => IO.unit
           )
         )
 

--- a/modules/core/src/test/scala/fs2/kafka/KafkaSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/KafkaSpec.scala
@@ -1,5 +1,6 @@
 package fs2.kafka
 
+import cats.ApplicativeError
 import cats.effect.IO
 import cats.effect.concurrent.Ref
 import fs2.{Chunk, Stream}
@@ -29,7 +30,7 @@ final class KafkaSpec extends BaseAsyncSpec {
 
   def exampleOffsets[F[_]](
     commit: Map[TopicPartition, OffsetAndMetadata] => F[Unit]
-  ): List[CommittableOffset[F]] = List(
+  )(implicit F: ApplicativeError[F, Throwable]): List[CommittableOffset[F]] = List(
     CommittableOffset[F](
       new TopicPartition("topic", 0),
       new OffsetAndMetadata(1L),


### PR DESCRIPTION
Prevents committing offsets when records from multiple consumers with different group IDs are mixed together in the same `CommittableOffsetBatch`.