### PR TITLE
Change to use Blocker over ExecutionContext

### DIFF
--- a/modules/core/src/test/scala/fs2/kafka/AdminClientSettingsSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/AdminClientSettingsSpec.scala
@@ -1,10 +1,9 @@
 package fs2.kafka
 
-import cats.effect.IO
+import cats.effect.{Blocker, IO}
 import cats.implicits._
 import org.apache.kafka.clients.admin.AdminClientConfig
 import scala.concurrent.duration._
-import scala.concurrent.ExecutionContext
 
 final class AdminClientSettingsSpec extends BaseSpec {
   describe("AdminClientSettings") {
@@ -130,18 +129,24 @@ final class AdminClientSettingsSpec extends BaseSpec {
       }
     }
 
-    it("should provide withExecutionContext") {
+    it("should provide withBlocker") {
       assert {
-        settings
-          .withExecutionContext(ExecutionContext.global)
-          .executionContext
-          .isDefined
+        Blocker[IO]
+          .use { blocker =>
+            IO {
+              settings
+                .withBlocker(blocker)
+                .blocker
+                .isDefined
+            }
+          }
+          .unsafeRunSync()
       }
     }
 
-    it("should not provide an executionContext unless set") {
+    it("should not provide a blocker unless set") {
       assert {
-        settings.executionContext.isEmpty
+        settings.blocker.isEmpty
       }
     }
 

--- a/modules/core/src/test/scala/fs2/kafka/ConsumerSettingsSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/ConsumerSettingsSpec.scala
@@ -1,18 +1,18 @@
 package fs2.kafka
 
-import cats.effect.IO
+import cats.effect.{Blocker, IO}
 import cats.implicits._
 import org.apache.kafka.clients.consumer.ConsumerConfig
-
-import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
 final class ConsumerSettingsSpec extends BaseSpec {
   describe("ConsumerSettings") {
-    it("should be able to override execution context") {
+    it("should be able to set blocker") {
       assert {
-        settings.executionContext.isEmpty &&
-        settingsWithContext.executionContext.nonEmpty
+        settings.blocker.isEmpty &&
+        settingWithBlocker.use { settings =>
+          IO(settings.blocker.nonEmpty)
+        }.unsafeRunSync
       }
     }
 
@@ -282,7 +282,9 @@ final class ConsumerSettingsSpec extends BaseSpec {
       valueDeserializer = Deserializer[IO, String]
     )
 
-  val settingsWithContext =
-    ConsumerSettings[IO, String, String]
-      .withExecutionContext(ExecutionContext.global)
+  val settingWithBlocker =
+    Blocker[IO].map { blocker =>
+      ConsumerSettings[IO, String, String]
+        .withBlocker(blocker)
+    }
 }


### PR DESCRIPTION
This pull request replaces:

- `executionContext`, and
- `withExecutionContext(ExecutionContext)`

for `AdminClientSettings`, `ConsumerSettings`, and `ProducerSettings` with:

- `blocker`, and
- `withBlocker(Blocker)`.