### PR TITLE
Revert complications in transactional producer & restore syntax.

### DIFF
--- a/docs/src/main/mdoc/transactions.md
+++ b/docs/src/main/mdoc/transactions.md
@@ -15,9 +15,7 @@ Kafka transactions are supported through a [`TransactionalKafkaProducer`][transa
 
 Following is an example where transactions are used to consume, process, produce, and commit.
 
-```scala
-// TODO: Fix this and re-enable mdoc after re-adding transactional syntax
-
+```scala mdoc
 import cats.effect.{ExitCode, IO, IOApp}
 import cats.syntax.functor._
 import fs2.kafka._
@@ -37,12 +35,11 @@ object Main extends IOApp {
 
     val producerSettings =
       ProducerSettings[IO, String, String]
-        .withTransactionalId("transactions")
         .withBootstrapServers("localhost")
 
     val stream =
       transactionalProducerStream[IO]
-        .using(producerSettings)
+        .using(producerSettings, "transaction-id")
         .flatMap { producer =>
           consumerStream[IO]
             .using(consumerSettings)

--- a/docs/src/main/mdoc/transactions.md
+++ b/docs/src/main/mdoc/transactions.md
@@ -33,13 +33,15 @@ object Main extends IOApp {
         .withBootstrapServers("localhost")
         .withGroupId("group")
 
-    val producerSettings =
+    val producerSettings = TransactionalProducerSettings(
+      "transaction-id",
       ProducerSettings[IO, String, String]
         .withBootstrapServers("localhost")
+    )
 
     val stream =
       transactionalProducerStream[IO]
-        .using(producerSettings, "transaction-id")
+        .using(producerSettings)
         .flatMap { producer =>
           consumerStream[IO]
             .using(consumerSettings)

--- a/docs/src/main/mdoc/transactions.md
+++ b/docs/src/main/mdoc/transactions.md
@@ -5,7 +5,7 @@ title: Transactions
 
 Kafka transactions are supported through a [`TransactionalKafkaProducer`][transactionalkafkaproducer]. In order to use transactions, the following steps should be taken. For details on [consumers](consumers.md) and [producers](producers.md), see the respective sections.
 
-- Use `withTransactionalId(transactionalId)` on `ProducerSettings`.
+- Create a `TransactionalProducerSettings` specifying the transactional ID.
 
 - Use `withIsolationLevel(IsolationLevel.ReadCommitted)` on `ConsumerSettings`.
 
@@ -33,11 +33,12 @@ object Main extends IOApp {
         .withBootstrapServers("localhost")
         .withGroupId("group")
 
-    val producerSettings = TransactionalProducerSettings(
-      "transaction-id",
-      ProducerSettings[IO, String, String]
-        .withBootstrapServers("localhost")
-    )
+    val producerSettings =
+      TransactionalProducerSettings(
+        "transactional-id",
+        ProducerSettings[IO, String, String]
+          .withBootstrapServers("localhost")
+      )
 
     val stream =
       transactionalProducerStream[IO]

--- a/modules/core/src/main/scala/fs2/kafka/TransactionalKafkaProducer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/TransactionalKafkaProducer.scala
@@ -16,12 +16,10 @@
 
 package fs2.kafka
 
-import cats.Parallel
-import cats.effect.{Blocker, ConcurrentEffect, ContextShift, ExitCase, Resource}
+import cats.effect.{ConcurrentEffect, ContextShift, ExitCase, Resource}
 import cats.implicits._
 import fs2.Chunk
 import fs2.kafka.internal._
-import fs2.kafka.internal.syntax._
 import fs2.kafka.internal.converters.collection._
 import org.apache.kafka.clients.producer.{ProducerConfig, RecordMetadata}
 
@@ -51,137 +49,83 @@ abstract class TransactionalKafkaProducer[F[_], K, V] {
 }
 
 private[kafka] object TransactionalKafkaProducer {
-
-  /**
-    * Support class capturing core functionality required to implement
-    * a [[TransactionalKafkaProducer]], allowing users to decide how transactional
-    * IDs are computed as a follow-up step to registering producer settings.
-    */
-  class Builder[F[_], G[_], K, V] private[kafka] (
+  def resource[F[_], K, V](
     settings: ProducerSettings[F, K, V],
+    transactionalId: String,
     transactionTimeout: Option[FiniteDuration]
   )(
     implicit F: ConcurrentEffect[F],
-    P: Parallel[F, G],
     context: ContextShift[F]
-  ) {
+  ): Resource[F, TransactionalKafkaProducer[F, K, V]] =
+    Resource.liftF(settings.keySerializer).flatMap { keySerializer =>
+      Resource.liftF(settings.valueSerializer).flatMap { valueSerializer =>
+        val fullSettings = {
+          val base = settings.withProperty(ProducerConfig.TRANSACTIONAL_ID_CONFIG, transactionalId)
 
-    type Records = CommittableProducerRecords[F, K, V]
-    type RecordsChunk = Chunk[Records]
-    type RecordGrouper = RecordsChunk => F[Chunk[(KafkaByteProducer, RecordsChunk)]]
+          transactionTimeout.fold(base) { t =>
+            base.withProperty(ProducerConfig.TRANSACTION_TIMEOUT_CONFIG, t.toMillis.toString)
+          }
+        }
 
-    private[this] def resource(
-      buildGrouper: Blocker => Resource[F, RecordGrouper]
-    ): Resource[F, TransactionalKafkaProducer[F, K, V]] =
-      Resource.liftF(settings.keySerializer).flatMap { keySerializer =>
-        Resource.liftF(settings.valueSerializer).flatMap { valueSerializer =>
-          settings.blocker.fold(Blockers.transactionalProducer)(Resource.pure[F, Blocker]).flatMap {
-            blocker =>
-              buildGrouper(blocker).map { grouper =>
-                new TransactionalKafkaProducer[F, K, V] {
-                  override def produce[P](
-                    records: TransactionalProducerRecords[F, K, V, P]
-                  ): F[ProducerResult[K, V, P]] =
-                    grouper(records.records)
-                      .flatMap { recordGroups =>
-                        recordGroups.parFlatTraverse {
-                          case (producer, recordGroup) =>
-                            produceTransaction(producer, recordGroup)
-                        }
-                      }
-                      .map(ProducerResult(_, records.passthrough))
+        WithProducer(fullSettings)
+          .evalTap { withProducer =>
+            withProducer { producer =>
+              F.delay(producer.initTransactions())
+            }
+          }
+          .map { withProducer =>
+            new TransactionalKafkaProducer[F, K, V] {
+              override def produce[P](
+                records: TransactionalProducerRecords[F, K, V, P]
+              ): F[ProducerResult[K, V, P]] =
+                produceTransaction(records)
+                  .map(ProducerResult(_, records.passthrough))
 
-                  private[this] def produceTransaction(
-                    producer: KafkaByteProducer,
-                    records: RecordsChunk
-                  ): F[Chunk[(ProducerRecord[K, V], RecordMetadata)]] =
-                    if (records.isEmpty) {
-                      F.pure(Chunk.empty)
-                    } else {
-                      val batch = CommittableOffsetBatch.fromFoldableMap(records)(_.offset)
+              private[this] def produceTransaction[P](
+                records: TransactionalProducerRecords[F, K, V, P]
+              ): F[Chunk[(ProducerRecord[K, V], RecordMetadata)]] = {
+                if (records.records.isEmpty) F.pure(Chunk.empty)
+                else {
+                  val batch =
+                    CommittableOffsetBatch.fromFoldableMap(records.records)(_.offset)
 
-                      val consumerGroupId =
-                        if (batch.consumerGroupIdsMissing || batch.consumerGroupIds.size != 1) {
-                          F.raiseError[String](ConsumerGroupException(batch.consumerGroupIds))
-                        } else {
-                          F.pure(batch.consumerGroupIds.head)
-                        }
+                  val consumerGroupId =
+                    if (batch.consumerGroupIdsMissing || batch.consumerGroupIds.size != 1)
+                      F.raiseError(ConsumerGroupException(batch.consumerGroupIds))
+                    else F.pure(batch.consumerGroupIds.head)
 
-                      consumerGroupId.flatMap { groupId =>
-                        records.flatTraverse { committable =>
-                          context
-                            .blockOn(blocker) {
-                              F.bracketCase(F.delay(producer.beginTransaction())) { _ =>
-                                committable.records
-                                  .traverse(
-                                    KafkaProducer
-                                      .produceRecord(keySerializer, valueSerializer, producer)
-                                  )
-                                  .flatMap(_.sequence)
-                                  .flatTap { _ =>
-                                    F.delay {
-                                      producer.sendOffsetsToTransaction(
-                                        batch.offsets.asJava,
-                                        groupId
-                                      )
-                                    }
-                                  }
-                              } {
-                                case (_, ExitCase.Completed) =>
-                                  F.delay(producer.commitTransaction())
-                                case (_, ExitCase.Canceled | ExitCase.Error(_)) =>
-                                  F.delay(producer.abortTransaction())
-                              }
+                  consumerGroupId.flatMap { groupId =>
+                    withProducer { producer =>
+                      F.bracketCase(F.delay(producer.beginTransaction())) { _ =>
+                        records.records
+                          .flatMap(_.records)
+                          .traverse(
+                            KafkaProducer.produceRecord(keySerializer, valueSerializer, producer)
+                          )
+                          .map(_.sequence)
+                          .flatTap { _ =>
+                            F.delay {
+                              producer.sendOffsetsToTransaction(
+                                batch.offsets.asJava,
+                                groupId
+                              )
                             }
-                        }
+                          }
+                      } {
+                        case (_, ExitCase.Completed) =>
+                          F.delay(producer.commitTransaction())
+                        case (_, ExitCase.Canceled | ExitCase.Error(_)) =>
+                          F.delay(producer.abortTransaction())
                       }
-                    }
-
-                  override def toString: String =
-                    "TransactionalKafkaProducer$" + System.identityHashCode(this)
+                    }.flatten
+                  }
                 }
               }
-          }
-        }
-      }
 
-    private def create(id: String): F[KafkaByteProducer] =
-      transactionTimeout
-        .fold(settings) { timeout =>
-          settings.withProperty(
-            ProducerConfig.TRANSACTION_TIMEOUT_CONFIG,
-            timeout.toMillis.toString
-          )
-        }
-        .withProperty(ProducerConfig.TRANSACTIONAL_ID_CONFIG, id)
-        .createProducer
-
-    private def init(blocker: Blocker)(producer: KafkaByteProducer): F[Unit] =
-      context.blockOn(blocker)(F.delay(producer.initTransactions()))
-
-    private def close(blocker: Blocker)(producer: KafkaByteProducer): F[Unit] =
-      context.blockOn(blocker)(F.delay(producer.close(settings.closeTimeout.asJava)))
-
-    /**
-      * Construct a [[TransactionalKafkaProducer]] which uses a constant ID
-      * for all transactions.
-      *
-      * NOTE: This mode only guarantees exactly-once processing if you have a
-      * single instance in the consumer group. True exactly-once processing is
-      * only guaranteed by running separate producers with unique transactional
-      * IDs per topic/partition processed by the group.
-      *
-      * @param transactionalId the constant ID to use in all transactions initialized
-      *                        by the constructed producer
-      */
-    def withConstantId(transactionalId: String): Resource[F, TransactionalKafkaProducer[F, K, V]] =
-      resource { blocker =>
-        Resource
-          .make(create(transactionalId))(close(blocker))
-          .evalTap(init(blocker))
-          .map { producer => records =>
-            F.pure(Chunk.singleton(producer -> records))
+              override def toString: String =
+                "TransactionalKafkaProducer$" + System.identityHashCode(this)
+            }
           }
       }
-  }
+    }
 }

--- a/modules/core/src/main/scala/fs2/kafka/TransactionalKafkaProducer.scala
+++ b/modules/core/src/main/scala/fs2/kafka/TransactionalKafkaProducer.scala
@@ -47,12 +47,14 @@ abstract class TransactionalKafkaProducer[F[_], K, V] {
 }
 
 private[kafka] object TransactionalKafkaProducer {
-  def resource[F[_], K, V](settings: TransactionalProducerSettings[F, K, V])(
+  def resource[F[_], K, V](
+    settings: TransactionalProducerSettings[F, K, V]
+  )(
     implicit F: ConcurrentEffect[F],
     context: ContextShift[F]
   ): Resource[F, TransactionalKafkaProducer[F, K, V]] =
-    Resource.liftF(settings.baseSettings.keySerializer).flatMap { keySerializer =>
-      Resource.liftF(settings.baseSettings.valueSerializer).flatMap { valueSerializer =>
+    Resource.liftF(settings.producerSettings.keySerializer).flatMap { keySerializer =>
+      Resource.liftF(settings.producerSettings.valueSerializer).flatMap { valueSerializer =>
         WithProducer(settings).map { withProducer =>
           new TransactionalKafkaProducer[F, K, V] {
             override def produce[P](

--- a/modules/core/src/main/scala/fs2/kafka/TransactionalProducerResource.scala
+++ b/modules/core/src/main/scala/fs2/kafka/TransactionalProducerResource.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018-2019 OVO Energy Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fs2.kafka
+
+import cats.effect.{ConcurrentEffect, ContextShift, Resource}
+
+import scala.concurrent.duration.FiniteDuration
+
+/**
+  * [[TransactionalProducerResource]] provides support for inferring
+  * the key and value type from [[ProducerSettings]] when using
+  * `transactionalProducerResource` with the following syntax.
+  *
+  * {{{
+  * transactionalProducerResource[F].using(settings)
+  * }}}
+  */
+final class TransactionalProducerResource[F[_]] private[kafka] (
+  private val F: ConcurrentEffect[F]
+) extends AnyVal {
+
+  /**
+    * Creates a new [[TransactionalKafkaProducer]] in the `Resource` context.
+    * This is equivalent to using `transactionalProducerResource` directly,
+    * except we're able to infer the key and value type.
+    */
+  def using[K, V](
+    settings: ProducerSettings[F, K, V],
+    transactionalId: String,
+    transactionTimeout: Option[FiniteDuration] = None
+  )(
+    implicit context: ContextShift[F]
+  ): Resource[F, TransactionalKafkaProducer[F, K, V]] =
+    transactionalProducerResource(settings, transactionalId, transactionTimeout)(F, context)
+
+  override def toString: String =
+    "TransactionalProducerResource$" + System.identityHashCode(this)
+}

--- a/modules/core/src/main/scala/fs2/kafka/TransactionalProducerResource.scala
+++ b/modules/core/src/main/scala/fs2/kafka/TransactionalProducerResource.scala
@@ -20,8 +20,8 @@ import cats.effect.{ConcurrentEffect, ContextShift, Resource}
 
 /**
   * [[TransactionalProducerResource]] provides support for inferring
-  * the key and value type from [[ProducerSettings]] when using
-  * `transactionalProducerResource` with the following syntax.
+  * the key and value type from [[TransactionalProducerSettings]]
+  * when using `transactionalProducerResource` with the following syntax.
   *
   * {{{
   * transactionalProducerResource[F].using(settings)

--- a/modules/core/src/main/scala/fs2/kafka/TransactionalProducerResource.scala
+++ b/modules/core/src/main/scala/fs2/kafka/TransactionalProducerResource.scala
@@ -18,8 +18,6 @@ package fs2.kafka
 
 import cats.effect.{ConcurrentEffect, ContextShift, Resource}
 
-import scala.concurrent.duration.FiniteDuration
-
 /**
   * [[TransactionalProducerResource]] provides support for inferring
   * the key and value type from [[ProducerSettings]] when using
@@ -38,14 +36,10 @@ final class TransactionalProducerResource[F[_]] private[kafka] (
     * This is equivalent to using `transactionalProducerResource` directly,
     * except we're able to infer the key and value type.
     */
-  def using[K, V](
-    settings: ProducerSettings[F, K, V],
-    transactionalId: String,
-    transactionTimeout: Option[FiniteDuration] = None
-  )(
+  def using[K, V](settings: TransactionalProducerSettings[F, K, V])(
     implicit context: ContextShift[F]
   ): Resource[F, TransactionalKafkaProducer[F, K, V]] =
-    transactionalProducerResource(settings, transactionalId, transactionTimeout)(F, context)
+    transactionalProducerResource(settings)(F, context)
 
   override def toString: String =
     "TransactionalProducerResource$" + System.identityHashCode(this)

--- a/modules/core/src/main/scala/fs2/kafka/TransactionalProducerSettings.scala
+++ b/modules/core/src/main/scala/fs2/kafka/TransactionalProducerSettings.scala
@@ -1,26 +1,40 @@
+/*
+ * Copyright 2018-2019 OVO Energy Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package fs2.kafka
 
 import cats.Show
-import cats.effect.Sync
 import org.apache.kafka.clients.producer.ProducerConfig
-
 import scala.concurrent.duration.FiniteDuration
 
 /**
   * [[TransactionalProducerSettings]] contain settings necessary to create a
-  * [[TransactionalKafkaProducer]]. At the very least, this includes a transactional
-  * ID and a collection of "standard" [[ProducerSettings]].<br>
-  * <br>
-  * [[TransactionalProducerSettings]] instances are immutable and all modification
-  * functions return a new [[TransactionalProducerSettings]] instance.<br>
-  * <br>
-  * Use `TransactionalProducerSettings#apply` to create a new instance.
+  * [[TransactionalKafkaProducer]]. This includes a transactional ID and any
+  * other [[ProducerSettings]].
+  *
+  * [[TransactionalProducerSettings]] instances are immutable and modification
+  * functions return a new [[TransactionalProducerSettings]] instance.
+  *
+  * Use [[TransactionalProducerSettings.apply]] to create a new instance.
   */
 sealed abstract class TransactionalProducerSettings[F[_], K, V] {
 
   /**
-    * The ID which should be used in all transactions. Populates
-    * this property when building the underlying Kafka producer.
+    * The transactional ID which should be used in transactions.
+    * This is the value for the following producer property.
     *
     * {{{
     * ProducerConfig.TRANSACTIONAL_ID_CONFIG
@@ -29,63 +43,57 @@ sealed abstract class TransactionalProducerSettings[F[_], K, V] {
   def transactionalId: String
 
   /**
-    * Settings unrelated to transactions which should be used to
-    * configure the Kafka producer.
+    * The producer settings including transactional properties,
+    * as configured by the [[TransactionalProducerSettings]].
     */
-  def baseSettings: ProducerSettings[F, K, V]
+  def producerSettings: ProducerSettings[F, K, V]
 
   /**
-    * Returns a new [[TransactionalProducerSettings]] instance with the
-    * specified transaction timeout. This is equivalent to setting the following
-    * property using the `withProperty` function on `baseSettings`, except
-    * you can specify it after constructing the [[TransactionalProducerSettings]]
-    * instance and using a [[FiniteDuration]] instead of a `String`.
+    * Returns a new [[TransactionalProducerSettings]] instance
+    * with the specified transaction timeout. This is setting
+    * the following producer property, except you can specify
+    * it with a `FiniteDuration` instead of a `String`.
     *
     * {{{
     * ProducerConfig.TRANSACTION_TIMEOUT_CONFIG
     * }}}
     */
-  def withTransactionTimeout(timeout: FiniteDuration): TransactionalProducerSettings[F, K, V]
-
-  /**
-    * Creates a new `Producer`, and initializes its transactional mode.
-    * Note that this operation should be bracketed, e.g. using `Resource`,
-    * to ensure the `close` function on the producer is called.
-    */
-  def createProducer: F[KafkaByteProducer]
-
-  override def toString: String =
-    s"TransactionalProducerSettings(transactionalId = $transactionalId)"
+  def withTransactionTimeout(
+    transactionTimeout: FiniteDuration
+  ): TransactionalProducerSettings[F, K, V]
 }
 
 object TransactionalProducerSettings {
   private[this] final case class TransactionalProducerSettingsImpl[F[_], K, V](
     override val transactionalId: String,
-    override val baseSettings: ProducerSettings[F, K, V]
-  )(implicit F: Sync[F])
-      extends TransactionalProducerSettings[F, K, V] {
+    override val producerSettings: ProducerSettings[F, K, V]
+  ) extends TransactionalProducerSettings[F, K, V] {
     override def withTransactionTimeout(
-      timeout: FiniteDuration
-    ): TransactionalProducerSettings[F, K, V] = copy(
-      baseSettings = baseSettings
-        .withProperty(ProducerConfig.TRANSACTION_TIMEOUT_CONFIG, timeout.toMillis.toString)
-    )
+      transactionTimeout: FiniteDuration
+    ): TransactionalProducerSettings[F, K, V] =
+      copy(
+        producerSettings = producerSettings
+          .withProperty(
+            ProducerConfig.TRANSACTION_TIMEOUT_CONFIG,
+            transactionTimeout.toMillis.toString
+          )
+      )
 
-    override def createProducer: F[KafkaByteProducer] =
-      F.flatTap(baseSettings.createProducer) { producer =>
-        F.delay(producer.initTransactions())
-      }
+    override def toString: String =
+      s"TransactionalProducerSettings(transactionalId = $transactionalId, producerSettings = $producerSettings)"
   }
 
-  def apply[F[_], K, V](id: String, settings: ProducerSettings[F, K, V])(
-    implicit F: Sync[F]
-  ): TransactionalProducerSettings[F, K, V] = {
+  def apply[F[_], K, V](
+    transactionalId: String,
+    producerSettings: ProducerSettings[F, K, V]
+  ): TransactionalProducerSettings[F, K, V] =
     TransactionalProducerSettingsImpl(
-      id,
-      settings.withProperty(ProducerConfig.TRANSACTIONAL_ID_CONFIG, id)
+      transactionalId = transactionalId,
+      producerSettings = producerSettings
+        .withProperty(ProducerConfig.TRANSACTIONAL_ID_CONFIG, transactionalId)
     )
-  }
 
-  implicit def transationalSettingsShow[F[_], K, V]: Show[TransactionalProducerSettings[F, K, V]] =
+  implicit def transactionalProducerSettingsShow[F[_], K, V]
+    : Show[TransactionalProducerSettings[F, K, V]] =
     Show.fromToString
 }

--- a/modules/core/src/main/scala/fs2/kafka/TransactionalProducerSettings.scala
+++ b/modules/core/src/main/scala/fs2/kafka/TransactionalProducerSettings.scala
@@ -1,0 +1,91 @@
+package fs2.kafka
+
+import cats.Show
+import cats.effect.Sync
+import org.apache.kafka.clients.producer.ProducerConfig
+
+import scala.concurrent.duration.FiniteDuration
+
+/**
+  * [[TransactionalProducerSettings]] contain settings necessary to create a
+  * [[TransactionalKafkaProducer]]. At the very least, this includes a transactional
+  * ID and a collection of "standard" [[ProducerSettings]].<br>
+  * <br>
+  * [[TransactionalProducerSettings]] instances are immutable and all modification
+  * functions return a new [[TransactionalProducerSettings]] instance.<br>
+  * <br>
+  * Use `TransactionalProducerSettings#apply` to create a new instance.
+  */
+sealed abstract class TransactionalProducerSettings[F[_], K, V] {
+
+  /**
+    * The ID which should be used in all transactions. Populates
+    * this property when building the underlying Kafka producer.
+    *
+    * {{{
+    * ProducerConfig.TRANSACTIONAL_ID_CONFIG
+    * }}}
+    */
+  def transactionalId: String
+
+  /**
+    * Settings unrelated to transactions which should be used to
+    * configure the Kafka producer.
+    */
+  def baseSettings: ProducerSettings[F, K, V]
+
+  /**
+    * Returns a new [[TransactionalProducerSettings]] instance with the
+    * specified transaction timeout. This is equivalent to setting the following
+    * property using the `withProperty` function on `baseSettings`, except
+    * you can specify it after constructing the [[TransactionalProducerSettings]]
+    * instance and using a [[FiniteDuration]] instead of a `String`.
+    *
+    * {{{
+    * ProducerConfig.TRANSACTION_TIMEOUT_CONFIG
+    * }}}
+    */
+  def withTransactionTimeout(timeout: FiniteDuration): TransactionalProducerSettings[F, K, V]
+
+  /**
+    * Creates a new `Producer`, and initializes its transactional mode.
+    * Note that this operation should be bracketed, e.g. using `Resource`,
+    * to ensure the `close` function on the producer is called.
+    */
+  def createProducer: F[KafkaByteProducer]
+
+  override def toString: String =
+    s"TransactionalProducerSettings(transactionalId = $transactionalId)"
+}
+
+object TransactionalProducerSettings {
+  private[this] final case class TransactionalProducerSettingsImpl[F[_], K, V](
+    override val transactionalId: String,
+    override val baseSettings: ProducerSettings[F, K, V]
+  )(implicit F: Sync[F])
+      extends TransactionalProducerSettings[F, K, V] {
+    override def withTransactionTimeout(
+      timeout: FiniteDuration
+    ): TransactionalProducerSettings[F, K, V] = copy(
+      baseSettings = baseSettings
+        .withProperty(ProducerConfig.TRANSACTION_TIMEOUT_CONFIG, timeout.toMillis.toString)
+    )
+
+    override def createProducer: F[KafkaByteProducer] =
+      F.flatTap(baseSettings.createProducer) { producer =>
+        F.delay(producer.initTransactions())
+      }
+  }
+
+  def apply[F[_], K, V](id: String, settings: ProducerSettings[F, K, V])(
+    implicit F: Sync[F]
+  ): TransactionalProducerSettings[F, K, V] = {
+    TransactionalProducerSettingsImpl(
+      id,
+      settings.withProperty(ProducerConfig.TRANSACTIONAL_ID_CONFIG, id)
+    )
+  }
+
+  implicit def transationalSettingsShow[F[_], K, V]: Show[TransactionalProducerSettings[F, K, V]] =
+    Show.fromToString
+}

--- a/modules/core/src/main/scala/fs2/kafka/TransactionalProducerStream.scala
+++ b/modules/core/src/main/scala/fs2/kafka/TransactionalProducerStream.scala
@@ -21,8 +21,8 @@ import fs2.Stream
 
 /**
   * [[TransactionalProducerStream]] provides support for inferring
-  * the key and value type from [[ProducerSettings]] when using
-  * `transactionalProducerStream` with the following syntax.
+  * the key and value type from [[TransactionalProducerSettings]]
+  * when using `transactionalProducerStream` with the following syntax.
   *
   * {{{
   * transactionalProducerStream[F].using(settings)

--- a/modules/core/src/main/scala/fs2/kafka/TransactionalProducerStream.scala
+++ b/modules/core/src/main/scala/fs2/kafka/TransactionalProducerStream.scala
@@ -19,8 +19,6 @@ package fs2.kafka
 import cats.effect.{ConcurrentEffect, ContextShift}
 import fs2.Stream
 
-import scala.concurrent.duration.FiniteDuration
-
 /**
   * [[TransactionalProducerStream]] provides support for inferring
   * the key and value type from [[ProducerSettings]] when using
@@ -39,14 +37,10 @@ final class TransactionalProducerStream[F[_]] private[kafka] (
     * This is equivalent to using `transactionalProducerStream` directly,
     * except we're able to infer the key and value type.
     */
-  def using[K, V](
-    settings: ProducerSettings[F, K, V],
-    transactionalId: String,
-    transactionTimeout: Option[FiniteDuration] = None
-  )(
+  def using[K, V](settings: TransactionalProducerSettings[F, K, V])(
     implicit context: ContextShift[F]
   ): Stream[F, TransactionalKafkaProducer[F, K, V]] =
-    transactionalProducerStream(settings, transactionalId, transactionTimeout)(F, context)
+    transactionalProducerStream(settings)(F, context)
 
   override def toString: String =
     "TransactionalProducerStream$" + System.identityHashCode(this)

--- a/modules/core/src/main/scala/fs2/kafka/TransactionalProducerStream.scala
+++ b/modules/core/src/main/scala/fs2/kafka/TransactionalProducerStream.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018-2019 OVO Energy Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fs2.kafka
+
+import cats.effect.{ConcurrentEffect, ContextShift}
+import fs2.Stream
+
+import scala.concurrent.duration.FiniteDuration
+
+/**
+  * [[TransactionalProducerStream]] provides support for inferring
+  * the key and value type from [[ProducerSettings]] when using
+  * `transactionalProducerStream` with the following syntax.
+  *
+  * {{{
+  * transactionalProducerStream[F].using(settings)
+  * }}}
+  */
+final class TransactionalProducerStream[F[_]] private[kafka] (
+  private val F: ConcurrentEffect[F]
+) extends AnyVal {
+
+  /**
+    * Creates a new [[TransactionalKafkaProducer]] in the `Stream` context.
+    * This is equivalent to using `transactionalProducerStream` directly,
+    * except we're able to infer the key and value type.
+    */
+  def using[K, V](
+    settings: ProducerSettings[F, K, V],
+    transactionalId: String,
+    transactionTimeout: Option[FiniteDuration] = None
+  )(
+    implicit context: ContextShift[F]
+  ): Stream[F, TransactionalKafkaProducer[F, K, V]] =
+    transactionalProducerStream(settings, transactionalId, transactionTimeout)(F, context)
+
+  override def toString: String =
+    "TransactionalProducerStream$" + System.identityHashCode(this)
+}

--- a/modules/core/src/main/scala/fs2/kafka/internal/Blockers.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/Blockers.scala
@@ -17,45 +17,43 @@
 package fs2.kafka.internal
 
 import cats.effect.{Blocker, Resource, Sync}
-import java.util.concurrent.{ExecutorService, Executors, ThreadFactory}
-
+import java.util.concurrent.{Executors, ThreadFactory}
 import scala.concurrent.ExecutionContext
 
 private[kafka] object Blockers {
   def consumer[F[_]](implicit F: Sync[F]): Resource[F, Blocker] =
-    singleThreadBlocker("fs2-kafka-consumer")
+    blocker("fs2-kafka-consumer")
 
   def producer[F[_]](implicit F: Sync[F]): Resource[F, Blocker] =
-    singleThreadBlocker("fs2-kafka-producer")
-
-  def transactionalProducer[F[_]](implicit F: Sync[F]): Resource[F, Blocker] =
-    cachingBlocker("fs2-kafka-transactional-producer")
+    blocker("fs2-kafka-producer")
 
   def adminClient[F[_]](implicit F: Sync[F]): Resource[F, Blocker] =
-    singleThreadBlocker("fs2-kafka-admin-client")
+    blocker("fs2-kafka-admin-client")
 
-  private[this] def singleThreadBlocker[F[_]](
-    name: String
-  )(implicit F: Sync[F]): Resource[F, Blocker] =
-    blocker(F.delay(Executors.newSingleThreadExecutor(threadFactory(name))))
+  private[this] def blocker[F[_]](name: String)(implicit F: Sync[F]): Resource[F, Blocker] =
+    Resource {
+      F.delay {
+        val executor =
+          Executors.newSingleThreadExecutor(
+            new ThreadFactory {
+              override def newThread(runnable: Runnable): Thread = {
+                val thread = new Thread(runnable)
+                thread.setName(s"$name-${thread.getId}")
+                thread.setDaemon(true)
+                thread
+              }
+            }
+          )
 
-  private[this] def cachingBlocker[F[_]](name: String)(implicit F: Sync[F]): Resource[F, Blocker] =
-    blocker(F.delay(Executors.newCachedThreadPool(threadFactory(name))))
+        val blocker =
+          Blocker.liftExecutionContext {
+            ExecutionContext.fromExecutor(executor)
+          }
 
-  private[this] def threadFactory(name: String): ThreadFactory =
-    new ThreadFactory {
-      override def newThread(runnable: Runnable): Thread = {
-        val thread = new Thread(runnable)
-        thread.setName(s"$name-${thread.getId}")
-        thread.setDaemon(true)
-        thread
+        val shutdown =
+          F.delay(executor.shutdown())
+
+        (blocker, shutdown)
       }
-    }
-
-  private[this] def blocker[F[_]](
-    executor: F[ExecutorService]
-  )(implicit F: Sync[F]): Resource[F, Blocker] =
-    Resource.make(executor)(es => F.delay(es.shutdown())).map { es =>
-      Blocker.liftExecutionContext(ExecutionContext.fromExecutor(es))
     }
 }

--- a/modules/core/src/main/scala/fs2/kafka/package.scala
+++ b/modules/core/src/main/scala/fs2/kafka/package.scala
@@ -243,9 +243,9 @@ package object kafka {
 
   /**
     * Creates a new [[TransactionalKafkaProducer]] in the `Resource` context,
-    * using the specified [[ProducerSettings]]. Note that there is another
-    * version where `F[_]` is specified explicitly and the key and value
-    * type can be inferred, which allows you to use the following syntax.
+    * using the specified [[TransactionalProducerSettings]]. Note that there
+    * is another version where `F[_]` is specified explicitly and the key and
+    * value type can be inferred, which allows you to use the following syntax.
     *
     * {{{
     * transactionalProducerResource[F].using(settings)
@@ -262,8 +262,8 @@ package object kafka {
   /**
     * Alternative version of `transactionalProducerResource` where the `F[_]`
     * is specified explicitly, and where the key and value type can be
-    * inferred from the [[ProducerSettings]]. This allows you to use
-    * the following syntax.
+    * inferred from the [[TransactionalProducerSettings]]. This allows
+    * you to use the following syntax.
     *
     * {{{
     * transactionalProducerResource[F].using(settings)
@@ -276,9 +276,9 @@ package object kafka {
 
   /**
     * Creates a new [[TransactionalKafkaProducer]] in the `Stream` context,
-    * using the specified [[ProducerSettings]]. Note that there is another
-    * version where `F[_]` is specified explicitly and the key and value
-    * type can be inferred, which allows you to use the following syntax.
+    * using the specified [[TransactionalProducerSettings]]. Note that there
+    * is another version where `F[_]` is specified explicitly and the key and
+    * value type can be inferred, which allows you to use the following syntax.
     *
     * {{{
     * transactionalProducerStream[F].using(settings)
@@ -295,8 +295,8 @@ package object kafka {
   /**
     * Alternative version of `transactionalProducerStream` where the `F[_]`
     * is specified explicitly, and where the key and value type can be
-    * inferred from the [[ProducerSettings]]. This allows you to use
-    * the following syntax.
+    * inferred from the [[TransactionalProducerSettings]]. This allows
+    * you to use the following syntax.
     *
     * {{{
     * transactionalProducerStream[F].using(settings)

--- a/modules/core/src/main/scala/fs2/kafka/package.scala
+++ b/modules/core/src/main/scala/fs2/kafka/package.scala
@@ -248,18 +248,16 @@ package object kafka {
     * type can be inferred, which allows you to use the following syntax.
     *
     * {{{
-    * transactionalProducerResource[F].using(settings, id, timeout)
+    * transactionalProducerResource[F].using(settings)
     * }}}
     */
   def transactionalProducerResource[F[_], K, V](
-    settings: ProducerSettings[F, K, V],
-    transactionalId: String,
-    transactionTimeout: Option[FiniteDuration] = None
+    settings: TransactionalProducerSettings[F, K, V]
   )(
     implicit F: ConcurrentEffect[F],
     context: ContextShift[F]
   ): Resource[F, TransactionalKafkaProducer[F, K, V]] =
-    TransactionalKafkaProducer.resource(settings, transactionalId, transactionTimeout)
+    TransactionalKafkaProducer.resource(settings)
 
   /**
     * Alternative version of `transactionalProducerResource` where the `F[_]`
@@ -268,7 +266,7 @@ package object kafka {
     * the following syntax.
     *
     * {{{
-    * transactionalProducerResource[F].using(settings, id, timeout)
+    * transactionalProducerResource[F].using(settings)
     * }}}
     */
   def transactionalProducerResource[F[_]](
@@ -283,18 +281,16 @@ package object kafka {
     * type can be inferred, which allows you to use the following syntax.
     *
     * {{{
-    * transactionalProducerStream[F].using(settings, id, timeout)
+    * transactionalProducerStream[F].using(settings)
     * }}}
     */
   def transactionalProducerStream[F[_], K, V](
-    settings: ProducerSettings[F, K, V],
-    transactionalId: String,
-    transactionTimeout: Option[FiniteDuration] = None
+    settings: TransactionalProducerSettings[F, K, V]
   )(
     implicit F: ConcurrentEffect[F],
     context: ContextShift[F]
   ): Stream[F, TransactionalKafkaProducer[F, K, V]] =
-    Stream.resource(transactionalProducerResource(settings, transactionalId, transactionTimeout))
+    Stream.resource(transactionalProducerResource(settings))
 
   /**
     * Alternative version of `transactionalProducerStream` where the `F[_]`
@@ -303,7 +299,7 @@ package object kafka {
     * the following syntax.
     *
     * {{{
-    * transactionalProducerStream[F].using(settings, id, timeout)
+    * transactionalProducerStream[F].using(settings)
     * }}}
     */
   def transactionalProducerStream[F[_]](

--- a/modules/core/src/test/scala/fs2/kafka/PackageSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/PackageSpec.scala
@@ -42,4 +42,19 @@ final class PackageSpec extends BaseAsyncSpec {
       producerStream[IO].using(settings)
     }
   }
+
+  describe("creating transactional producers") {
+    it("should support defined syntax") {
+      val settings =
+        ProducerSettings[IO, String, String]
+
+      transactionalProducerResource[IO, String, String](settings, "id")
+      transactionalProducerResource[IO].toString should startWith("TransactionalProducerResource$")
+      transactionalProducerResource[IO].using(settings, "id")
+
+      transactionalProducerStream[IO, String, String](settings, "id")
+      transactionalProducerStream[IO].toString should startWith("TransactionalProducerStream$")
+      transactionalProducerStream[IO].using(settings, "id")
+    }
+  }
 }

--- a/modules/core/src/test/scala/fs2/kafka/PackageSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/PackageSpec.scala
@@ -45,16 +45,15 @@ final class PackageSpec extends BaseAsyncSpec {
 
   describe("creating transactional producers") {
     it("should support defined syntax") {
-      val settings =
-        ProducerSettings[IO, String, String]
+      val settings = TransactionalProducerSettings("id", ProducerSettings[IO, String, String])
 
-      transactionalProducerResource[IO, String, String](settings, "id")
+      transactionalProducerResource[IO, String, String](settings)
       transactionalProducerResource[IO].toString should startWith("TransactionalProducerResource$")
-      transactionalProducerResource[IO].using(settings, "id")
+      transactionalProducerResource[IO].using(settings)
 
-      transactionalProducerStream[IO, String, String](settings, "id")
+      transactionalProducerStream[IO, String, String](settings)
       transactionalProducerStream[IO].toString should startWith("TransactionalProducerStream$")
-      transactionalProducerStream[IO].using(settings, "id")
+      transactionalProducerStream[IO].using(settings)
     }
   }
 }

--- a/modules/core/src/test/scala/fs2/kafka/TransactionalKafkaProducerSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/TransactionalKafkaProducerSpec.scala
@@ -18,253 +18,236 @@ import scala.concurrent.duration._
 
 class TransactionalKafkaProducerSpec extends BaseKafkaSpec with OptionValues with EitherValues {
 
-  private def builder(
-    settings: ProducerSettings[IO, String, String],
-    timeout: Option[FiniteDuration] = None
-  ) = new TransactionalKafkaProducer.Builder(settings, timeout)
+  it("should be able to produce single records in a transaction") {
+    withKafka { (config, topic) =>
+      createCustomTopic(topic, partitions = 3)
+      val toProduce = (0 to 10).map(n => s"key-$n" -> s"value-$n")
 
-  describe("TransactionalKafkaProducer#withConstantId") {
-    it("should be able to produce single records in a transaction") {
-      withKafka { (config, topic) =>
-        createCustomTopic(topic, partitions = 3)
-        val toProduce = (0 to 10).map(n => s"key-$n" -> s"value-$n")
-
-        val produced =
-          (for {
-            producer <- Stream.resource {
-              builder(producerSettings[IO](config)).withConstantId("transactions")
-            }
-            _ <- Stream.eval(IO(producer.toString should startWith("TransactionalKafkaProducer$")))
-            records <- Stream.chunk(Chunk.seq(toProduce)).zipWithIndex.map {
-              case ((key, value), i) =>
-                val offset =
-                  CommittableOffset[IO](
-                    new TopicPartition(topic, (i % 3).toInt),
-                    new OffsetAndMetadata(i),
-                    Some("group"),
-                    _ => IO.unit
-                  )
-
-                TransactionalProducerRecords.one(
-                  CommittableProducerRecords.one(
-                    ProducerRecord(topic, key, value),
-                    offset
-                  ),
-                  (key, value)
-                )
-            }
-            passthrough <- Stream
-              .eval(producer.produce(records))
-              .map(_.passthrough)
-              .buffer(toProduce.size)
-          } yield passthrough).compile.toVector.unsafeRunSync()
-
-        produced should contain theSameElementsAs toProduce
-
-        val consumed = {
-          implicit val transactionalConfig: EmbeddedKafkaConfig = EmbeddedKafkaConfig(
-            kafkaPort = config.kafkaPort,
-            zooKeeperPort = config.zooKeeperPort,
-            customConsumerProperties =
-              Map(ConsumerConfig.ISOLATION_LEVEL_CONFIG -> "read_committed")
-          )
-          consumeNumberKeyedMessagesFrom[String, String](topic, produced.size)
-        }
-
-        consumed should contain theSameElementsAs produced.toList
-      }
-    }
-
-    it("should be able to produce multiple records in a transaction") {
-      withKafka { (config, topic) =>
-        createCustomTopic(topic, partitions = 3)
-        val toProduce =
-          Chunk.seq((0 to 100).toList.map(n => s"key-$n" -> s"value-$n"))
-
-        val toPassthrough = "passthrough"
-
-        val produced =
-          (for {
-            producer <- Stream.resource {
-              builder(producerSettings[IO](config)).withConstantId("transactions")
-            }
-            recordsToProduce = toProduce.map {
-              case (key, value) => ProducerRecord(topic, key, value)
-            }
-            offsets = toProduce.mapWithIndex {
-              case (_, i) =>
+      val produced =
+        (for {
+          producer <- transactionalProducerStream(producerSettings[IO](config), "transactions")
+          _ <- Stream.eval(IO(producer.toString should startWith("TransactionalKafkaProducer$")))
+          records <- Stream.chunk(Chunk.seq(toProduce)).zipWithIndex.map {
+            case ((key, value), i) =>
+              val offset =
                 CommittableOffset[IO](
-                  new TopicPartition(topic, i % 3),
-                  new OffsetAndMetadata(i.toLong),
+                  new TopicPartition(topic, (i % 3).toInt),
+                  new OffsetAndMetadata(i),
                   Some("group"),
                   _ => IO.unit
                 )
-            }
-            records = TransactionalProducerRecords(
-              recordsToProduce.zip(offsets).map {
-                case (record, offset) =>
-                  CommittableProducerRecords.one(
-                    record,
-                    offset
-                  )
-              },
-              toPassthrough
-            )
-            result <- Stream.eval(producer.produce(records))
-          } yield result).compile.lastOrError.unsafeRunSync()
 
-        val records =
-          produced.records.map {
-            case (record, _) =>
-              record.key -> record.value
+              TransactionalProducerRecords.one(
+                CommittableProducerRecords.one(
+                  ProducerRecord(topic, key, value),
+                  offset
+                ),
+                (key, value)
+              )
           }
+          passthrough <- Stream
+            .eval(producer.produce(records))
+            .map(_.passthrough)
+            .buffer(toProduce.size)
+        } yield passthrough).compile.toVector.unsafeRunSync()
 
-        assert(records == toProduce && produced.passthrough == toPassthrough)
+      produced should contain theSameElementsAs toProduce
 
-        val consumed = {
-          implicit val transactionalConfig: EmbeddedKafkaConfig = EmbeddedKafkaConfig(
-            kafkaPort = config.kafkaPort,
-            zooKeeperPort = config.zooKeeperPort,
-            customConsumerProperties =
-              Map(ConsumerConfig.ISOLATION_LEVEL_CONFIG -> "read_committed")
-          )
-          consumeNumberKeyedMessagesFrom[String, String](topic, records.size)
-        }
-
-        consumed should contain theSameElementsAs records.toList
+      val consumed = {
+        implicit val transactionalConfig: EmbeddedKafkaConfig = EmbeddedKafkaConfig(
+          kafkaPort = config.kafkaPort,
+          zooKeeperPort = config.zooKeeperPort,
+          customConsumerProperties = Map(ConsumerConfig.ISOLATION_LEVEL_CONFIG -> "read_committed")
+        )
+        consumeNumberKeyedMessagesFrom[String, String](topic, produced.size)
       }
+
+      consumed should contain theSameElementsAs produced.toList
     }
+  }
 
-    it("should abort transactions if committing offsets fails") {
-      withKafka { (config, topic) =>
-        createCustomTopic(topic, partitions = 3)
-        val toProduce = (0 to 100).toList.map(n => s"key-$n" -> s"value-$n").toList
-        val toPassthrough = "passthrough"
+  it("should be able to produce multiple records in a transaction") {
+    withKafka { (config, topic) =>
+      createCustomTopic(topic, partitions = 3)
+      val toProduce =
+        Chunk.seq((0 to 100).toList.map(n => s"key-$n" -> s"value-$n"))
 
-        val error = new RuntimeException("BOOM")
+      val toPassthrough = "passthrough"
 
-        val produced =
-          (for {
-            producer <- Stream.resource {
-              builder {
-                producerSettings[IO](config)
-                  .withCreateProducer { properties =>
-                    IO.delay {
-                      new org.apache.kafka.clients.producer.KafkaProducer[Array[Byte], Array[Byte]](
-                        (properties: Map[String, AnyRef]).asJava,
-                        new ByteArraySerializer,
-                        new ByteArraySerializer
-                      ) {
-                        override def sendOffsetsToTransaction(
-                          offsets: util.Map[TopicPartition, OffsetAndMetadata],
-                          consumerGroupId: String
-                        ): Unit =
-                          if (offsets.containsKey(new TopicPartition(topic, 2))) {
-                            throw error
-                          } else {
-                            super.sendOffsetsToTransaction(offsets, consumerGroupId)
-                          }
-                      }
-                    }
-                  }
-              }.withConstantId("transactions")
-            }
-            recordsToProduce = toProduce.map {
-              case (key, value) => ProducerRecord(topic, key, value)
-            }
-            offsets = toProduce.mapWithIndex {
-              case (_, i) =>
-                CommittableOffset(
-                  new TopicPartition(topic, i % 3),
-                  new OffsetAndMetadata(i.toLong),
-                  Some("group"),
-                  _ => IO.unit
+      val produced =
+        (for {
+          producer <- transactionalProducerStream(producerSettings[IO](config), "transactions")
+          recordsToProduce = toProduce.map {
+            case (key, value) => ProducerRecord(topic, key, value)
+          }
+          offsets = toProduce.mapWithIndex {
+            case (_, i) =>
+              CommittableOffset[IO](
+                new TopicPartition(topic, i % 3),
+                new OffsetAndMetadata(i.toLong),
+                Some("group"),
+                _ => IO.unit
+              )
+          }
+          records = TransactionalProducerRecords(
+            recordsToProduce.zip(offsets).map {
+              case (record, offset) =>
+                CommittableProducerRecords.one(
+                  record,
+                  offset
                 )
-            }
-            records = TransactionalProducerRecords(
-              Chunk.seq(recordsToProduce.zip(offsets)).map {
-                case (record, offset) =>
-                  CommittableProducerRecords(
-                    NonEmptyList.one(record),
-                    offset
-                  )
-              },
-              toPassthrough
-            )
-            result <- Stream.eval(producer.produce(records).attempt)
-          } yield result).compile.lastOrError.unsafeRunSync()
-
-        produced shouldBe Left(error)
-
-        val consumedOrError = {
-          implicit val transactionalConfig: EmbeddedKafkaConfig = EmbeddedKafkaConfig(
-            kafkaPort = config.kafkaPort,
-            zooKeeperPort = config.zooKeeperPort,
-            customConsumerProperties =
-              Map(ConsumerConfig.ISOLATION_LEVEL_CONFIG -> "read_committed")
+            },
+            toPassthrough
           )
-          Either.catchNonFatal(consumeFirstKeyedMessageFrom[String, String](topic))
+          result <- Stream.eval(producer.produce(records))
+        } yield result).compile.lastOrError.unsafeRunSync()
+
+      val records =
+        produced.records.map {
+          case (record, _) =>
+            record.key -> record.value
         }
 
-        consumedOrError.isLeft shouldBe true
+      assert(records == toProduce && produced.passthrough == toPassthrough)
+
+      val consumed = {
+        implicit val transactionalConfig: EmbeddedKafkaConfig = EmbeddedKafkaConfig(
+          kafkaPort = config.kafkaPort,
+          zooKeeperPort = config.zooKeeperPort,
+          customConsumerProperties = Map(ConsumerConfig.ISOLATION_LEVEL_CONFIG -> "read_committed")
+        )
+        consumeNumberKeyedMessagesFrom[String, String](topic, records.size)
       }
+
+      consumed should contain theSameElementsAs records.toList
     }
+  }
 
-    it("should use user-specified transaction timeouts") {
-      withKafka { (config, topic) =>
-        createCustomTopic(topic, partitions = 3)
-        val toProduce = (0 to 100).toList.map(n => s"key-$n" -> s"value-$n")
+  it("should abort transactions if committing offsets fails") {
+    withKafka { (config, topic) =>
+      createCustomTopic(topic, partitions = 3)
+      val toProduce = (0 to 100).toList.map(n => s"key-$n" -> s"value-$n").toList
+      val toPassthrough = "passthrough"
 
-        val produced =
-          (for {
-            producer <- Stream.resource {
-              builder(
-                producerSettings[IO](config).withCreateProducer { properties =>
-                  IO.delay {
-                    new org.apache.kafka.clients.producer.KafkaProducer[Array[Byte], Array[Byte]](
-                      (properties: Map[String, AnyRef]).asJava,
-                      new ByteArraySerializer,
-                      new ByteArraySerializer
-                    ) {
-                      override def commitTransaction(): Unit = {
-                        Thread.sleep(2 * transactionTimeoutInterval.toMillis)
-                        super.commitTransaction()
+      val error = new RuntimeException("BOOM")
+
+      val produced =
+        (for {
+          producer <- transactionalProducerStream(
+            producerSettings[IO](config)
+              .withCreateProducer { properties =>
+                IO.delay {
+                  new org.apache.kafka.clients.producer.KafkaProducer[Array[Byte], Array[Byte]](
+                    (properties: Map[String, AnyRef]).asJava,
+                    new ByteArraySerializer,
+                    new ByteArraySerializer
+                  ) {
+                    override def sendOffsetsToTransaction(
+                      offsets: util.Map[TopicPartition, OffsetAndMetadata],
+                      consumerGroupId: String
+                    ): Unit =
+                      if (offsets.containsKey(new TopicPartition(topic, 2))) {
+                        throw error
+                      } else {
+                        super.sendOffsetsToTransaction(offsets, consumerGroupId)
                       }
-                    }
                   }
-                },
-                Some(transactionTimeoutInterval - 250.millis)
-              ).withConstantId("transactions")
-            }
-            recordsToProduce = toProduce.map {
-              case (key, value) => ProducerRecord(topic, key, value)
-            }
-            offset = CommittableOffset(
-              new TopicPartition(topic, 1),
-              new OffsetAndMetadata(recordsToProduce.length.toLong),
-              Some("group"),
-              _ => IO.unit
-            )
-            records = TransactionalProducerRecords.one(
-              CommittableProducerRecords(recordsToProduce, offset)
-            )
-            result <- Stream.eval(producer.produce(records).attempt)
-          } yield result).compile.lastOrError.unsafeRunSync()
-
-        produced.left.value shouldBe a[ProducerFencedException]
-
-        val consumedOrError = {
-          implicit val transactionalConfig: EmbeddedKafkaConfig = EmbeddedKafkaConfig(
-            kafkaPort = config.kafkaPort,
-            zooKeeperPort = config.zooKeeperPort,
-            customConsumerProperties =
-              Map(ConsumerConfig.ISOLATION_LEVEL_CONFIG -> "read_committed")
+                }
+              },
+            "transactions"
           )
-          Either.catchNonFatal(consumeFirstKeyedMessageFrom[String, String](topic))
-        }
+          recordsToProduce = toProduce.map {
+            case (key, value) => ProducerRecord(topic, key, value)
+          }
+          offsets = toProduce.mapWithIndex {
+            case (_, i) =>
+              CommittableOffset(
+                new TopicPartition(topic, i % 3),
+                new OffsetAndMetadata(i.toLong),
+                Some("group"),
+                _ => IO.unit
+              )
+          }
+          records = TransactionalProducerRecords(
+            Chunk.seq(recordsToProduce.zip(offsets)).map {
+              case (record, offset) =>
+                CommittableProducerRecords(
+                  NonEmptyList.one(record),
+                  offset
+                )
+            },
+            toPassthrough
+          )
+          result <- Stream.eval(producer.produce(records).attempt)
+        } yield result).compile.lastOrError.unsafeRunSync()
 
-        consumedOrError.isLeft shouldBe true
+      produced shouldBe Left(error)
+
+      val consumedOrError = {
+        implicit val transactionalConfig: EmbeddedKafkaConfig = EmbeddedKafkaConfig(
+          kafkaPort = config.kafkaPort,
+          zooKeeperPort = config.zooKeeperPort,
+          customConsumerProperties = Map(ConsumerConfig.ISOLATION_LEVEL_CONFIG -> "read_committed")
+        )
+        Either.catchNonFatal(consumeFirstKeyedMessageFrom[String, String](topic))
       }
+
+      consumedOrError.isLeft shouldBe true
+    }
+  }
+
+  it("should use user-specified transaction timeouts") {
+    withKafka { (config, topic) =>
+      createCustomTopic(topic, partitions = 3)
+      val toProduce = (0 to 100).toList.map(n => s"key-$n" -> s"value-$n")
+
+      val produced =
+        (for {
+          producer <- transactionalProducerStream(
+            producerSettings[IO](config).withCreateProducer { properties =>
+              IO.delay {
+                new org.apache.kafka.clients.producer.KafkaProducer[Array[Byte], Array[Byte]](
+                  (properties: Map[String, AnyRef]).asJava,
+                  new ByteArraySerializer,
+                  new ByteArraySerializer
+                ) {
+                  override def commitTransaction(): Unit = {
+                    Thread.sleep(2 * transactionTimeoutInterval.toMillis)
+                    super.commitTransaction()
+                  }
+                }
+              }
+            },
+            "transactions",
+            Some(transactionTimeoutInterval - 250.millis)
+          )
+          recordsToProduce = toProduce.map {
+            case (key, value) => ProducerRecord(topic, key, value)
+          }
+          offset = CommittableOffset(
+            new TopicPartition(topic, 1),
+            new OffsetAndMetadata(recordsToProduce.length.toLong),
+            Some("group"),
+            _ => IO.unit
+          )
+          records = TransactionalProducerRecords.one(
+            CommittableProducerRecords(recordsToProduce, offset)
+          )
+          result <- Stream.eval(producer.produce(records).attempt)
+        } yield result).compile.lastOrError.unsafeRunSync()
+
+      produced.left.value shouldBe a[ProducerFencedException]
+
+      val consumedOrError = {
+        implicit val transactionalConfig: EmbeddedKafkaConfig = EmbeddedKafkaConfig(
+          kafkaPort = config.kafkaPort,
+          zooKeeperPort = config.zooKeeperPort,
+          customConsumerProperties = Map(ConsumerConfig.ISOLATION_LEVEL_CONFIG -> "read_committed")
+        )
+        Either.catchNonFatal(consumeFirstKeyedMessageFrom[String, String](topic))
+      }
+
+      consumedOrError.isLeft shouldBe true
     }
   }
 }


### PR DESCRIPTION
Partially reverts #174, as proposed in https://github.com/ovotech/fs2-kafka/pull/182#issuecomment-525091340.