### PR TITLE
Change to prioritize polls over other requests

### DIFF
--- a/modules/core/src/main/scala/fs2/kafka/ConsumerSettings.scala
+++ b/modules/core/src/main/scala/fs2/kafka/ConsumerSettings.scala
@@ -316,7 +316,7 @@ sealed abstract class ConsumerSettings[F[_], K, V] {
   /**
     * How often we should attempt to call `poll` on the Java `KafkaConsumer`.<br>
     * <br>
-    * The default value is 50 milliseconds.
+    * The default value is 100 milliseconds.
     */
   def pollInterval: FiniteDuration
 
@@ -563,7 +563,7 @@ object ConsumerSettings {
       ),
       closeTimeout = 20.seconds,
       commitTimeout = 15.seconds,
-      pollInterval = 50.millis,
+      pollInterval = 100.millis,
       pollTimeout = 50.millis,
       commitRecovery = CommitRecovery.Default,
       recordMetadata = _ => OffsetFetchResponse.NO_METADATA,

--- a/modules/core/src/main/scala/fs2/kafka/KafkaConsumer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/KafkaConsumer.scala
@@ -267,76 +267,70 @@ sealed abstract class KafkaConsumer[F[_], K, V] {
 private[kafka] object KafkaConsumer {
   private[this] def startConsumerActor[F[_], K, V](
     requests: Queue[F, Request[F, K, V]],
-    polls: Queue[F, Request[F, K, V]],
-    actor: KafkaConsumerActor[F, K, V]
+    actor: KafkaConsumerActor[F, K, V],
+    settings: ConsumerSettings[F, K, V]
   )(
     implicit F: Concurrent[F],
-    context: ContextShift[F]
-  ): Resource[F, Fiber[F, Unit]] =
-    Resource.make {
-      Deferred[F, Either[Throwable, Unit]].flatMap { deferred =>
-        F.guaranteeCase {
-            requests.tryDequeue1
-              .flatMap(_.map(F.pure).getOrElse(polls.dequeue1))
-              .flatMap(actor.handle(_) >> context.shift)
-              .foreverM[Unit]
-          } {
-            case ExitCase.Error(e) => deferred.complete(Left(e))
-            case _                 => deferred.complete(Right(()))
-          }
-          .start
-          .map(fiber => Fiber[F, Unit](deferred.get.rethrow, fiber.cancel.start.void))
-      }
-    }(_.cancel)
-
-  private[this] def startPollScheduler[F[_], K, V](
-    polls: Queue[F, Request[F, K, V]],
-    pollInterval: FiniteDuration
-  )(
-    implicit F: Concurrent[F],
+    context: ContextShift[F],
     timer: Timer[F]
-  ): Resource[F, Fiber[F, Unit]] =
+  ): Resource[F, Fiber[F, Unit]] = {
+    val duration = (length: Long) => FiniteDuration(length, settings.pollInterval.unit)
+    val monotonicTime = timer.clock.monotonic(settings.pollInterval.unit)
+    val pollInterval = settings.pollInterval.length
+    val pollRequest = Request.poll[F, K, V]
+
     Resource.make {
-      Deferred[F, Either[Throwable, Unit]].flatMap { deferred =>
-        F.guaranteeCase {
-            polls
-              .enqueue1(Request.poll)
-              .flatMap(_ => timer.sleep(pollInterval))
-              .foreverM[Unit]
-          } {
-            case ExitCase.Error(e) => deferred.complete(Left(e))
-            case _                 => deferred.complete(Right(()))
-          }
-          .start
-          .map(fiber => Fiber[F, Unit](deferred.get.rethrow, fiber.cancel.start.void))
+      Deferred[F, Either[Throwable, Unit]].flatMap { doneDeferred =>
+        Ref[F].of(0L).flatMap { lastPollTimeRef =>
+          F.guaranteeCase {
+              lastPollTimeRef.get
+                .flatMap { lastPollTime =>
+                  monotonicTime
+                    .flatMap { currentTime =>
+                      val timeToNextPoll =
+                        lastPollTime + pollInterval - currentTime
+
+                      val nextRequest =
+                        if (timeToNextPoll <= 0L)
+                          lastPollTimeRef.set(currentTime).as(pollRequest)
+                        else {
+                          val nextPoll = timer.sleep(duration(timeToNextPoll))
+                          F.race(nextPoll, requests.dequeue1).flatMap {
+                            case Left(()) =>
+                              monotonicTime
+                                .flatMap(lastPollTimeRef.set)
+                                .as(pollRequest)
+                            case Right(request) =>
+                              F.pure(request)
+                          }
+                        }
+
+                      nextRequest.flatMap(actor.handle(_) >> context.shift)
+                    }
+                }
+                .foreverM[Unit]
+            } {
+              case ExitCase.Error(e) => doneDeferred.complete(Left(e))
+              case _                 => doneDeferred.complete(Right(()))
+            }
+            .start
+            .map(fiber => Fiber[F, Unit](doneDeferred.get.rethrow, fiber.cancel.start.void))
+        }
       }
     }(_.cancel)
+  }
 
   private[this] def createKafkaConsumer[F[_], K, V](
     requests: Queue[F, Request[F, K, V]],
     settings: ConsumerSettings[F, K, V],
     actor: Fiber[F, Unit],
-    polls: Fiber[F, Unit],
     streamIdRef: Ref[F, Int],
     id: Int,
     withConsumer: WithConsumer[F]
   )(implicit F: Concurrent[F]): KafkaConsumer[F, K, V] =
     new KafkaConsumer[F, K, V] {
-      override val fiber: Fiber[F, Unit] = {
-        val actorFiber =
-          Fiber[F, Unit](F.guaranteeCase(actor.join) {
-            case ExitCase.Completed => polls.cancel
-            case _                  => F.unit
-          }, actor.cancel)
-
-        val pollsFiber =
-          Fiber[F, Unit](F.guaranteeCase(polls.join) {
-            case ExitCase.Completed => actor.cancel
-            case _                  => F.unit
-          }, polls.cancel)
-
-        actorFiber combine pollsFiber
-      }
+      override val fiber: Fiber[F, Unit] =
+        actor
 
       override def partitionedStream: Stream[F, Stream[F, CommittableConsumerRecord[F, K, V]]] = {
         val chunkQueue: F[Queue[F, Option[Chunk[CommittableConsumerRecord[F, K, V]]]]] =
@@ -673,7 +667,6 @@ private[kafka] object KafkaConsumer {
       implicit0(jitter: Jitter[F]) <- Resource.liftF(Jitter.default[F])
       implicit0(logging: Logging[F]) <- Resource.liftF(Logging.default[F](id))
       requests <- Resource.liftF(Queue.unbounded[F, Request[F, K, V]])
-      polls <- Resource.liftF(Queue.bounded[F, Request[F, K, V]](1))
       ref <- Resource.liftF(Ref.of[F, State[F, K, V]](State.empty))
       streamId <- Resource.liftF(Ref.of[F, Int](0))
       withConsumer <- WithConsumer(settings)
@@ -685,7 +678,6 @@ private[kafka] object KafkaConsumer {
         requests = requests,
         withConsumer = withConsumer
       )
-      actor <- startConsumerActor(requests, polls, actor)
-      polls <- startPollScheduler(polls, settings.pollInterval)
-    } yield createKafkaConsumer(requests, settings, actor, polls, streamId, id, withConsumer)
+      actor <- startConsumerActor(requests, actor, settings)
+    } yield createKafkaConsumer(requests, settings, actor, streamId, id, withConsumer)
 }

--- a/modules/core/src/main/scala/fs2/kafka/internal/KafkaConsumerActor.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/KafkaConsumerActor.scala
@@ -553,7 +553,7 @@ private[kafka] object KafkaConsumerActor {
     private[this] val pollInstance: Poll[Nothing, Nothing, Nothing] =
       Poll[Nothing, Nothing, Nothing]()
 
-    def poll[F[_], K, V]: Poll[F, K, V] =
+    def poll[F[_], K, V]: Request[F, K, V] =
       pollInstance.asInstanceOf[Poll[F, K, V]]
 
     final case class SubscribeTopics[F[_], K, V](

--- a/modules/core/src/test/scala/fs2/kafka/ConsumerSettingsSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/ConsumerSettingsSpec.scala
@@ -299,7 +299,7 @@ final class ConsumerSettingsSpec extends BaseSpec {
 
     it("should have a Show instance and matching toString") {
       assert {
-        settings.show == "ConsumerSettings(closeTimeout = 20 seconds, commitTimeout = 15 seconds, pollInterval = 50 milliseconds, pollTimeout = 50 milliseconds, commitRecovery = Default)" &&
+        settings.show == "ConsumerSettings(closeTimeout = 20 seconds, commitTimeout = 15 seconds, pollInterval = 100 milliseconds, pollTimeout = 50 milliseconds, commitRecovery = Default)" &&
         settings.show == settings.toString
       }
     }


### PR DESCRIPTION
The `pollInterval` and `pollTimeout` in `ConsumerSettings` control how often we should call `poll`, and for how long `poll` is allowed to block, respectively. The current behavior in `KafkaConsumer` does not necessarily respect these settings, as other requests are prioritzed before polling.

https://github.com/ovotech/fs2-kafka/blob/73710c1f98fe7e479c705359593020857813fb3d/modules/core/src/main/scala/fs2/kafka/KafkaConsumer.scala#L279-L282

Not only are other requests prioritized, but if there are no other outstanding requests, we wait for the next poll to happen, regardless whether other requests come in during that time. Essentially, we wait while we could handle other requests, and potentially don't respect `pollInterval`.

This pull request changes the behaviour to better respect `pollInterval`, by prioritizing polls, and also handles other requests while waiting for the next poll, effectively dealing with both concerns. Since both `pollInterval` and `pollTimeout` were set to 50 ms by default, this could potentially leave little to no time for other requests. Therefore, we increase the default `pollInterval` to 100 ms.