### PR TITLE
Revert "Change to prioritize polls over other requests"

### DIFF
--- a/modules/core/src/main/scala/fs2/kafka/ConsumerSettings.scala
+++ b/modules/core/src/main/scala/fs2/kafka/ConsumerSettings.scala
@@ -316,7 +316,7 @@ sealed abstract class ConsumerSettings[F[_], K, V] {
   /**
     * How often we should attempt to call `poll` on the Java `KafkaConsumer`.<br>
     * <br>
-    * The default value is 100 milliseconds.
+    * The default value is 50 milliseconds.
     */
   def pollInterval: FiniteDuration
 
@@ -563,7 +563,7 @@ object ConsumerSettings {
       ),
       closeTimeout = 20.seconds,
       commitTimeout = 15.seconds,
-      pollInterval = 100.millis,
+      pollInterval = 50.millis,
       pollTimeout = 50.millis,
       commitRecovery = CommitRecovery.Default,
       recordMetadata = _ => OffsetFetchResponse.NO_METADATA,

--- a/modules/core/src/main/scala/fs2/kafka/internal/KafkaConsumerActor.scala
+++ b/modules/core/src/main/scala/fs2/kafka/internal/KafkaConsumerActor.scala
@@ -577,7 +577,7 @@ private[kafka] object KafkaConsumerActor {
     private[this] val pollInstance: Poll[Nothing, Nothing, Nothing] =
       Poll[Nothing, Nothing, Nothing]()
 
-    def poll[F[_], K, V]: Request[F, K, V] =
+    def poll[F[_], K, V]: Poll[F, K, V] =
       pollInstance.asInstanceOf[Poll[F, K, V]]
 
     final case class SubscribeTopics[F[_], K, V](

--- a/modules/core/src/test/scala/fs2/kafka/ConsumerSettingsSpec.scala
+++ b/modules/core/src/test/scala/fs2/kafka/ConsumerSettingsSpec.scala
@@ -299,7 +299,7 @@ final class ConsumerSettingsSpec extends BaseSpec {
 
     it("should have a Show instance and matching toString") {
       assert {
-        settings.show == "ConsumerSettings(closeTimeout = 20 seconds, commitTimeout = 15 seconds, pollInterval = 100 milliseconds, pollTimeout = 50 milliseconds, commitRecovery = Default)" &&
+        settings.show == "ConsumerSettings(closeTimeout = 20 seconds, commitTimeout = 15 seconds, pollInterval = 50 milliseconds, pollTimeout = 50 milliseconds, commitRecovery = Default)" &&
         settings.show == settings.toString
       }
     }


### PR DESCRIPTION
Reverts ovotech/fs2-kafka#180. It seems likely that the approach can result in cases where polls are always prioritized (either due to the scheduling, or because the Java consumer doesn't respect the timeout well enough).