### PR TITLE
Change default max.retries to 0

### DIFF
--- a/docs/src/main/mdoc/producers.md
+++ b/docs/src/main/mdoc/producers.md
@@ -122,6 +122,10 @@ ProducerSettings(
 
 ### Default Settings
 
+The following Java Kafka producer properties are overridden by default.
+
+- `max.retries` is set to `0`, to avoid the risk of records being produced out-of-order. If we don't need to produce records in-order, then this can be set to some positive integer value. An alternative is to enable retries and use `withMaxInFlightRequestsPerConnection(1)` or `withEnableIdempotence(true)`. The blog post [Does Kafka really guarantee the order of messages?](https://blog.softwaremill.com/does-kafka-really-guarantee-the-order-of-messages-3ca849fd19d2) provides more detail on this topic.
+
 The following settings are specific to the library.
 
 - `withCloseTimeout` controls the timeout when waiting for producer shutdown. Default is 60 seconds.

--- a/modules/core/src/main/scala/fs2/kafka/ProducerSettings.scala
+++ b/modules/core/src/main/scala/fs2/kafka/ProducerSettings.scala
@@ -338,7 +338,9 @@ object ProducerSettings {
       keySerializer = keySerializer,
       valueSerializer = valueSerializer,
       blocker = None,
-      properties = Map.empty,
+      properties = Map(
+        ProducerConfig.RETRIES_CONFIG -> "0"
+      ),
       closeTimeout = 60.seconds,
       parallelism = 100,
       createProducerWith = properties =>


### PR DESCRIPTION
In Kafka 2.1, the default producer `max.retries` was changed to `Int.MaxValue`. This means records can be produced out-of-order. The blog post [Does Kafka really guarantee the order of messages?](https://blog.softwaremill.com/does-kafka-really-guarantee-the-order-of-messages-3ca849fd19d2) provides more detail on the topic. The fact that this change happened in a minor version can be surprising for people who missed [KIP-91](https://cwiki.apache.org/confluence/display/KAFKA/KIP-91+Provide+Intuitive+User+Timeouts+in+The+Producer) in the release notes.

The suggestion implemented by this pull request is to keep the old behaviour of `max.retries` set to `0`, so this new behaviour becomes opt-in, rather than on-by-default.