### PR TITLE
Revert #129

### DIFF
--- a/modules/core/src/main/scala/fs2/kafka/internal/LogEntry.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/LogEntry.scala
@@ -99,6 +99,15 @@ private[kafka] object LogEntry {
       s"Completed fetches with records for partitions [${recordsString(records)}]. Current state [$state]."
   }
 
+  final case class RevokedFetchesWithRecords[F[_], K, V](
+    records: Records[F, K, V],
+    state: State[F, K, V]
+  ) extends LogEntry {
+    override def level: LogLevel = Debug
+    override def message: String =
+      s"Revoked fetches with records for partitions [${recordsString(records)}]. Current state [$state]."
+  }
+
   final case class RevokedFetchesWithoutRecords[F[_], K, V](
     partitions: Set[TopicPartition],
     state: State[F, K, V]


### PR DESCRIPTION
It seems the assumption made in #129 is incorrect: `poll(timeout)` with `timeout > 0` can both result in assignment and new records being returned for the new assignment. Therefore, we generally need to store records before fetch requests are received. This pull request effectively reverts #129.